### PR TITLE
add ur_moveit.launch.py parameter to use working controller when using fake hardware

### DIFF
--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -45,6 +45,7 @@ def launch_setup(context, *args, **kwargs):
 
     # Initialize Arguments
     ur_type = LaunchConfiguration("ur_type")
+    is_using_fake_hardware = LaunchConfiguration("is_using_fake_hardware")
     safety_limits = LaunchConfiguration("safety_limits")
     safety_pos_margin = LaunchConfiguration("safety_pos_margin")
     safety_k_position = LaunchConfiguration("safety_k_position")
@@ -162,6 +163,11 @@ def launch_setup(context, *args, **kwargs):
 
     # Trajectory Execution Configuration
     controllers_yaml = load_yaml("ur_moveit_config", "config/controllers.yaml")
+    # the scaled_joint_trajectory_controller does not work on simulated robots
+    if is_using_fake_hardware:
+        controllers_yaml["scaled_joint_trajectory_controller"]["default"]= False
+        controllers_yaml["joint_trajectory_controller"]["default"]= True
+
     moveit_controllers = {
         "moveit_simple_controller_manager": controllers_yaml,
         "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
@@ -255,6 +261,13 @@ def generate_launch_description():
             "ur_type",
             description="Type/series of used UR robot.",
             choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e"],
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "is_using_fake_hardware",
+            default_value="false",
+            description="Indicate whether robot is running with fake hardware mirroring command to its states.",
         )
     )
     declared_arguments.append(

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -45,7 +45,7 @@ def launch_setup(context, *args, **kwargs):
 
     # Initialize Arguments
     ur_type = LaunchConfiguration("ur_type")
-    is_using_fake_hardware = LaunchConfiguration("is_using_fake_hardware")
+    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     safety_limits = LaunchConfiguration("safety_limits")
     safety_pos_margin = LaunchConfiguration("safety_pos_margin")
     safety_k_position = LaunchConfiguration("safety_k_position")
@@ -164,7 +164,7 @@ def launch_setup(context, *args, **kwargs):
     # Trajectory Execution Configuration
     controllers_yaml = load_yaml("ur_moveit_config", "config/controllers.yaml")
     # the scaled_joint_trajectory_controller does not work on simulated robots
-    if is_using_fake_hardware:
+    if use_fake_hardware:
         controllers_yaml["scaled_joint_trajectory_controller"]["default"]= False
         controllers_yaml["joint_trajectory_controller"]["default"]= True
 
@@ -265,7 +265,7 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "is_using_fake_hardware",
+            "use_fake_hardware",
             default_value="false",
             description="Indicate whether robot is running with fake hardware mirroring command to its states.",
         )

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -165,8 +165,8 @@ def launch_setup(context, *args, **kwargs):
     controllers_yaml = load_yaml("ur_moveit_config", "config/controllers.yaml")
     # the scaled_joint_trajectory_controller does not work on simulated robots
     if use_fake_hardware:
-        controllers_yaml["scaled_joint_trajectory_controller"]["default"]= False
-        controllers_yaml["joint_trajectory_controller"]["default"]= True
+        controllers_yaml["scaled_joint_trajectory_controller"]["default"] = False
+        controllers_yaml["joint_trajectory_controller"]["default"] = True
 
     moveit_controllers = {
         "moveit_simple_controller_manager": controllers_yaml,

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -163,7 +163,7 @@ def launch_setup(context, *args, **kwargs):
 
     # Trajectory Execution Configuration
     controllers_yaml = load_yaml("ur_moveit_config", "config/controllers.yaml")
-    # the scaled_joint_trajectory_controller does not work on simulated robots
+    # the scaled_joint_trajectory_controller does not work on fake hardware
     if use_fake_hardware:
         controllers_yaml["scaled_joint_trajectory_controller"]["default"] = False
         controllers_yaml["joint_trajectory_controller"]["default"] = True


### PR DESCRIPTION
Workaround for #390 (simulated hardware throws an underflow error which breaks scaled_joint_trajectory_controller #301) by allowing user to specify whether the robot driver is using fake_hardware as CLI argument. If this is the case, MoveIt will fall back on the joint_trajectory_controller. This behavior is disabled by default and requires user to manually set argument is_using_fake_hardware to true when running ur_moveit.launch.py. 