### PR TITLE
Loop plan animation by default

### DIFF
--- a/ur_moveit_config/rviz/view_robot.rviz
+++ b/ur_moveit_config/rviz/view_robot.rviz
@@ -125,7 +125,7 @@ Visualization Manager:
             Show Axes: false
             Show Trail: false
             Value: true
-        Loop Animation: false
+        Loop Animation: true
         Robot Alpha: 0.5
         Robot Color: 150; 50; 150
         Show Robot Collision: false


### PR DESCRIPTION
In my opinion this makes a lot of sense, especially since the full path is not animated when havng this switched off.