### PR TITLE
add kinematics_interface and control_msgs to semi-src workspace

### DIFF
--- a/Universal_Robots_ROS2_Driver.humble.repos
+++ b/Universal_Robots_ROS2_Driver.humble.repos
@@ -15,3 +15,11 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_controllers
     version: master
+  kinematics_interface:
+    type: git
+    url: https://github.com/ros-controls/kinematics_interface.git
+    version: master
+  control_msgs:
+    type: git
+    url: https://github.com/ros-controls/control_msgs.git
+    version: humble

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -15,3 +15,11 @@ repositories:
     type: git
     url: https://github.com/ros-controls/ros2_controllers
     version: master
+  kinematics_interface:
+    type: git
+    url: https://github.com/ros-controls/kinematics_interface.git
+    version: master
+  control_msgs:
+    type: git
+    url: https://github.com/ros-controls/control_msgs.git
+    version: humble


### PR DESCRIPTION
With the new admittance_controller this is necessary, since we have ros2_control and ros2_controllers already in the repos file.

Adding the admittance_controller to the driver would be another step (see #511). This PR just keeps our CI stable.