### PR TITLE
Use ur_client_library from released version

### DIFF
--- a/Universal_Robots_ROS2_Driver.repos
+++ b/Universal_Robots_ROS2_Driver.repos
@@ -15,10 +15,6 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git
     version: 0.2.1
-  Universal_Robots_Client_Library:
-    type: git
-    url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
-    version: master
   ur_msgs:
     type: git
     url: https://github.com/destogl/ur_msgs.git


### PR DESCRIPTION
As the client library has been released to ROS foxy, it might be good to
also use this inside CI. This would also help when making changes to the client
library, as the downstream build shadows the current PR when being installed from
source instead of using the version from the current build workspace.