### PR TITLE
Fixing launch files ⛏: Fix typo and changes when launching newest MoveIt on rolling.

### DIFF
--- a/ur_bringup/launch/ur_control.launch.py
+++ b/ur_bringup/launch/ur_control.launch.py
@@ -368,7 +368,7 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "launch_dashboard_client", default_value="true", description="Launch RViz?"
+            "launch_dashboard_client", default_value="true", description="Launch Dashboard client?"
         )
     )
     declared_arguments.append(

--- a/ur_bringup/launch/ur_moveit.launch.py
+++ b/ur_bringup/launch/ur_moveit.launch.py
@@ -21,7 +21,7 @@ from launch.conditions import IfCondition
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from ur_bringup.launch_common import load_yaml, load_yaml_abs
+from ur_bringup.launch_common import load_yaml
 
 
 def launch_setup(context, *args, **kwargs):
@@ -147,12 +147,12 @@ def launch_setup(context, *args, **kwargs):
     )
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_content}
 
-    kinematics_yaml = load_yaml("ur_moveit_config", "config/kinematics.yaml")
+    kinematics_yaml = PathJoinSubstitution(
+        [FindPackageShare("ur_moveit_config"), "config", "kinematics.yaml"]
+    )
     robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml}
 
-    robot_description_planning = {
-        "robot_description_planning": load_yaml_abs(str(joint_limit_params.perform(context)))
-    }
+    robot_description_planning = {"robot_description_planning": joint_limit_params}
 
     # Planning Configuration
     ompl_planning_pipeline_config = {


### PR DESCRIPTION
Update wrong description for “dashboard” parameter.

MoveIt now uses proper node parameters, so parameter substitution is possible/needed instead of manual YAML parsing.﻿ Without this change, I get the following error because parameter type is interpreted wrongly.

![moveit_error_wrong_parameter_type](https://user-images.githubusercontent.com/1918204/147110964-edcca62f-88c6-49e3-8b0f-124147ad4188.png)

