### PR TITLE
Add on_init() to ur_controllers

### DIFF
--- a/ur_controllers/include/ur_controllers/force_torque_sensor_broadcaster.hpp
+++ b/ur_controllers/include/ur_controllers/force_torque_sensor_broadcaster.hpp
@@ -68,13 +68,13 @@ public:
 
   controller_interface::return_type update() override;
 
+  CallbackReturn on_init() override;
+
   CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
 
   CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
 
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
-
-  controller_interface::return_type init(const std::string& controller_name) override;
 
 protected:
   // param storage

--- a/ur_controllers/include/ur_controllers/gpio_controller.hpp
+++ b/ur_controllers/include/ur_controllers/gpio_controller.hpp
@@ -74,9 +74,9 @@ public:
 
   controller_interface::InterfaceConfiguration state_interface_configuration() const override;
 
-  controller_interface::return_type init(const std::string& controller_name) override;
-
   controller_interface::return_type update() override;
+
+  CallbackReturn on_init() override;
 
   CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
 

--- a/ur_controllers/include/ur_controllers/speed_scaling_state_broadcaster.hpp
+++ b/ur_controllers/include/ur_controllers/speed_scaling_state_broadcaster.hpp
@@ -46,6 +46,8 @@ public:
 
   controller_interface::return_type update() override;
 
+  rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn on_init() override;
+
   rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
   on_configure(const rclcpp_lifecycle::State& previous_state) override;
 

--- a/ur_controllers/src/force_torque_sensor_broadcaster.cpp
+++ b/ur_controllers/src/force_torque_sensor_broadcaster.cpp
@@ -24,13 +24,8 @@ ForceTorqueStateBroadcaster::ForceTorqueStateBroadcaster()
 {
 }
 
-controller_interface::return_type ForceTorqueStateBroadcaster::init(const std::string& controller_name)
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn ForceTorqueStateBroadcaster::on_init()
 {
-  auto ret = ControllerInterface::init(controller_name);
-  if (ret != controller_interface::return_type::OK) {
-    return ret;
-  }
-
   try {
     auto_declare<std::vector<std::string>>("state_interface_names", {});
     auto_declare<std::string>("sensor_name", "");
@@ -38,10 +33,10 @@ controller_interface::return_type ForceTorqueStateBroadcaster::init(const std::s
     auto_declare<std::string>("frame_id", "");
   } catch (const std::exception& e) {
     fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
-    return controller_interface::return_type::ERROR;
+    return CallbackReturn::ERROR;
   }
 
-  return controller_interface::return_type::OK;
+  return CallbackReturn::SUCCESS;
 }
 
 controller_interface::InterfaceConfiguration ForceTorqueStateBroadcaster::command_interface_configuration() const

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -104,11 +104,11 @@ controller_interface::InterfaceConfiguration ur_controllers::GPIOController::sta
   return config;
 }
 
-controller_interface::return_type ur_controllers::GPIOController::init(const std::string& controller_name)
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn ur_controllers::GPIOController::on_init()
 {
   initMsgs();
 
-  return ControllerInterface::init(controller_name);
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
 controller_interface::return_type ur_controllers::GPIOController::update()

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -55,7 +55,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update()
     RCLCPP_ERROR(get_node()->get_logger(), "Speed scaling interface not found in hardware interface.");
   }
 
-  if (get_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+  if (lifecycle_state_.id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
     return controller_interface::return_type::OK;
   }
 
@@ -137,7 +137,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update()
     rcl_duration_value_t period = (time_data.time - time_data_.readFromRT()->time).nanoseconds();
     time_data.period = rclcpp::Duration::from_nanoseconds(scaling_factor_ * period);
     time_data.uptime = time_data_.readFromRT()->uptime + time_data.period;
-    rclcpp::Time traj_time = time_data_.readFromRT()->uptime + rclcpp::Duration(period);
+    rclcpp::Time traj_time = time_data_.readFromRT()->uptime + rclcpp::Duration::from_nanoseconds(period);
     time_data_.writeFromNonRT(time_data);
 
     // if sampling the first time, set the point before you sample

--- a/ur_controllers/src/speed_scaling_state_broadcaster.cpp
+++ b/ur_controllers/src/speed_scaling_state_broadcaster.cpp
@@ -57,11 +57,20 @@ controller_interface::InterfaceConfiguration SpeedScalingStateBroadcaster::state
   return config;
 }
 
+rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn SpeedScalingStateBroadcaster::on_init()
+{
+  try {
+    auto_declare<double>("state_publish_rate", 100.0);
+  } catch (const std::exception& e) {
+    fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
+    return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
+  return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
 rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn
 SpeedScalingStateBroadcaster::on_configure(const rclcpp_lifecycle::State& /*previous_state*/)
 {
-  auto_declare<double>("state_publish_rate", 100.0);
-
   if (!node_->get_parameter("state_publish_rate", publish_rate_)) {
     RCLCPP_INFO(get_node()->get_logger(), "Parameter 'state_publish_rate' not set");
     return rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn::ERROR;


### PR DESCRIPTION
[Recent changes in ros2_control](https://github.com/ros-controls/ros2_control/commit/05718bcbc9918de46ac5257895edec5945603a0c) led to compilation errors on Rolling in the ur_controller package because of undefined virtual functions like this:
```
--- stderr: ur_controllers                                
In file included from /opt/ros/rolling/include/class_loader/class_loader_core.hpp:57,
                 from /opt/ros/rolling/include/class_loader/class_loader.hpp:55,
                 from /opt/ros/rolling/include/pluginlib/class_list_macros.hpp:40,
                 from /home/sebi/ws_ur10_welding/src/Universal_Robots_ROS2_Driver/ur_controllers/src/speed_scaling_state_broadcaster.cpp:120:
/opt/ros/rolling/include/class_loader/meta_object.hpp: In instantiation of ‘B* class_loader::impl::MetaObject<C, B>::create() const [with C = ur_controllers::SpeedScalingStateBroadcaster; B = controller_interface::ControllerInterface]’:
/opt/ros/rolling/include/class_loader/meta_object.hpp:216:7:   required from here
/opt/ros/rolling/include/class_loader/meta_object.hpp:218:12: error: invalid new-expression of abstract class type ‘ur_controllers::SpeedScalingStateBroadcaster’
  218 |     return new C;
      |            ^~~~~
In file included from /home/sebi/ws_ur10_welding/src/Universal_Robots_ROS2_Driver/ur_controllers/src/speed_scaling_state_broadcaster.cpp:24:
/home/sebi/ws_ur10_welding/src/Universal_Robots_ROS2_Driver/ur_controllers/include/ur_controllers/speed_scaling_state_broadcaster.hpp:38:7: note:   because the following virtual functions are pure within ‘ur_controllers::SpeedScalingStateBroadcaster’:
   38 | class SpeedScalingStateBroadcaster : public controller_interface::ControllerInterface
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /home/sebi/ws_ur10_welding/src/Universal_Robots_ROS2_Driver/ur_controllers/include/ur_controllers/speed_scaling_state_broadcaster.hpp:31,
                 from /home/sebi/ws_ur10_welding/src/Universal_Robots_ROS2_Driver/ur_controllers/src/speed_scaling_state_broadcaster.cpp:24:
/home/sebi/ws_ur10_welding/install/controller_interface/include/controller_interface/controller_interface.hpp:92:50: note: 	‘virtual rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn controller_interface::ControllerInterface::on_init()’
   92 |   virtual LifecycleNodeInterface::CallbackReturn on_init() = 0;
      |                                                  ^~~~~~~
make[2]: *** [CMakeFiles/ur_controllers.dir/build.make:76: CMakeFiles/ur_controllers.dir/src/speed_scaling_state_broadcaster.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:78: CMakeFiles/ur_controllers.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```

 I've fixed these errors by defining the on_init function for every controller and fixed two warnings caused in ur_controllers/src/scaled_joint_trajectory_controller.cpp 