### PR TITLE
fix missing executable arg of joint_state_broadcaster

### DIFF
--- a/ur_bringup/launch/ur_control.launch.py
+++ b/ur_bringup/launch/ur_control.launch.py
@@ -180,7 +180,7 @@ def launch_setup(context, *args, **kwargs):
 
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
-        executable="  ",
+        executable="spawner",
         arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
     )
 


### PR DESCRIPTION
https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/commit/3e099dda8c42e3f584cb10839d3a02aec2cc3f49 seems to have a simple copy paste error, where the executable argument went missing.

This should fix https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/247