### PR TITLE
Document cloning the correct branch for humble

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Deprecation: The `ur_bringup` package is deprecated and will be removed from Iro
 4. Pull relevant packages, install dependencies, compile, and source the workspace by using:
    ```
    cd $COLCON_WS
-   git clone https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git src/Universal_Robots_ROS2_Driver
+   git clone -b ${ROS_DISTRO} https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git src/Universal_Robots_ROS2_Driver
    vcs import src --skip-existing --input src/Universal_Robots_ROS2_Driver/Universal_Robots_ROS2_Driver-not-released.${ROS_DISTRO}.repos
    rosdep update
    rosdep install --ignore-src --from-paths src -y -r


### PR DESCRIPTION
This seems to have been forgotten when branching out humble.