### PR TITLE
Implement "choices" for robot_type param

### DIFF
--- a/ur_bringup/launch/ur_control.launch.py
+++ b/ur_bringup/launch/ur_control.launch.py
@@ -26,7 +26,11 @@ def generate_launch_description():
     declared_arguments = []
     # UR specific arguments
     declared_arguments.append(
-        DeclareLaunchArgument("ur_type", description="Type/series of used UR robot.")
+        DeclareLaunchArgument(
+            "ur_type",
+            description="Type/series of used UR robot.",
+            choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e"],
+        )
     )
     # TODO(anyone): enable this when added into ROS2-foxy
     # choices=['ur3', 'ur3e', 'ur5', 'ur5e', 'ur10', 'ur10e', 'ur16e']))

--- a/ur_bringup/launch/ur_moveit.launch.py
+++ b/ur_bringup/launch/ur_moveit.launch.py
@@ -263,10 +263,12 @@ def generate_launch_description():
     declared_arguments = []
     # UR specific arguments
     declared_arguments.append(
-        DeclareLaunchArgument("ur_type", description="Type/series of used UR robot.")
+        DeclareLaunchArgument(
+            "ur_type",
+            description="Type/series of used UR robot.",
+            choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e"],
+        )
     )
-    # TODO(anyone): enable this when added into ROS2-foxy
-    # choices=['ur3', 'ur3e', 'ur5', 'ur5e', 'ur10', 'ur10e', 'ur16e']))
     declared_arguments.append(
         DeclareLaunchArgument(
             "robot_ip", description="IP address by which the robot can be reached."

--- a/ur_description/launch/view_ur.launch.py
+++ b/ur_description/launch/view_ur.launch.py
@@ -25,7 +25,11 @@ def generate_launch_description():
     declared_arguments = []
     # UR specific arguments
     declared_arguments.append(
-        DeclareLaunchArgument("ur_type", description="Type/series of used UR robot.")
+        DeclareLaunchArgument(
+            "ur_type",
+            description="Type/series of used UR robot.",
+            choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e"],
+        )
     )
     # TODO(anyone): enable this when added into ROS2-foxy
     # choices=['ur3', 'ur3e', 'ur5', 'ur5e', 'ur10', 'ur10e', 'ur16e']))

--- a/ur_robot_driver/test/integration_test.py
+++ b/ur_robot_driver/test/integration_test.py
@@ -48,7 +48,10 @@ def generate_test_description():
 
     declared_arguments.append(
         DeclareLaunchArgument(
-            "ur_type", default_value="ur5e", description="Type/series of used UR robot."
+            "ur_type",
+            default_value="ur5e",
+            description="Type/series of used UR robot.",
+            choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e"],
         )
     )
 


### PR DESCRIPTION
You can test this easily by launching with an incorrect robot type, e.g.

`ros2 launch ur_bringup ur_control.launch.py ur_type:=urX robot_ip:=yyy.yyy.yyy.yyy use_fake_hardware:=true launch_rviz:=false`