### PR TITLE
Update Universal_Robots_ROS2_Driver.humble.repos to pin ros2_controllers on humble branch

### DIFF
--- a/Universal_Robots_ROS2_Driver.humble.repos
+++ b/Universal_Robots_ROS2_Driver.humble.repos
@@ -14,7 +14,7 @@ repositories:
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers
-    version: master
+    version: humble
   kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git


### PR DESCRIPTION
`/root/src/ur_driver/ros2_controllers/diff_drive_controller/include/diff_drive_controller/odometry.hpp:28:10: fatal error: rcpputils/rolling_mean_accumulator.hpp: No such file or directory
   28 | #include "rcpputils/rolling_mean_accumulator.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [CMakeFiles/diff_drive_controller.dir/build.make:90: CMakeFiles/diff_drive_controller.dir/src/odometry.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
In file included from /root/src/ur_driver/ros2_controllers/diff_drive_controller/include/diff_drive_controller/diff_drive_controller.hpp:30,
                 from /root/src/ur_driver/ros2_controllers/diff_drive_controller/src/diff_drive_controller.cpp:25:
/root/src/ur_driver/ros2_controllers/diff_drive_controller/include/diff_drive_controller/odometry.hpp:28:10: fatal error: rcpputils/rolling_mean_accumulator.hpp: No such file or directory
   28 | #include "rcpputils/rolling_mean_accumulator.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.`

Steps to reproduce (ran in ros:humble-ros-base docker image)
`git clone https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git -b humble src/ur_driver`
`vcs import src/ur_driver --skip-existing --input src/ur_driver/Universal_Robots_ROS2_Driver.${ROS_DISTRO}.repos`
`rosdep install -y --from-paths src/ur_driver --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false`
`colcon build`
