### PR TITLE
back-port use_fake_hardware parameter in ur_moveit.launch.py to Galactic (#464)

### DIFF
--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -43,6 +43,7 @@ def launch_setup(context, *args, **kwargs):
 
     # Initialize Arguments
     ur_type = LaunchConfiguration("ur_type")
+    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     safety_limits = LaunchConfiguration("safety_limits")
     safety_pos_margin = LaunchConfiguration("safety_pos_margin")
     safety_k_position = LaunchConfiguration("safety_k_position")
@@ -159,6 +160,11 @@ def launch_setup(context, *args, **kwargs):
 
     # Trajectory Execution Configuration
     controllers_yaml = load_yaml("ur_moveit_config", "config/controllers.yaml")
+    # the scaled_joint_trajectory_controller does not work on fake hardware
+    if use_fake_hardware:
+        controllers_yaml["scaled_joint_trajectory_controller"]["default"] = False
+        controllers_yaml["joint_trajectory_controller"]["default"] = True
+
     moveit_controllers = {
         "moveit_simple_controller_manager": controllers_yaml,
         "moveit_controller_manager": "moveit_simple_controller_manager/MoveItSimpleControllerManager",
@@ -260,6 +266,13 @@ def generate_launch_description():
             "ur_type",
             description="Type/series of used UR robot.",
             choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e"],
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_fake_hardware",
+            default_value="false",
+            description="Indicate whether robot is running with fake hardware mirroring command to its states.",
         )
     )
     declared_arguments.append(

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -161,7 +161,8 @@ def launch_setup(context, *args, **kwargs):
     # Trajectory Execution Configuration
     controllers_yaml = load_yaml("ur_moveit_config", "config/controllers.yaml")
     # the scaled_joint_trajectory_controller does not work on fake hardware
-    if use_fake_hardware:
+    change_controllers = context.perform_substitution(use_fake_hardware)
+    if change_controllers == "true":
         controllers_yaml["scaled_joint_trajectory_controller"]["default"] = False
         controllers_yaml["joint_trajectory_controller"]["default"] = True
 


### PR DESCRIPTION
The patch in #464 fixes my problem where the UR Gazebo Sim won't move because the Scaled JTC controller is loaded into the MoveitSimpleControllerManager as default controller (and there is no way to change it during runtime through e.g. a service). Building main branch breaks because of same error message as in #434, so I found it simpler to backport a single commit from main.

This is my very first pull request in a professional repository so sorry in advance for any mistakes or shortages. For example, I am not sure which tests you refer to under item 3 in the [contributing page](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/blob/f580ae73edc67b10ce89ff72d30f70269935e39d/CONTRIBUTING.md): Are you referring to the pre-commit tests? 