### PR TITLE
Move out ros2_control macro from ur kinematic macro

### DIFF
--- a/ur_description/urdf/ur.urdf.xacro
+++ b/ur_description/urdf/ur.urdf.xacro
@@ -4,7 +4,6 @@
    <xacro:arg name="name" default="ur"/>
    <!-- import main macro -->
    <xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>
-   <xacro:include filename="$(find ur_description)/urdf/inc/ur_common.xacro" />
 
    <!-- parameters -->
    <xacro:arg name="prefix" default="" />
@@ -12,6 +11,7 @@
    <xacro:arg name="kinematics_params" default=""/>
    <xacro:arg name="physical_params" default=""/>
    <xacro:arg name="visual_params" default=""/>
+   <xacro:arg name="transmission_hw_interface" default=""/>
    <xacro:arg name="safety_limits" default="false"/>
    <xacro:arg name="safety_pos_margin" default="0.15"/>
    <xacro:arg name="safety_k_position" default="20"/>
@@ -29,31 +29,22 @@
    <xacro:arg name="input_recipe_filename" default="$(find ur_robot_driver)/resources/rtde_input_recipe.txt"/>
 
    <!-- Load configuration data from the provided .yaml files -->
-   <xacro:read_model_data
+   <xacro:ur_robot
+     prefix="$(arg prefix)"
      joint_limits_parameters_file="$(arg joint_limit_params)"
      kinematics_parameters_file="$(arg kinematics_params)"
      physical_parameters_file="$(arg physical_params)"
-     visual_parameters_file="$(arg visual_params)"/>
-
-   <!-- arm -->
-   <xacro:ur_robot
-     prefix="$(arg prefix)"
+     visual_parameters_file="$(arg visual_params)"
+     transmission_hw_interface="$(arg transmission_hw_interface)"
      safety_limits="$(arg safety_limits)"
      safety_pos_margin="$(arg safety_pos_margin)"
      safety_k_position="$(arg safety_k_position)"
-     />
-  <!-- ros2 control include -->
-  <xacro:include filename="$(find ur_description)/urdf/ur.ros2_control.xacro" />
-  <!-- ros2 control instance -->
-  <xacro:ur_ros2_control
-    name="URPositionHardwareInterface" prefix="$(arg prefix)"
-    use_fake_hardware="$(arg use_fake_hardware)"
-    initial_positions="${load_yaml(initial_positions_file)}"
-    fake_sensor_commands="$(arg fake_sensor_commands)"
-    script_filename="$(arg script_filename)"
-    output_recipe_filename="$(arg output_recipe_filename)"
-    input_recipe_filename="$(arg input_recipe_filename)"
-    tf_prefix=""
-    hash_kinematics="${kinematics_hash}"
-    robot_ip="$(arg robot_ip)" />
+     use_fake_hardware="$(arg use_fake_hardware)"
+     fake_sensor_commands="$(arg fake_sensor_commands)"
+     initial_positions="${load_yaml(initial_positions_file)}"
+     robot_ip="$(arg robot_ip)"
+     script_filename="$(arg script_filename)"
+     output_recipe_filename="$(arg output_recipe_filename)"
+     input_recipe_filename="$(arg input_recipe_filename)"
+  />
 </robot>

--- a/ur_description/urdf/ur.urdf.xacro
+++ b/ur_description/urdf/ur.urdf.xacro
@@ -4,6 +4,7 @@
    <xacro:arg name="name" default="ur"/>
    <!-- import main macro -->
    <xacro:include filename="$(find ur_description)/urdf/ur_macro.xacro"/>
+   <xacro:include filename="$(find ur_description)/urdf/inc/ur_common.xacro" />
 
    <!-- parameters -->
    <xacro:arg name="prefix" default="" />
@@ -11,7 +12,6 @@
    <xacro:arg name="kinematics_params" default=""/>
    <xacro:arg name="physical_params" default=""/>
    <xacro:arg name="visual_params" default=""/>
-   <xacro:arg name="transmission_hw_interface" default=""/>
    <xacro:arg name="safety_limits" default="false"/>
    <xacro:arg name="safety_pos_margin" default="0.15"/>
    <xacro:arg name="safety_k_position" default="20"/>
@@ -23,18 +23,37 @@
    <xacro:arg name="initial_positions_file" default="$(find ur_description)/config/initial_positions.yaml"/>
    <xacro:property name="initial_positions_file" default="$(arg initial_positions_file)"/>
 
-   <!-- arm -->
-   <xacro:ur_robot
-     prefix="$(arg prefix)"
+   <xacro:arg name="robot_ip" default="0.0.0.0" />
+   <xacro:arg name="script_filename" default="$(find ur_robot_driver)/resources/ros_control.urscript"/>
+   <xacro:arg name="output_recipe_filename" default="$(find ur_robot_driver)/resources/rtde_input_recipe.txt"/>
+   <xacro:arg name="input_recipe_filename" default="$(find ur_robot_driver)/resources/rtde_input_recipe.txt"/>
+
+   <!-- Load configuration data from the provided .yaml files -->
+   <xacro:read_model_data
      joint_limits_parameters_file="$(arg joint_limit_params)"
      kinematics_parameters_file="$(arg kinematics_params)"
      physical_parameters_file="$(arg physical_params)"
-     visual_parameters_file="$(arg visual_params)"
-     transmission_hw_interface="$(arg transmission_hw_interface)"
+     visual_parameters_file="$(arg visual_params)"/>
+
+   <!-- arm -->
+   <xacro:ur_robot
+     prefix="$(arg prefix)"
      safety_limits="$(arg safety_limits)"
      safety_pos_margin="$(arg safety_pos_margin)"
      safety_k_position="$(arg safety_k_position)"
-     use_fake_hardware="$(arg use_fake_hardware)"
-     fake_sensor_commands="$(arg fake_sensor_commands)"
-     initial_positions="${load_yaml(initial_positions_file)}" />
+     />
+  <!-- ros2 control include -->
+  <xacro:include filename="$(find ur_description)/urdf/ur.ros2_control.xacro" />
+  <!-- ros2 control instance -->
+  <xacro:ur_ros2_control
+    name="URPositionHardwareInterface" prefix="$(arg prefix)"
+    use_fake_hardware="$(arg use_fake_hardware)"
+    initial_positions="${load_yaml(initial_positions_file)}"
+    fake_sensor_commands="$(arg fake_sensor_commands)"
+    script_filename="$(arg script_filename)"
+    output_recipe_filename="$(arg output_recipe_filename)"
+    input_recipe_filename="$(arg input_recipe_filename)"
+    tf_prefix=""
+    hash_kinematics="${kinematics_hash}"
+    robot_ip="$(arg robot_ip)" />
 </robot>

--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -50,54 +50,12 @@
      - Muhammad Asif Rana
   -->
 
-  <xacro:include filename="$(find ur_description)/urdf/inc/ur_transmissions.xacro" />
-  <xacro:include filename="$(find ur_description)/urdf/inc/ur_common.xacro" />
-
   <xacro:macro name="ur_robot" params="
     prefix
-    joint_limits_parameters_file
-    kinematics_parameters_file
-    physical_parameters_file
-    visual_parameters_file
-    transmission_hw_interface:=hardware_interface/PositionJointInterface
     safety_limits:=false
     safety_pos_margin:=0.15
     safety_k_position:=20
-    use_fake_hardware:=false
-    fake_sensor_commands:=false
-    initial_positions:=${dict(shoulder_pan_joint=0.0,shoulder_lift_joint=-1.57,elbow_joint=0.0,wrist_1_joint=-1.57,wrist_2_joint=0.0,wrist_3_joint=0.0)}">
-    <!-- Load configuration data from the provided .yaml files -->
-    <xacro:read_model_data
-      joint_limits_parameters_file="${joint_limits_parameters_file}"
-      kinematics_parameters_file="${kinematics_parameters_file}"
-      physical_parameters_file="${physical_parameters_file}"
-      visual_parameters_file="${visual_parameters_file}"/>
-
-    <!-- Data files required by the UR driver -->
-    <xacro:arg name="script_filename" default="$(find ur_robot_driver)/resources/ros_control.urscript"/>
-    <xacro:arg name="output_recipe_filename" default="$(find ur_robot_driver)/resources/rtde_output_recipe.txt"/>
-    <xacro:arg name="input_recipe_filename" default="$(find ur_robot_driver)/resources/rtde_input_recipe.txt"/>
-    <xacro:arg name="robot_ip" default="10.0.1.186"/>
-
-
-    <!-- ros2 control include -->
-    <xacro:include filename="$(find ur_description)/urdf/ur.ros2_control.xacro" />
-    <!-- ros2 control instance -->
-    <xacro:ur_ros2_control
-      name="URPositionHardwareInterface" prefix="${prefix}"
-      use_fake_hardware="$(arg use_fake_hardware)"
-      initial_positions="${initial_positions}"
-      fake_sensor_commands="$(arg fake_sensor_commands)"
-      script_filename="$(arg script_filename)"
-      output_recipe_filename="$(arg output_recipe_filename)"
-      input_recipe_filename="$(arg input_recipe_filename)"
-      tf_prefix=""
-      hash_kinematics="${kinematics_hash}"
-      robot_ip="$(arg robot_ip)" />
-
-    <!-- Add URDF transmission elements (for ros_control) -->
-    <!--<xacro:ur_arm_transmission prefix="${prefix}" hw_interface="${transmission_hw_interface}" />-->
-    <!-- Placeholder for ros2_control transmission which don't yet exist -->
+    ">
 
     <!-- links -  main serial chain -->
     <link name="${prefix}base_link"/>

--- a/ur_description/urdf/ur_macro.xacro
+++ b/ur_description/urdf/ur_macro.xacro
@@ -1,317 +1,53 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro">
-  <!--
-    Base UR robot series xacro macro.
+   <xacro:include filename="$(find ur_description)/urdf/ur_kinematics_macro.xacro"/>
+   <xacro:include filename="$(find ur_description)/urdf/inc/ur_common.xacro" />
 
-    NOTE this is NOT a URDF. It cannot directly be loaded by consumers
-    expecting a flattened '.urdf' file. See the top-level '.xacro' for that
-    (but note that .xacro must still be processed by the xacro command).
-
-    This file models the base kinematic chain of a UR robot, which then gets
-    parameterised by various configuration files to convert it into a UR3(e),
-    UR5(e), UR10(e) or UR16e.
-
-    NOTE the default kinematic parameters (i.e., link lengths, frame locations,
-    offsets, etc) do not correspond to any particular robot. They are defaults
-    only. There WILL be non-zero offsets between the Forward Kinematics results
-    in TF (i.e., robot_state_publisher) and the values reported by the Teach
-    Pendant.
-
-    For accurate (and robot-specific) transforms, the 'kinematics_parameters_file'
-    parameter MUST point to a .yaml file containing the appropriate values for
-    the targeted robot.
-
-    If using the UniversalRobots/Universal_Robots_ROS_Driver, follow the steps
-    described in the readme of that repository to extract the kinematic
-    calibration from the controller and generate the required .yaml file.
-
-    Main author of the migration to yaml configs Ludovic Delval.
-
-    Contributors to previous versions (in no particular order)
-
-     - Denis Stogl
-     - Lovro Ivanov
-     - Felix Messmer
-     - Kelsey Hawkins
-     - Wim Meeussen
-     - Shaun Edwards
-     - Nadia Hammoudeh Garcia
-     - Dave Hershberger
-     - G. vd. Hoorn
-     - Philip Long
-     - Dave Coleman
-     - Miguel Prada
-     - Mathias Luedtke
-     - Marcel Schnirring
-     - Felix von Drigalski
-     - Felix Exner
-     - Jimmy Da Silva
-     - Ajit Krisshna N L
-     - Muhammad Asif Rana
-  -->
-
-  <xacro:macro name="ur_robot" params="
+   <xacro:macro name="ur_robot" params="
     prefix
+    joint_limits_parameters_file
+    kinematics_parameters_file
+    physical_parameters_file
+    visual_parameters_file
+    transmission_hw_interface:=hardware_interface/PositionJointInterface
     safety_limits:=false
     safety_pos_margin:=0.15
     safety_k_position:=20
+    use_fake_hardware:=false
+    fake_sensor_commands:=false
+    robot_ip:=0.0.0.0
+    script_filename:=to_be_filled_by_ur_robot_driver
+    output_recipe_filename:=to_be_filled_by_ur_robot_driver
+    input_recipe_filename:=to_be_filled_by_ur_robot_driver
+    initial_positions:=${dict(shoulder_pan_joint=0.0,shoulder_lift_joint=-1.57,elbow_joint=0.0,wrist_1_joint=-1.57,wrist_2_joint=0.0,wrist_3_joint=0.0)}
     ">
 
-    <!-- links -  main serial chain -->
-    <link name="${prefix}base_link"/>
-    <link name="${prefix}base_link_inertia">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 ${pi}"/>
-        <geometry>
-          <mesh filename="${base_visual_mesh}"/>
-        </geometry>
-        <material name="${base_visual_material_name}">
-          <color rgba="${base_visual_material_color}"/>
-        </material>
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 ${pi}"/>
-        <geometry>
-          <mesh filename="${base_collision_mesh}"/>
-        </geometry>
-      </collision>
-      <xacro:cylinder_inertial radius="${base_inertia_radius}" length="${base_inertia_length}" mass="${base_mass}">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-      </xacro:cylinder_inertial>
-    </link>
-    <link name="${prefix}shoulder_link">
-      <visual>
-        <origin xyz="0 0 0" rpy="0 0 ${pi}"/>
-        <geometry>
-          <mesh filename="${shoulder_visual_mesh}"/>
-        </geometry>
-        <material name="${shoulder_visual_material_name}">
-          <color rgba="${shoulder_visual_material_color}"/>
-        </material>
-      </visual>
-      <collision>
-        <origin xyz="0 0 0" rpy="0 0 ${pi}"/>
-        <geometry>
-          <mesh filename="${shoulder_collision_mesh}"/>
-        </geometry>
-      </collision>
-      <xacro:cylinder_inertial radius="${shoulder_inertia_radius}" length="${shoulder_inertia_length}" mass="${shoulder_mass}">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-      </xacro:cylinder_inertial>
-    </link>
-    <link name="${prefix}upper_arm_link">
-      <visual>
-        <origin xyz="0 0 ${shoulder_offset}" rpy="${pi/2} 0 ${-pi/2}"/>
-        <geometry>
-          <mesh filename="${upper_arm_visual_mesh}"/>
-        </geometry>
-        <material name="${upper_arm_visual_material_name}">
-          <color rgba="${upper_arm_visual_material_color}"/>
-        </material>
-      </visual>
-      <collision>
-        <origin xyz="0 0 ${shoulder_offset}" rpy="${pi/2} 0 ${-pi/2}"/>
-        <geometry>
-          <mesh filename="${upper_arm_collision_mesh}"/>
-        </geometry>
-      </collision>
-      <xacro:cylinder_inertial radius="${upperarm_inertia_radius}" length="${upperarm_inertia_length}" mass="${upper_arm_mass}">
-        <origin xyz="${-0.5 * upperarm_inertia_length} 0.0 ${upper_arm_inertia_offset}" rpy="0 ${pi/2} 0" />
-      </xacro:cylinder_inertial>
-    </link>
-    <link name="${prefix}forearm_link">
-      <visual>
-        <origin xyz="0 0 ${elbow_offset}" rpy="${pi/2} 0 ${-pi/2}"/>
-        <geometry>
-          <mesh filename="${forearm_visual_mesh}"/>
-        </geometry>
-        <material name="${forearm_visual_material_name}">
-          <color rgba="${forearm_visual_material_color}"/>
-        </material>
-      </visual>
-      <collision>
-        <origin xyz="0 0 ${elbow_offset}" rpy="${pi/2} 0 ${-pi/2}"/>
-        <geometry>
-          <mesh filename="${forearm_collision_mesh}"/>
-        </geometry>
-      </collision>
-      <xacro:cylinder_inertial radius="${forearm_inertia_radius}" length="${forearm_inertia_length}"  mass="${forearm_mass}">
-        <origin xyz="${-0.5 * forearm_inertia_length} 0.0 ${elbow_offset}" rpy="0 ${pi/2} 0" />
-      </xacro:cylinder_inertial>
-    </link>
-    <link name="${prefix}wrist_1_link">
-      <visual>
-        <origin xyz="0 0 ${wrist_1_visual_offset}" rpy="${pi/2} 0 0"/>
-        <geometry>
-          <mesh filename="${wrist_1_visual_mesh}"/>
-        </geometry>
-        <material name="${wrist_1_visual_material_name}">
-          <color rgba="${wrist_1_visual_material_color}"/>
-        </material>
-      </visual>
-      <collision>
-        <origin xyz="0 0 ${wrist_1_visual_offset}" rpy="${pi/2} 0 0"/>
-        <geometry>
-          <mesh filename="${wrist_1_collision_mesh}"/>
-        </geometry>
-      </collision>
-      <xacro:cylinder_inertial radius="${wrist_1_inertia_radius}" length="${wrist_1_inertia_length}"  mass="${wrist_1_mass}">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-      </xacro:cylinder_inertial>
-    </link>
-    <link name="${prefix}wrist_2_link">
-      <visual>
-        <origin xyz="0 0 ${wrist_2_visual_offset}" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="${wrist_2_visual_mesh}"/>
-        </geometry>
-        <material name="${wrist_2_visual_material_name}">
-          <color rgba="${wrist_2_visual_material_color}"/>
-        </material>
-      </visual>
-      <collision>
-        <origin xyz="0 0 ${wrist_2_visual_offset}" rpy="0 0 0"/>
-        <geometry>
-          <mesh filename="${wrist_2_collision_mesh}"/>
-        </geometry>
-      </collision>
-      <xacro:cylinder_inertial radius="${wrist_2_inertia_radius}" length="${wrist_2_inertia_length}"  mass="${wrist_2_mass}">
-        <origin xyz="0 0 0" rpy="0 0 0" />
-      </xacro:cylinder_inertial>
-    </link>
-    <link name="${prefix}wrist_3_link">
-      <visual>
-        <origin xyz="0 0 ${wrist_3_visual_offset}" rpy="${pi/2} 0 0"/>
-        <geometry>
-          <mesh filename="${wrist_3_visual_mesh}"/>
-        </geometry>
-        <material name="${wrist_3_visual_material_name}">
-          <color rgba="${wrist_3_visual_material_color}"/>
-        </material>
-      </visual>
-      <collision>
-        <origin xyz="0 0 ${wrist_3_visual_offset}" rpy="${pi/2} 0 0"/>
-        <geometry>
-          <mesh filename="${wrist_3_collision_mesh}"/>
-        </geometry>
-      </collision>
-      <xacro:cylinder_inertial radius="${wrist_3_inertia_radius}" length="${wrist_3_inertia_length}"  mass="${wrist_3_mass}">
-        <origin xyz="0.0 0.0 ${-0.5 * wrist_3_inertia_length}" rpy="0 0 0" />
-      </xacro:cylinder_inertial>
-    </link>
+     <xacro:read_model_data
+       joint_limits_parameters_file="${joint_limits_parameters_file}"
+       kinematics_parameters_file="${kinematics_parameters_file}"
+       physical_parameters_file="${physical_parameters_file}"
+       visual_parameters_file="${visual_parameters_file}"/>
 
-    <!-- joints - main serial chain -->
-    <joint name="${prefix}base_link-base_link_inertia" type="fixed">
-      <parent link="${prefix}base_link" />
-      <child link="${prefix}base_link_inertia" />
-      <!-- 'base_link' is REP-103 aligned (so X+ forward), while the internal
-           frames of the robot/controller have X+ pointing backwards.
-           Use the joint between 'base_link' and 'base_link_inertia' (a dummy
-           link/frame) to introduce the necessary rotation over Z (of pi rad).
-      -->
-      <origin xyz="0 0 0" rpy="0 0 ${pi}" />
-    </joint>
-    <joint name="${prefix}shoulder_pan_joint" type="revolute">
-      <parent link="${prefix}base_link_inertia" />
-      <child link="${prefix}shoulder_link" />
-      <origin xyz="${shoulder_x} ${shoulder_y} ${shoulder_z}" rpy="${shoulder_roll} ${shoulder_pitch} ${shoulder_yaw}" />
-      <axis xyz="0 0 1" />
-      <limit lower="${shoulder_pan_lower_limit}" upper="${shoulder_pan_upper_limit}"
-        effort="${shoulder_pan_effort_limit}" velocity="${shoulder_pan_velocity_limit}"/>
-      <xacro:if value="${safety_limits}">
-         <safety_controller soft_lower_limit="${shoulder_pan_lower_limit + safety_pos_margin}" soft_upper_limit="${shoulder_pan_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
-      </xacro:if>
-      <dynamics damping="0" friction="0"/>
-    </joint>
-    <joint name="${prefix}shoulder_lift_joint" type="revolute">
-      <parent link="${prefix}shoulder_link" />
-      <child link="${prefix}upper_arm_link" />
-      <origin xyz="${upper_arm_x} ${upper_arm_y} ${upper_arm_z}" rpy="${upper_arm_roll} ${upper_arm_pitch} ${upper_arm_yaw}" />
-      <axis xyz="0 0 1" />
-      <limit lower="${shoulder_lift_lower_limit}" upper="${shoulder_lift_upper_limit}"
-        effort="${shoulder_lift_effort_limit}" velocity="${shoulder_lift_velocity_limit}"/>
-      <xacro:if value="${safety_limits}">
-         <safety_controller soft_lower_limit="${shoulder_lift_lower_limit + safety_pos_margin}" soft_upper_limit="${shoulder_lift_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
-      </xacro:if>
-      <dynamics damping="0" friction="0"/>
-    </joint>
-    <joint name="${prefix}elbow_joint" type="revolute">
-      <parent link="${prefix}upper_arm_link" />
-      <child link="${prefix}forearm_link" />
-      <origin xyz="${forearm_x} ${forearm_y} ${forearm_z}" rpy="${forearm_roll} ${forearm_pitch} ${forearm_yaw}" />
-      <axis xyz="0 0 1" />
-      <limit lower="${elbow_joint_lower_limit}" upper="${elbow_joint_upper_limit}"
-        effort="${elbow_joint_effort_limit}" velocity="${elbow_joint_velocity_limit}"/>
-      <xacro:if value="${safety_limits}">
-         <safety_controller soft_lower_limit="${elbow_joint_lower_limit + safety_pos_margin}" soft_upper_limit="${elbow_joint_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
-      </xacro:if>
-      <dynamics damping="0" friction="0"/>
-    </joint>
-    <joint name="${prefix}wrist_1_joint" type="revolute">
-      <parent link="${prefix}forearm_link" />
-      <child link="${prefix}wrist_1_link" />
-      <origin xyz="${wrist_1_x} ${wrist_1_y} ${wrist_1_z}" rpy="${wrist_1_roll} ${wrist_1_pitch} ${wrist_1_yaw}" />
-      <axis xyz="0 0 1" />
-      <limit lower="${wrist_1_lower_limit}" upper="${wrist_1_upper_limit}"
-        effort="${wrist_1_effort_limit}" velocity="${wrist_1_velocity_limit}"/>
-      <xacro:if value="${safety_limits}">
-         <safety_controller soft_lower_limit="${wrist_1_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_1_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
-      </xacro:if>
-      <dynamics damping="0" friction="0"/>
-    </joint>
-    <joint name="${prefix}wrist_2_joint" type="revolute">
-      <parent link="${prefix}wrist_1_link" />
-      <child link="${prefix}wrist_2_link" />
-      <origin xyz="${wrist_2_x} ${wrist_2_y} ${wrist_2_z}" rpy="${wrist_2_roll} ${wrist_2_pitch} ${wrist_2_yaw}" />
-      <axis xyz="0 0 1" />
-      <limit lower="${wrist_2_lower_limit}" upper="${wrist_2_upper_limit}"
-             effort="${wrist_2_effort_limit}" velocity="${wrist_2_velocity_limit}"/>
-      <xacro:if value="${safety_limits}">
-         <safety_controller soft_lower_limit="${wrist_2_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_2_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
-      </xacro:if>
-      <dynamics damping="0" friction="0"/>
-    </joint>
-    <joint name="${prefix}wrist_3_joint" type="revolute">
-      <parent link="${prefix}wrist_2_link" />
-      <child link="${prefix}wrist_3_link" />
-      <origin xyz="${wrist_3_x} ${wrist_3_y} ${wrist_3_z}" rpy="${wrist_3_roll} ${wrist_3_pitch} ${wrist_3_yaw}" />
-      <axis xyz="0 0 1" />
-      <limit lower="${wrist_3_lower_limit}" upper="${wrist_3_upper_limit}"
-             effort="${wrist_3_effort_limit}" velocity="${wrist_3_velocity_limit}"/>
-      <xacro:if value="${safety_limits}">
-         <safety_controller soft_lower_limit="${wrist_3_lower_limit + safety_pos_margin}" soft_upper_limit="${wrist_3_upper_limit - safety_pos_margin}" k_position="${safety_k_position}" k_velocity="0.0"/>
-      </xacro:if>
-      <dynamics damping="0" friction="0"/>
-    </joint>
-
-    <!-- ROS-Industrial 'base' frame - base_link to UR 'Base' Coordinates transform -->
-    <link name="${prefix}base"/>
-    <joint name="${prefix}base_link-base_fixed_joint" type="fixed">
-      <!-- Note the rotation over Z of pi radians - as base_link is REP-103
-           aligned (i.e., has X+ forward, Y+ left and Z+ up), this is needed
-           to correctly align 'base' with the 'Base' coordinate system of
-           the UR controller.
-      -->
-      <origin xyz="0 0 0" rpy="0 0 ${pi}"/>
-      <parent link="${prefix}base_link"/>
-      <child link="${prefix}base"/>
-    </joint>
-
-    <!-- ROS-Industrial 'flange' frame - attachment point for EEF models -->
-    <link name="${prefix}flange" />
-    <joint name="${prefix}wrist_3-flange" type="fixed">
-      <parent link="${prefix}wrist_3_link" />
-      <child link="${prefix}flange" />
-      <origin xyz="0 0 0" rpy="0 ${-pi/2.0} ${-pi/2.0}" />
-    </joint>
-
-    <!-- ROS-Industrial 'tool0' frame - all-zeros tool frame -->
-    <link name="${prefix}tool0"/>
-    <joint name="${prefix}flange-tool0" type="fixed">
-      <!-- default toolframe - X+ left, Y+ up, Z+ front -->
-      <origin xyz="0 0 0" rpy="${pi/2.0} 0 ${pi/2.0}"/>
-      <parent link="${prefix}flange"/>
-      <child link="${prefix}tool0"/>
-    </joint>
-  </xacro:macro>
+     <!-- arm -->
+     <xacro:ur_robot_kinematics
+       prefix="${prefix}"
+       safety_limits="${safety_limits}"
+       safety_pos_margin="${safety_pos_margin}"
+       safety_k_position="${safety_k_position}"
+       />
+    <!-- ros2 control include -->
+    <xacro:include filename="$(find ur_description)/urdf/ur.ros2_control.xacro" />
+    <!-- ros2 control instance -->
+    <xacro:ur_ros2_control
+      name="URPositionHardwareInterface" prefix="${prefix}"
+      use_fake_hardware="${use_fake_hardware}"
+      initial_positions="${load_yaml(initial_positions_file)}"
+      fake_sensor_commands="${fake_sensor_commands}"
+      script_filename="${script_filename}"
+      output_recipe_filename="${output_recipe_filename}"
+      input_recipe_filename="${input_recipe_filename}"
+      tf_prefix=""
+      hash_kinematics="${kinematics_hash}"
+      robot_ip="${robot_ip}" />
+   </xacro:macro>
 </robot>


### PR DESCRIPTION
This PR aims at taking a step further in refactoring the description, as its current state is rather suboptimal. With this PR I strive for
 - Having a separated visual description from the control description
 - Having a single macro that users can include

I'll start this PR as a draft as I'd like to incorporate feedback from the community on how to structure things. In the long run I'd like to apply this restructuring also to the Humble and Rolling versions.