### PR TITLE
Silence a compilation warning

### DIFF
--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -264,7 +264,7 @@ bool DashboardClientROS::connect()
 {
   timeval tv;
   // Timeout after which a call to the dashboard server will be considered failure if no answer has been received.
-  double time_buffer;
+  double time_buffer = 0;
   node_->get_parameter("receive_timeout", time_buffer);
   tv.tv_sec = time_buffer;
   tv.tv_usec = 0;


### PR DESCRIPTION
Since setting the receive timeout takes the time_buffer as an argument
this raises a "may be used uninitialized" warning. Setting this to 0
explicitly should prevent that.