### PR TITLE
ignore doc/conf.py from copyright checks

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          linter: [cppcheck, copyright, lint_cmake]
+          linter: [cppcheck, lint_cmake]
     steps:
     - uses: actions/checkout@v1
     - uses: ros-tooling/setup-ros@v0.2
@@ -23,6 +23,26 @@ jobs:
           ur_dashboard_msgs
           ur_moveit_config
           ur_robot_driver
+
+  ament_copyright:
+    name: ament_copyright
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v1
+      - uses: ros-tooling/setup-ros@v0.2
+      - uses: ros-tooling/action-ros-lint@v0.1
+        with:
+          distribution: rolling
+          linter: copyright
+          arguments: '--exclude ur_robot_driver/doc/conf.py'
+          package-name:
+            ur_bringup
+            ur_controllers
+            ur_dashboard_msgs
+            ur_moveit_config
+            ur_robot_driver
 
   ament_lint_120:
     name: ament_${{ matrix.linter }}


### PR DESCRIPTION
This splipped through in #340 and fixes the ament_copyright check.

In my opinion, this is not a file that can be copyrighted, hence I suggest ignoring it.