### PR TITLE
Revert "Use ros2_controllers sources (#412)"

### DIFF
--- a/.github/workflows/humble-execution-test.yml
+++ b/.github/workflows/humble-execution-test.yml
@@ -16,7 +16,6 @@ jobs:
         ROS_DISTRO: [humble]
         ROS_REPO: [main, testing]
     env:
-      UPSTREAM_WORKSPACE: Universal_Robots_ROS2_Driver-not-released.${{ matrix.ROS_DISTRO }}.repos
       DOCKER_RUN_OPTS: --network static_test_net
       BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
       IMMEDIATE_TEST_OUTPUT: true

--- a/.github/workflows/rolling-execution-test.yml
+++ b/.github/workflows/rolling-execution-test.yml
@@ -16,7 +16,6 @@ jobs:
         ROS_DISTRO: [rolling]
         ROS_REPO: [main, testing]
     env:
-      UPSTREAM_WORKSPACE: Universal_Robots_ROS2_Driver-not-released.${{ matrix.ROS_DISTRO }}.repos
       DOCKER_RUN_OPTS: --network static_test_net
       BEFORE_INIT: 'apt-get update -qq && apt-get install -y iproute2 iputils-ping && ip addr && ping -c5 192.168.56.101'
       IMMEDIATE_TEST_OUTPUT: true

--- a/Universal_Robots_ROS2_Driver-not-released.humble.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.humble.repos
@@ -1,5 +1,1 @@
-repositories:
-  ros2_controllers:
-    type: git
-    url: https://github.com/ros-controls/ros2_controllers
-    version: master
+repositories: []

--- a/Universal_Robots_ROS2_Driver-not-released.rolling.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.rolling.repos
@@ -1,5 +1,1 @@
-repositories:
-  ros2_controllers:
-    type: git
-    url: https://github.com/ros-controls/ros2_controllers
-    version: master
+repositories: []

--- a/Universal_Robots_ROS2_Driver.humble.repos
+++ b/Universal_Robots_ROS2_Driver.humble.repos
@@ -11,7 +11,3 @@ repositories:
     type: git
     url: https://github.com/ros-industrial/ur_msgs.git
     version: foxy-devel
-  ros2_controllers:
-    type: git
-    url: https://github.com/ros-controls/ros2_controllers
-    version: master

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -11,7 +11,3 @@ repositories:
     type: git
     url: https://github.com/ros-industrial/ur_msgs.git
     version: foxy-devel
-  ros2_controllers:
-    type: git
-    url: https://github.com/ros-controls/ros2_controllers
-    version: master


### PR DESCRIPTION
This reverts commit 6d13661ee3f83b80bc253ef5b63284b730c402b8.

Rolling has already been synced and I hope that humble will follow soon. Since upstream master has made some API incompatible changes, it might make sense to revert this now, I believe.