### PR TITLE
Foxy: Update dependencies and binary repos file

### DIFF
--- a/.github/workflows/foxy-binary-build.yml
+++ b/.github/workflows/foxy-binary-build.yml
@@ -21,7 +21,6 @@ jobs:
           - {ROS_DISTRO: foxy, ROS_REPO: main}
           - {ROS_DISTRO: foxy, ROS_REPO: testing}
     env:
-      UPSTREAM_WORKSPACE: Universal_Robots_ROS2_Driver-not-released.${{ matrix.env.ROS_DISTRO }}.repos
       DOCKER_RUN_OPTS: --network static_test_net
       BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
       IMMEDIATE_TEST_OUTPUT: true

--- a/.github/workflows/foxy-binary-build.yml
+++ b/.github/workflows/foxy-binary-build.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
+      fail-fast: false
       matrix:
         env:
           - {ROS_DISTRO: foxy, ROS_REPO: main}

--- a/README.md
+++ b/README.md
@@ -152,7 +152,14 @@ The most relevant arguments are the following:
 
    To check the controllers' state use `ros2 control list_controllers` command.
 
-- Send some goal to the Joint Trajectory Controller by using a demo node from [ros2_control_demos](https://github.com/ros-controls/ros2_control_demos) package by starting  the following command in another terminal:
+- Send some goal to the Joint Trajectory Controller by using a demo node from
+  [ros2_control_demos](https://github.com/ros-controls/ros2_control_demos) package by starting  the
+  following command in another terminal.
+
+  **NOTE: As the `ros2_control_demos` package is currently not released for ROS2 Foxy, you'll have
+  to build it in your workspace in order to use this launchfile. We are aware that this is not
+  ideal, but we thought it would be better to not drop the testing launchfile at all and provide
+  this info to users.**
    ```
    ros2 launch ur_bringup test_joint_trajectory_controller.launch.py
    ```

--- a/Universal_Robots_ROS2_Driver-not-released.foxy.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.foxy.repos
@@ -1,9 +1,0 @@
-repositories:
-  ros2_control_demos:
-    type: git
-    url: https://github.com/ros-controls/ros2_control_demos.git
-    version: foxy
-  ur_msgs:
-    type: git
-    url: https://github.com/ros-industrial/ur_msgs.git
-    version: foxy-devel

--- a/ur_bringup/launch/test_joint_trajectory_controller.launch.py
+++ b/ur_bringup/launch/test_joint_trajectory_controller.launch.py
@@ -15,11 +15,13 @@
 # Author: Denis Stogl
 #
 # Description: After a robot has been loaded, this will execute a series of trajectories.
+import sys
 
 from launch import LaunchDescription
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
+from ament_index_python.packages import get_package_share_directory, PackageNotFoundError
 
 
 def generate_launch_description():
@@ -27,6 +29,20 @@ def generate_launch_description():
     position_goals = PathJoinSubstitution(
         [FindPackageShare("ur_bringup"), "config", "test_goal_publishers_config.yaml"]
     )
+
+    # Kind of hack until this dependency is released
+    # TODO (@anyone): Remove this once the upstream package is released
+    try:
+        get_package_share_directory("ros2_control_test_nodes")
+    except PackageNotFoundError:
+        print(
+            "ERROR:"
+            "Could not find package 'ros2_control_test_nodes'. Please install it (build it from "
+            "source) in order to run this launchfile. See here for details: explanation:\n"
+            "https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/foxy"
+            "#example-commands-for-testing-the-driver"
+        )
+        sys.exit(1)
 
     return LaunchDescription(
         [

--- a/ur_bringup/launch/test_scaled_joint_trajectory_controller.launch.py
+++ b/ur_bringup/launch/test_scaled_joint_trajectory_controller.launch.py
@@ -15,11 +15,13 @@
 # Author: Denis Stogl
 #
 # Description: After a robot has been loaded, this will execute a series of trajectories.
+import sys
 
 from launch import LaunchDescription
 from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
+from ament_index_python.packages import get_package_share_directory, PackageNotFoundError
 
 
 def generate_launch_description():
@@ -28,6 +30,20 @@ def generate_launch_description():
         [FindPackageShare("ur_bringup"), "config", "test_goal_publishers_config.yaml"]
     )
 
+    # Kind of hack until this dependency is released
+    # TODO (@anyone): Remove this once the upstream package is released
+    try:
+        get_package_share_directory("ros2_control_test_nodes")
+    except PackageNotFoundError:
+        print(
+            "ERROR:"
+            "Could not find package 'ros2_control_test_nodes'. Please install it (build it from "
+            "source) in order to run this launchfile. See here for details: explanation:\n"
+            "https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/foxy"
+            "#example-commands-for-testing-the-driver"
+        )
+        sys.exit(1)
+
     return LaunchDescription(
         [
             Node(
@@ -35,10 +51,7 @@ def generate_launch_description():
                 executable="publisher_joint_trajectory_controller",
                 name="publisher_scaled_joint_trajectory_controller",
                 parameters=[position_goals],
-                output={
-                    "stdout": "screen",
-                    "stderr": "screen",
-                },
+                output={"stdout": "screen", "stderr": "screen"},
             )
         ]
     )

--- a/ur_bringup/package.xml
+++ b/ur_bringup/package.xml
@@ -31,7 +31,6 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>ur_controllers</exec_depend>
   <exec_depend>ur_description</exec_depend>
-  <exec_depend>ur_robot_driver</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>xacro</exec_depend>
 

--- a/ur_bringup/package.xml
+++ b/ur_bringup/package.xml
@@ -5,8 +5,6 @@
   <version>0.0.0</version>
   <description>Launch file and run-time configurations, e.g. controllers.</description>
 
-  <author>Lovro Ivanov</author>
-  <author>Denis Stogl</author>
 
   <maintainer email="grosse@fzi.de">Marvin Große Besselmann</maintainer>
   <maintainer email="lovro.ivanov@gmail.com">Lovro Ivanov</maintainer>
@@ -17,6 +15,9 @@
 
   <url type="bugtracker">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues</url>
   <url type="repository">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver</url>
+
+  <author>Lovro Ivanov</author>
+  <author>Denis Stogl</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/ur_bringup/package.xml
+++ b/ur_bringup/package.xml
@@ -23,9 +23,15 @@
 
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>joint_trajectory_controller</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <!--<exec_depend>ros2_controllers_test_nodes</exec_depend>-->
   <exec_depend>rviz2</exec_depend>
+  <exec_depend>ur_controllers</exec_depend>
+  <exec_depend>ur_description</exec_depend>
+  <exec_depend>ur_robot_driver</exec_depend>
   <exec_depend>urdf</exec_depend>
   <exec_depend>xacro</exec_depend>
 


### PR DESCRIPTION
Closing #342 

Also affects #347, as the dependency is not put in. Unfortunately, this will lead to an error when launching the package if it is not built inside the workspace.