### PR TITLE
Make reading and writing work when hardware is disconnected

### DIFF
--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -511,6 +511,7 @@ hardware_interface::return_type URPositionHardwareInterface::read()
   }
 
   RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Unable to read from hardware...");
+  // TODO(anyone): could not read from the driver --> return ERROR --> on error will be called
   return hardware_interface::return_type::OK;
 }
 
@@ -535,6 +536,7 @@ hardware_interface::return_type URPositionHardwareInterface::write()
   }
 
   RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Unable to write to hardware...");
+  // TODO(anyone): could not read from the driver --> return ERROR --> on error will be called
   return hardware_interface::return_type::OK;
 }
 

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -510,8 +510,8 @@ hardware_interface::return_type URPositionHardwareInterface::read()
     return hardware_interface::return_type::OK;
   }
 
-  // TODO(anyone): could not read from the driver --> reset controllers
-  return hardware_interface::return_type::ERROR;
+  RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Unable to read from hardware...");
+  return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type URPositionHardwareInterface::write()
@@ -534,7 +534,8 @@ hardware_interface::return_type URPositionHardwareInterface::write()
     return hardware_interface::return_type::OK;
   }
 
-  return hardware_interface::return_type::ERROR;
+  RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Unable to write to hardware...");
+  return hardware_interface::return_type::OK;
 }
 
 void URPositionHardwareInterface::handleRobotProgramState(bool program_running)


### PR DESCRIPTION
In the current implementation of the ros-controls/ros2_control [System](https://github.com/ros-controls/ros2_control/blob/master/hardware_interface/src/system.cpp#L222) the [read](https://github.com/ros-controls/ros2_control/blob/c4cdbee6c9139f9e85c9d03d62d05ca683cc83a8/hardware_interface/src/system.cpp#L215-L229) and [write](https://github.com/ros-controls/ros2_control/blob/c4cdbee6c9139f9e85c9d03d62d05ca683cc83a8/hardware_interface/src/system.cpp#L231-L245) are not called if their lifecycle state is different than `PRIMARY_STATE_INACTIVE` or `PRIMARY_STATE_ACTIVE`. This is changed when the `SystemInterface` returns [`hardware_interface::return_type::ERROR`](https://github.com/ros-controls/ros2_control/blob/c4cdbee6c9139f9e85c9d03d62d05ca683cc83a8/hardware_interface/src/system.cpp#L241). The state management when the error is returned can be see [here](https://github.com/ros-controls/ros2_control/blob/c4cdbee6c9139f9e85c9d03d62d05ca683cc83a8/hardware_interface/src/system.cpp#L166-L185). 

This also fixes the `Pipeline producer overflowed!` problem - #210   in non-headless mode when the program is not yet running, but the driver is started. 