### PR TITLE
Fix selecting the right controller given fake_hw

### DIFF
--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -164,7 +164,8 @@ def launch_setup(context, *args, **kwargs):
     # Trajectory Execution Configuration
     controllers_yaml = load_yaml("ur_moveit_config", "config/controllers.yaml")
     # the scaled_joint_trajectory_controller does not work on fake hardware
-    if use_fake_hardware:
+    change_controllers = context.perform_substitution(use_fake_hardware)
+    if change_controllers == "true":
         controllers_yaml["scaled_joint_trajectory_controller"]["default"] = False
         controllers_yaml["joint_trajectory_controller"]["default"] = True
 


### PR DESCRIPTION
This was falsely introduced earlier. This is a working version. The wrong version was introduced in #464, where I seemed to miss checking real hardware. Thanks @grassjelly for providing this solution in https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/470#issuecomment-1254658620.