### PR TITLE
Fix scheduled foxy build

### DIFF
--- a/.github/workflows/foxy-source-build.yml
+++ b/.github/workflows/foxy-source-build.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           required-ros-distributions: ${{ env.ROS_DISTRO }}
       - uses: actions/checkout@v1
+        with:
+          ref: foxy
       - name: start ursim
         run: |
           .github/dockerursim/build_and_run_docker_ursim.sh


### PR DESCRIPTION
The scheduled build is running on the default branch if not told differently.