### PR TITLE
Update readme install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ ROS2 Distro | Foxy  | Galactic | Rolling
    ```
    cd $COLCON_WS
    git clone https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git src/Universal_Robots_ROS2_Driver
-   vcs import src --skip-existing --input src/Universal_Robots_ROS2_Driver/Universal_Robots_ROS2_Driver.repos
+   vcs import src --skip-existing --input src/Universal_Robots_ROS2_Driver/Universal_Robots_ROS2_Driver-not-released.${ROS_DISTRO}.repos
    rosdep install --ignore-src --from-paths src -y -r
    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
    source install/setup.bash

--- a/Universal_Robots_ROS2_Driver-not-released.foxy.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.foxy.repos
@@ -1,9 +1,0 @@
-repositories:
-  ros2_control_demos:
-    type: git
-    url: https://github.com/ros-controls/ros2_control_demos.git
-    version: foxy
-  ur_msgs:
-    type: git
-    url: https://github.com/destogl/ur_msgs.git
-    version: ros2

--- a/Universal_Robots_ROS2_Driver-not-released.galactic.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.galactic.repos
@@ -2,7 +2,7 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
-    version: master
+    version: galactic
   ros2_control_demos:
     type: git
     url: https://github.com/ros-controls/ros2_control_demos.git
@@ -10,7 +10,7 @@ repositories:
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git
-    version: master
+    version: galactic
   Universal_Robots_Client_Library:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
As risen for example in #296 our current installation instructions build a lot from source using the default branches. Obviously, this introduces changes not really applicable to older ROS versions.

For example, ros2_control dropped support for the deprecated `spawner.py` on the main branch. Therefore, I suggest changing the README to use the distro-specific dependency definitions and I updated the galactic definitions here.

In the long run we should try to reduce those as well, as packages from our `not-released...` rosdistro files are indeed released. But that's for another PR...