### PR TITLE
Use dessant/issue-states workflow to close issues moved to project board Done column

### DIFF
--- a/.github/workflows/issue-states.yml
+++ b/.github/workflows/issue-states.yml
@@ -1,0 +1,15 @@
+name: 'Set issue state'
+
+on:
+  project_card:
+    types: [created, edited, moved]
+
+jobs:
+  set-state:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/issue-states@v2
+        with:
+          github-token: ${{ github.token }}
+          open-issue-columns: 'To do, In progress, Under Review'
+          closed-issue-columns: 'Done'


### PR DESCRIPTION
See https://github.com/dessant/issue-states

I tested this on a separate repo for the following conditions:
- Closing an Issue will still result in it being moved to the Done column in any automated Project boards it is associated with.
- **New**: Moving an Issue to the Done column in any Project board will result in the Issue being closed. This can then trigger the Issue being moved to the Done column in other Project boards if they are automated.
- Reopening a closed Issue will still result in it being moved to the In progress column in any automated Project boards it is associated with.
- **New**: Moving an issue from the Done column to any other column will reopen the Issue. This can then trigger the Issue being moved to the In progress column in any automated Project boards (including the one you just moved it in).