### PR TITLE
Fixed argument/parameter usage of urdf macro

### DIFF
--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -85,9 +85,9 @@
     <!-- ros2 control instance -->
     <xacro:ur_ros2_control
       name="URPositionHardwareInterface" prefix="${prefix}"
-      use_fake_hardware="$(arg use_fake_hardware)"
+      use_fake_hardware="$(use_fake_hardware)"
       initial_positions="${initial_positions}"
-      fake_sensor_commands="$(arg fake_sensor_commands)"
+      fake_sensor_commands="$(fake_sensor_commands)"
       script_filename="$(arg script_filename)"
       output_recipe_filename="$(arg output_recipe_filename)"
       input_recipe_filename="$(arg input_recipe_filename)"


### PR DESCRIPTION
"use_fake_hardware" and "fake_sensor_commands" are used as arguments instead of params. This required external urdf files that will use these macro to declare these two values as arguments instead of passing them via marcro parameter.