### PR TITLE
added ur_bringup to test_depend of ur_robot_driver

### DIFF
--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -43,6 +43,7 @@
 
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>rclpy</test_depend>
+  <test_depend>ur_bringup</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Currently, our binary package builds for the driver [fail](https://build.ros2.org/job/Fbin_uF64__ur_robot_driver__ubuntu_focal_amd64__binary/) because of the missing declaration.

This PR should fix that.