### PR TITLE
Remove Foxy upstream not-released file

### DIFF
--- a/.github/workflows/foxy-binary-build.yml
+++ b/.github/workflows/foxy-binary-build.yml
@@ -15,7 +15,6 @@ jobs:
           - {ROS_DISTRO: foxy, ROS_REPO: main}
           - {ROS_DISTRO: foxy, ROS_REPO: testing}
     env:
-      UPSTREAM_WORKSPACE: Universal_Robots_ROS2_Driver-not-released.${{ matrix.env.ROS_DISTRO }}.repos
       DOCKER_RUN_OPTS: --network static_test_net
       BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
       IMMEDIATE_TEST_OUTPUT: true


### PR DESCRIPTION
since scheduled builds run on the default branch, this has to be adapted.
The file got removed on the foxy branch which is checked out by this job.

This got updated in #373 