### PR TITLE
Force galactic branch for scheduled builds

### DIFF
--- a/.github/workflows/galactic-binary-build.yml
+++ b/.github/workflows/galactic-binary-build.yml
@@ -21,6 +21,8 @@ jobs:
       CACHE_PREFIX: ${{ matrix.ROS_DISTRO }}-${{ matrix.ROS_REPO }}-binary
     steps:
       - uses: actions/checkout@v1
+        with:
+          ref: galactic
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: cache target_ws

--- a/.github/workflows/galactic-semi-binary-build.yml
+++ b/.github/workflows/galactic-semi-binary-build.yml
@@ -22,6 +22,8 @@ jobs:
       CACHE_PREFIX: ${{ matrix.ROS_DISTRO }}-${{ matrix.ROS_REPO }}-semi-binary
     steps:
       - uses: actions/checkout@v1
+        with:
+          ref: galactic
       # The target directory cache doesn't include the source directory because
       # that comes from the checkout.  See "prepare target_ws for cache" task below
       - name: cache target_ws


### PR DESCRIPTION
As scheduled runs have to run on the main branch, we have to explicitly
checkout the distro's branch in the CI run.