### PR TITLE
Quickfix humble release

### DIFF
--- a/Universal_Robots_ROS2_Driver.humble.repos
+++ b/Universal_Robots_ROS2_Driver.humble.repos
@@ -14,7 +14,7 @@ repositories:
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers
-    version: master
+    version: 2.12.0
   kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -106,7 +106,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
   }
 
   JointTrajectoryPoint state_current, state_desired, state_error;
-  const auto joint_num = params_.joints.size();
+  const auto joint_num = joint_names_.size();
   resize_joint_trajectory_point(state_current, joint_num);
 
   // current state update
@@ -206,7 +206,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
         // send feedback
         auto feedback = std::make_shared<FollowJTrajAction::Feedback>();
         feedback->header.stamp = time;
-        feedback->joint_names = params_.joints;
+        feedback->joint_names = joint_names_;
 
         feedback->actual = state_current;
         feedback->desired = state_desired;


### PR DESCRIPTION
Since the humble release is currently broken (see #522), this suggests reverting back to the ros2_controllers 2.12.0 API.

Since we wanted to branch out for Humble at some point, anyway, this seems to be a good time to do that.