### PR TITLE
Added method to setRealtimePriority of the controller manager thread

### DIFF
--- a/ur_robot_driver/src/ur_ros2_control_node.cpp
+++ b/ur_robot_driver/src/ur_ros2_control_node.cpp
@@ -55,8 +55,21 @@
 
 #include <pthread.h>
 
+/**
+ * @brief set the priority of the current thread to the passed priority and tie the thread to a certain core
+ * @param priority - the desired priority between [0,99] with 99 beeing the highest priority
+ * @param cpu_core - the number of the core you want to tie the thread to (0,your amount of cores]. You are not allowed to tie the thread to core 0 as core 0 is often used for kernel tasks!
+ * 
+ * @note In order for this method to work without root permissions you need to add the following lines to /etc/security/limits.conf (without the ticks "")
+ *    "* soft rtprio 99"
+ *    "* hard rtprio 99"
+ * You need to logout and log back into your session in order for these changes to be applied
+
+*/
 bool setRealtimePriority(int priority, int cpu_core){
   //Taken from https://github.com/leggedrobotics/ethercat_sdk_master/blob/6b420bc1785cf26324aab62c79347b2a6e07924d/src/ethercat_sdk_master/EthercatMaster.cpp#L121
+  
+
   bool success = true;
   //Handle to our thread
   pthread_t thread = pthread_self();


### PR DESCRIPTION
This PR adds a method to increase the priority of the controller manager thread and tie the thread to a core 1.

This method of achieving near realtime performance  for systems without  the linux RT patches has been successfully tried and is in use in the RSL ethercat stack.

The original code for this method can be found in: https://github.com/leggedrobotics/ethercat_sdk_master/blob/master/src/ethercat_sdk_master/EthercatMaster.cpp

In order for this to work without sudo you will need add the following lines to `etc/security/limits.conf`

```
* soft rtprio 99
* hard rtprio 99
```

I also used the same code succesfully for a setup with two UR16e controlled from the same PC (without ros2control). 