### PR TITLE
Update ros2_control_demos dependency to foxy branch

### DIFF
--- a/Universal_Robots_ROS2_Driver-not-released.foxy.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.foxy.repos
@@ -2,7 +2,7 @@ repositories:
   ros2_control_demos:
     type: git
     url: https://github.com/ros-controls/ros2_control_demos.git
-    version: master
+    version: foxy
   ur_msgs:
     type: git
     url: https://github.com/destogl/ur_msgs.git


### PR DESCRIPTION
This has been fixed for the full source list in a849a5bc6ec2584b8ede882afdb8f0b56beb1756 but not for the `not-released`-list.