### PR TITLE
Use gpio tag in urdf

### DIFF
--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -72,10 +72,6 @@ CallbackReturn URPositionHardwareInterface::on_init(const hardware_interface::Ha
   system_interface_initialized_ = 0.0;
 
   for (const hardware_interface::ComponentInfo& joint : info_.joints) {
-    if (joint.name == "gpio" || joint.name == "speed_scaling" || joint.name == "resend_robot_program" ||
-        joint.name == "system_interface") {
-      continue;
-    }
     if (joint.command_interfaces.size() != 2) {
       RCLCPP_FATAL(rclcpp::get_logger("URPositionHardwareInterface"),
                    "Joint '%s' has %zu command interfaces found. 2 expected.", joint.name.c_str(),
@@ -133,10 +129,6 @@ std::vector<hardware_interface::StateInterface> URPositionHardwareInterface::exp
 {
   std::vector<hardware_interface::StateInterface> state_interfaces;
   for (size_t i = 0; i < info_.joints.size(); ++i) {
-    if (info_.joints[i].name == "gpio" || info_.joints[i].name == "speed_scaling" ||
-        info_.joints[i].name == "resend_robot_program" || info_.joints[i].name == "system_interface") {
-      continue;
-    }
     state_interfaces.emplace_back(hardware_interface::StateInterface(
         info_.joints[i].name, hardware_interface::HW_IF_POSITION, &urcl_joint_positions_[i]));
 
@@ -214,10 +206,6 @@ std::vector<hardware_interface::CommandInterface> URPositionHardwareInterface::e
 {
   std::vector<hardware_interface::CommandInterface> command_interfaces;
   for (size_t i = 0; i < info_.joints.size(); ++i) {
-    if (info_.joints[i].name == "gpio" || info_.joints[i].name == "speed_scaling" ||
-        info_.joints[i].name == "resend_robot_program" || info_.joints[i].name == "system_interface") {
-      continue;
-    }
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
         info_.joints[i].name, hardware_interface::HW_IF_POSITION, &urcl_position_commands_[i]));
 


### PR DESCRIPTION
This is now fully functional, and it should be tested on hardware with  UniversalRobots/Universal_Robots_ROS2_Description#16.