### PR TITLE
Added services to set tool voltage and zero force torque sensor

### DIFF
--- a/ur_controllers/include/ur_controllers/gpio_controller.hpp
+++ b/ur_controllers/include/ur_controllers/gpio_controller.hpp
@@ -63,16 +63,19 @@ enum CommandInterfaces
 {
   DIGITAL_OUTPUTS_CMD = 0u,
   ANALOG_OUTPUTS_CMD = 18,
-  IO_ASYNC_SUCCESS = 20,
-  TARGET_SPEED_FRACTION_CMD = 21,
-  TARGET_SPEED_FRACTION_ASYNC_SUCCESS = 22,
-  RESEND_ROBOT_PROGRAM_CMD = 23,
-  RESEND_ROBOT_PROGRAM_ASYNC_SUCCESS = 24,
-  PAYLOAD_MASS = 25,
-  PAYLOAD_COG_X = 26,
-  PAYLOAD_COG_Y = 27,
-  PAYLOAD_COG_Z = 28,
-  PAYLOAD_ASYNC_SUCCESS = 29,
+  TOOL_VOLTAGE_CMD = 20,
+  IO_ASYNC_SUCCESS = 21,
+  TARGET_SPEED_FRACTION_CMD = 22,
+  TARGET_SPEED_FRACTION_ASYNC_SUCCESS = 23,
+  RESEND_ROBOT_PROGRAM_CMD = 24,
+  RESEND_ROBOT_PROGRAM_ASYNC_SUCCESS = 25,
+  PAYLOAD_MASS = 26,
+  PAYLOAD_COG_X = 27,
+  PAYLOAD_COG_Y = 28,
+  PAYLOAD_COG_Z = 29,
+  PAYLOAD_ASYNC_SUCCESS = 30,
+  ZERO_FTSENSOR_CMD = 31,
+  ZERO_FTSENSOR_ASYNC_SUCCESS = 32,
 };
 
 enum StateInterfaces
@@ -125,6 +128,8 @@ private:
   bool setPayload(const ur_msgs::srv::SetPayload::Request::SharedPtr req,
                   ur_msgs::srv::SetPayload::Response::SharedPtr resp);
 
+  bool zeroFTSensor(std_srvs::srv::Trigger::Request::SharedPtr req, std_srvs::srv::Trigger::Response::SharedPtr resp);
+
   void publishIO();
 
   void publishToolData();
@@ -150,6 +155,7 @@ protected:
   rclcpp::Service<ur_msgs::srv::SetSpeedSliderFraction>::SharedPtr set_speed_slider_srv_;
   rclcpp::Service<ur_msgs::srv::SetIO>::SharedPtr set_io_srv_;
   rclcpp::Service<ur_msgs::srv::SetPayload>::SharedPtr set_payload_srv_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr tare_sensor_srv_;
 
   std::shared_ptr<rclcpp::Publisher<ur_msgs::msg::IOStates>> io_pub_;
   std::shared_ptr<rclcpp::Publisher<ur_msgs::msg::ToolDataMsg>> tool_data_pub_;

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -174,11 +174,14 @@ protected:
   // asynchronous commands
   std::array<double, 18> standard_dig_out_bits_cmd_;
   std::array<double, 2> standard_analog_output_cmd_;
+  double tool_voltage_cmd_;
   double io_async_success_;
   double target_speed_fraction_cmd_;
   double scaling_async_success_;
   double resend_robot_program_cmd_;
   double resend_robot_program_async_success_;
+  double zero_ftsensor_cmd_;
+  double zero_ftsensor_async_success_;
   bool first_pass_;
   bool initialized_;
   double system_interface_initialized_;

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -68,6 +68,8 @@ def launch_setup(context, *args, **kwargs):
     tool_device_name = LaunchConfiguration("tool_device_name")
     tool_tcp_port = LaunchConfiguration("tool_tcp_port")
     tool_voltage = LaunchConfiguration("tool_voltage")
+    reverse_ip = LaunchConfiguration("reverse_ip")
+    script_command_port = LaunchConfiguration("script_command_port")
 
     joint_limit_params = PathJoinSubstitution(
         [FindPackageShare(description_package), "config", ur_type, "joint_limits.yaml"]
@@ -171,6 +173,12 @@ def launch_setup(context, *args, **kwargs):
             " ",
             "tool_voltage:=",
             tool_voltage,
+            " ",
+            "reverse_ip:=",
+            reverse_ip,
+            " ",
+            "script_command_port:=",
+            script_command_port,
             " ",
         ]
     )
@@ -532,6 +540,20 @@ def generate_launch_description():
             "tool_voltage",
             default_value="0",  # 0 being a conservative value that won't destroy anything
             description="Tool voltage that will be setup.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "reverse_ip",
+            default_value="0.0.0.0",
+            description="IP that will be used for the robot controller to communicate back to the driver.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "script_command_port",
+            default_value="50004",
+            description="Port that will be opened to forward script commands from the driver to the robot",
         )
     )
 


### PR DESCRIPTION
Added launch arguments for reverse ip and script command interface port.

This requires the changes from [pr](https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/111) in the client library and also the changes from [pr](https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/38) in the ur ros2 description. 

To be able to use the script commands when the robot is in local control we have to use the urscript from the client, this is being addressed in #316.  

This will fix the issues #420 and #447. 
