### PR TITLE
Load kinematics parameters as yaml

### DIFF
--- a/ur_moveit_config/config/kinematics.yaml
+++ b/ur_moveit_config/config/kinematics.yaml
@@ -1,5 +1,8 @@
-ur_manipulator:
-  kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
-  kinematics_solver_search_resolution: 0.005
-  kinematics_solver_timeout: 0.005
-  kinematics_solver_attempts: 3
+/**:
+  ros__parameters:
+    robot_description_kinematics:
+      ur_manipulator:
+        kinematics_solver: kdl_kinematics_plugin/KDLKinematicsPlugin
+        kinematics_solver_search_resolution: 0.005
+        kinematics_solver_timeout: 0.005
+        kinematics_solver_attempts: 3

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -123,11 +123,8 @@ def launch_setup(context, *args, **kwargs):
     )
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_content}
 
-    # kinematics_yaml = load_yaml("ur_moveit_config", "config/kinematics.yaml")
-    kinematics_yaml = PathJoinSubstitution(
-        [FindPackageShare(moveit_config_package), "config", "kinematics.yaml"]
-    )
-    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml}
+    kinematics_yaml_config = load_yaml("ur_moveit_config", "config/kinematics.yaml")
+    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml_config}
 
     # robot_description_planning = {
     # "robot_description_planning": load_yaml_abs(str(joint_limit_params.perform(context)))

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -123,8 +123,9 @@ def launch_setup(context, *args, **kwargs):
     )
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_content}
 
-    kinematics_yaml_config = load_yaml("ur_moveit_config", "config/kinematics.yaml")
-    robot_description_kinematics = {"robot_description_kinematics": kinematics_yaml_config}
+    robot_description_kinematics = PathJoinSubstitution(
+        [FindPackageShare(moveit_config_package), "config", "kinematics.yaml"]
+    )
 
     # robot_description_planning = {
     # "robot_description_planning": load_yaml_abs(str(joint_limit_params.perform(context)))


### PR DESCRIPTION
This fixes #307 which outlines a regression introduced in #278

~~@destogl As we use the raw string "ur_moveit_config" in several other places, it probably doesn't harm to leave this.~~
With the implementation from bf37c75 it should be possible to keep both.