### PR TITLE
Fixed controller name for force_torque_sensor_broadcaster

### DIFF
--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -12,7 +12,7 @@ controller_manager:
       type: ur_controllers/SpeedScalingStateBroadcaster
 
     force_torque_sensor_broadcaster:
-      type: force_torque_sensor_broadcaster/ForceTorqueStateBroadcaster
+      type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
 
     joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController


### PR DESCRIPTION
This got lost in #403 since it was started before #405 was merged.