### PR TITLE
Separate control node

### DIFF
--- a/ur_bringup/config/ur10_update_rate.yaml
+++ b/ur_bringup/config/ur10_update_rate.yaml
@@ -1,3 +1,3 @@
 controller_manager:
   ros__parameters:
-    update_rate: 150  # Hz
+    update_rate: 125  # Hz

--- a/ur_bringup/config/ur10e_update_rate.yaml
+++ b/ur_bringup/config/ur10e_update_rate.yaml
@@ -1,3 +1,3 @@
 controller_manager:
   ros__parameters:
-    update_rate: 530  # Hz
+    update_rate: 500  # Hz

--- a/ur_bringup/config/ur16e_update_rate.yaml
+++ b/ur_bringup/config/ur16e_update_rate.yaml
@@ -1,3 +1,3 @@
 controller_manager:
   ros__parameters:
-    update_rate: 530  # Hz
+    update_rate: 500  # Hz

--- a/ur_bringup/config/ur3_update_rate.yaml
+++ b/ur_bringup/config/ur3_update_rate.yaml
@@ -1,3 +1,3 @@
 controller_manager:
   ros__parameters:
-    update_rate: 150  # Hz
+    update_rate: 125  # Hz

--- a/ur_bringup/config/ur3e_update_rate.yaml
+++ b/ur_bringup/config/ur3e_update_rate.yaml
@@ -1,3 +1,3 @@
 controller_manager:
   ros__parameters:
-    update_rate: 530  # Hz
+    update_rate: 500  # Hz

--- a/ur_bringup/config/ur5_update_rate.yaml
+++ b/ur_bringup/config/ur5_update_rate.yaml
@@ -1,3 +1,3 @@
 controller_manager:
   ros__parameters:
-    update_rate: 150  # Hz
+    update_rate: 125  # Hz

--- a/ur_bringup/config/ur5e_update_rate.yaml
+++ b/ur_bringup/config/ur5e_update_rate.yaml
@@ -1,3 +1,3 @@
 controller_manager:
   ros__parameters:
-    update_rate: 530  # Hz
+    update_rate: 500  # Hz

--- a/ur_bringup/launch/ur_control.launch.py
+++ b/ur_bringup/launch/ur_control.launch.py
@@ -154,6 +154,18 @@ def launch_setup(context, *args, **kwargs):
             "stdout": "screen",
             "stderr": "screen",
         },
+        condition=IfCondition(use_fake_hardware),
+    )
+
+    ur_control_node = Node(
+        package="ur_robot_driver",
+        executable="ur_ros2_control_node",
+        parameters=[robot_description, update_rate_config_file, initial_joint_controllers],
+        output={
+            "stdout": "screen",
+            "stderr": "screen",
+        },
+        condition=UnlessCondition(use_fake_hardware),
     )
 
     dashboard_client_node = Node(
@@ -236,6 +248,7 @@ def launch_setup(context, *args, **kwargs):
 
     nodes_to_start = [
         control_node,
+        ur_control_node,
         dashboard_client_node,
         robot_state_publisher_node,
         rviz_node,

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -12,6 +12,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(controller_manager REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -26,6 +27,7 @@ find_package(rclpy REQUIRED)
 include_directories(include)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
+  controller_manager
   hardware_interface
   pluginlib
   rclcpp
@@ -64,8 +66,17 @@ add_executable(dashboard_client
 target_link_libraries(dashboard_client ${catkin_LIBRARIES} ur_client_library::urcl)
 ament_target_dependencies(dashboard_client ${${PROJECT_NAME}_EXPORTED_TARGETS} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
+add_executable(ur_ros2_control_node src/ur_ros2_control_node.cpp)
+target_include_directories(ur_ros2_control_node PUBLIC ${controller_manager_INCLUDE_DIRS})
+target_link_libraries(ur_ros2_control_node ${controller_manager_LIBRARIES})
+ament_target_dependencies(ur_ros2_control_node
+  controller_interface
+  hardware_interface
+  rclcpp
+)
+
 install(
-  TARGETS dashboard_client
+  TARGETS dashboard_client ur_ros2_control_node
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -24,6 +24,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <depend>controller_manager</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
@@ -39,8 +40,6 @@
   <depend>ur_description</depend>
   <depend>ur_bringup</depend>
   <depend>ur_controllers</depend>
-
-  <exec_depend>controller_manager</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ur_robot_driver/src/ur_ros2_control_node.cpp
+++ b/ur_robot_driver/src/ur_ros2_control_node.cpp
@@ -1,0 +1,81 @@
+// Copyright 2022 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the Universal Robots A/S nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Lovro Ivanov lovro.ivanov@gmail.com
+ * \date    2022-1-7
+ *
+ */
+//----------------------------------------------------------------------
+
+#include <thread>
+#include <memory>
+
+// ROS includes
+#include "controller_manager/controller_manager.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+// code is inspired by
+// https://github.com/ros-controls/ros2_control/blob/master/controller_manager/src/ros2_control_node.cpp
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+
+  // create executor
+  std::shared_ptr<rclcpp::Executor> e = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+  // create controller manager instance
+  auto controller_manager = std::make_shared<controller_manager::ControllerManager>(e, "controller_manager");
+
+  // control loop thread
+  std::thread control_loop([controller_manager]() {
+    // use fixed time step
+    const rclcpp::Duration dt = rclcpp::Duration::from_seconds(1.0 / controller_manager->get_update_rate());
+
+    while (rclcpp::ok()) {
+      // ur client library is blocking and is the one that is controlling time step
+      controller_manager->read();
+      controller_manager->update(controller_manager->now(), dt);
+      controller_manager->write();
+    }
+  });
+
+  // spin the executor with controller manager node
+  e->add_node(controller_manager);
+  e->spin();
+
+  // wait for control loop to finish
+  control_loop.join();
+
+  // shutdown
+  rclcpp::shutdown();
+
+  return 0;
+}


### PR DESCRIPTION
PR info:
Adds separate ros2 control node without sleeping in the main loop as a way to solve the [`Pipeline produced overflow!` problem](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/210).

Instead of #263.