### PR TITLE
Fix erroneous version of python black in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
         args: [--py36-plus]
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
         args: ["--line-length=100"]


### PR DESCRIPTION
From some reason, the old version is failing import requirements recently. Bumping the version fixes the issue.