### PR TITLE
Change default controller in MoveIt config

### DIFF
--- a/ur_moveit_config/config/controllers.yaml
+++ b/ur_moveit_config/config/controllers.yaml
@@ -1,10 +1,25 @@
 controller_names:
+  - scaled_joint_trajectory_controller
   - joint_trajectory_controller
+
+
+scaled_joint_trajectory_controller:
+  action_ns: follow_joint_trajectory
+  type: FollowJointTrajectory
+  default: true
+  joints:
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+
 
 joint_trajectory_controller:
   action_ns: follow_joint_trajectory
   type: FollowJointTrajectory
-  default: true
+  default: false
   joints:
     - shoulder_pan_joint
     - shoulder_lift_joint


### PR DESCRIPTION
I forgot to add this in #287.

Nevertheless, when I change this an `underlow` exception in controller happens, which crashes ros2_control_node
```
﻿[ros2_control_node-1] terminate called after throwing an instance of 'std::underflow_error'
[ros2_control_node-1]   what():  addition leads to int64_t underflow
```

@fmauch do you have any idea why this should happen when MoveIt is used with scaling JTC? (I assume you experienced this issue already.)

Until this is fixed/merged users would have to set "joint_trajectory_controller" as default when using the driver with MoveIt.
