### PR TITLE
Replace warehouse_ros_mongo with warehouse_ros_sqlite

### DIFF
--- a/Universal_Robots_ROS2_Driver-not-released.rolling.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.rolling.repos
@@ -7,3 +7,7 @@ repositories:
     type: git
     url: https://github.com/ros-planning/srdfdom.git
     version: ros2
+  warehouse_ros_sqlite:
+    type: git
+    url: https://github.com/ros-planning/warehouse_ros_sqlite
+    version: ros2

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -31,3 +31,7 @@ repositories:
     type: git
     url: https://github.com/ros-planning/srdfdom.git
     version: ros2
+  warehouse_ros_sqlite:
+    type: git
+    url: https://github.com/ros-planning/warehouse_ros_sqlite
+    version: ros2

--- a/ur_moveit_config/package.xml
+++ b/ur_moveit_config/package.xml
@@ -20,7 +20,7 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>urdf</exec_depend>
-  <exec_depend>warehouse_ros_mongo</exec_depend>
+  <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <export>


### PR DESCRIPTION
Since mongodb is not available on Ubuntu jammy, I don't see `warehouse_ros_mongodb` is coming on Jammy any time soon. See upstream https://github.com/ros-planning/warehouse_ros_mongo/issues/71 for details.

Keeping this draft as I currently don't have a jammy system to test this on.