### PR TITLE
Fix lifecycle_msgs dependency

### DIFF
--- a/ur_controllers/CMakeLists.txt
+++ b/ur_controllers/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(control_msgs REQUIRED)
 find_package(controller_interface REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(joint_trajectory_controller REQUIRED)
+find_package(lifecycle_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(rcutils REQUIRED)
@@ -33,6 +34,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   controller_interface
   geometry_msgs
   joint_trajectory_controller
+  lifecycle_msgs
   pluginlib
   rclcpp_lifecycle
   rcutils

--- a/ur_controllers/package.xml
+++ b/ur_controllers/package.xml
@@ -25,6 +25,7 @@
   <depend>controller_interface</depend>
   <depend>geometry_msgs</depend>
   <depend>joint_trajectory_controller</depend>
+  <depend>lifecycle_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>rcutils</depend>

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -38,6 +38,7 @@
 #include <memory>
 #include <vector>
 
+#include "lifecycle_msgs/msg/state.hpp"
 #include "ur_controllers/scaled_joint_trajectory_controller.hpp"
 
 namespace ur_controllers


### PR DESCRIPTION
Fixes
```
/ros2_workspace/src/Universal_Robots_ROS2_Driver/ur_controllers/src/scaled_joint_trajectory_controller.cpp:73:48: error: ‘lifecycle_msgs::msg::State’ has not been declared
   73 |   if (get_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
      |                                                ^~~~~
```