### PR TITLE
Only start controller_stopper when not using fake_hardware

### DIFF
--- a/ur_bringup/launch/ur_control.launch.py
+++ b/ur_bringup/launch/ur_control.launch.py
@@ -231,6 +231,7 @@ def launch_setup(context, *args, **kwargs):
         name="controller_stopper",
         output="screen",
         emulate_tty=True,
+        condition=UnlessCondition(use_fake_hardware),
         parameters=[
             {"headless_mode": headless_mode},
             {"joint_controller_active": activate_joint_controller},


### PR DESCRIPTION
It only makes sense to start the controller_stopper when real hardware (or URSim) is used.