### PR TITLE
Do not build ros2_controllers from upstream workspace anymore

### DIFF
--- a/Universal_Robots_ROS2_Driver-not-released.humble.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.humble.repos
@@ -4,7 +4,3 @@
 # Once Upstream packages are released and synced to the target distributions in the required
 # version, the entry in this file shall be removed again.
 repositories:
-  ros2_controllers:
-    type: git
-    url: https://github.com/ros-controls/ros2_controllers.git
-    version: 2.13.0

--- a/Universal_Robots_ROS2_Driver-not-released.rolling.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.rolling.repos
@@ -4,7 +4,3 @@
 # Once Upstream packages are released and synced to the target distributions in the required
 # version, the entry in this file shall be removed again.
 repositories:
-  ros2_controllers:
-    type: git
-    url: https://github.com/ros-controls/ros2_controllers.git
-    version: 2.13.0


### PR DESCRIPTION
With the latest ros2_controllers release this is no longer required.

Rolling has been released and synchronized, Humble is currently held  for release with the fixing ros2_controllers version [waiting](https://github.com/ros/rosdistro/pull/35356) in line, hence the failing builds, hence the draft status.  