### PR TITLE
[Foxy] Fix a syntax error in semi-binary build

### DIFF
--- a/.github/workflows/foxy-semi-binary-build.yml
+++ b/.github/workflows/foxy-semi-binary-build.yml
@@ -15,7 +15,7 @@ jobs:
     name: foxy semi-binary build
     runs-on: ubuntu-latest
     strategy:
-    max-parallel: 1
+      max-parallel: 1
       matrix:
         env:
           - {ROS_DISTRO: foxy, ROS_REPO: main}


### PR DESCRIPTION
This got lost in #312. Apparently, workflows with a syntax error do not show up as failed in the PR.