### PR TITLE
Fix repos file for scheduled foxy source build

### DIFF
--- a/.github/workflows/foxy-source-build.yml
+++ b/.github/workflows/foxy-source-build.yml
@@ -34,7 +34,7 @@ jobs:
             ur_robot_driver
           vcs-repo-file-url: |
             https://raw.githubusercontent.com/ros2/ros2/${{ env.ROS_DISTRO }}/ros2.repos
-            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/Universal_Robots_ROS2_Driver.repos
+            https://raw.githubusercontent.com/${{ github.repository }}/tree/foxy/Universal_Robots_ROS2_Driver.repos
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
       - uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
Since the scheduled build has to be run from the main branch,
but we need to use the repos file from the foxy branch, we have to specify
it directly.