### PR TITLE
Do not print an error output if writing is not possible

### DIFF
--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -533,7 +533,7 @@ hardware_interface::return_type URPositionHardwareInterface::read()
 hardware_interface::return_type URPositionHardwareInterface::write()
 {
   // If there is no interpreting program running on the robot, we do not want to send anything.
-  // TODO: We would still like to disable the controllers requiring a writable interface. In ROS1
+  // TODO(anyone): We would still like to disable the controllers requiring a writable interface. In ROS1
   // this was done externally using the controller_stopper.
   if ((runtime_state_ == static_cast<uint32_t>(rtde::RUNTIME_STATE::PLAYING) ||
        runtime_state_ == static_cast<uint32_t>(rtde::RUNTIME_STATE::PAUSING)) &&

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -532,6 +532,9 @@ hardware_interface::return_type URPositionHardwareInterface::read()
 
 hardware_interface::return_type URPositionHardwareInterface::write()
 {
+  // If there is no interpreting program running on the robot, we do not want to send anything.
+  // TODO: We would still like to disable the controllers requiring a writable interface. In ROS1
+  // this was done externally using the controller_stopper.
   if ((runtime_state_ == static_cast<uint32_t>(rtde::RUNTIME_STATE::PLAYING) ||
        runtime_state_ == static_cast<uint32_t>(rtde::RUNTIME_STATE::PAUSING)) &&
       robot_program_running_ && (!non_blocking_read_ || packet_read_)) {
@@ -546,12 +549,8 @@ hardware_interface::return_type URPositionHardwareInterface::write()
     }
 
     packet_read_ = false;
-
-    return hardware_interface::return_type::OK;
   }
 
-  RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Unable to write to hardware...");
-  // TODO(anyone): could not read from the driver --> return ERROR --> on error will be called
   return hardware_interface::return_type::OK;
 }
 


### PR DESCRIPTION
If writing to the hardware is not possible, as the interpreting program
is currently not running, there's no need to print an error message in each
control cycle.

This aims at fixing #262 and possibly #264 