### PR TITLE
Remove non-required dependency from CMakeLists

### DIFF
--- a/ur_moveit_config/CMakeLists.txt
+++ b/ur_moveit_config/CMakeLists.txt
@@ -3,7 +3,6 @@ project(ur_moveit_config)
 
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_python REQUIRED)
-find_package(rclpy REQUIRED)
 
 install(DIRECTORY config launch rviz srdf
   DESTINATION share/${PROJECT_NAME}


### PR DESCRIPTION
Similar to fd66700db47aefe7fa8f64e4068d9d5213d367d5 we need to remove that dependency on the main branch.