### PR TITLE
Adding maximum retry counter in gpio controller (Multiarm part 3)

### DIFF
--- a/ur_controllers/CMakeLists.txt
+++ b/ur_controllers/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 find_package(ur_dashboard_msgs REQUIRED)
 find_package(ur_msgs REQUIRED)
+find_package(generate_parameter_library REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   angles
@@ -32,19 +33,36 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   std_srvs
   ur_dashboard_msgs
   ur_msgs
+  generate_parameter_library
 )
 
 include_directories(include)
 
+
+generate_parameter_library(
+  gpio_controller_parameters
+  src/gpio_controller_parameters.yaml
+)
+
+generate_parameter_library(
+  speed_scaling_state_broadcaster_parameters
+  src/speed_scaling_state_broadcaster_parameters.yaml
+)
+
+
+
 add_library(${PROJECT_NAME} SHARED
-  src/scaled_joint_trajectory_controller.cpp
+  #src/scaled_joint_trajectory_controller.cpp
   src/speed_scaling_state_broadcaster.cpp
   src/gpio_controller.cpp)
 
 target_include_directories(${PROJECT_NAME} PRIVATE
   include
 )
-
+target_link_libraries(${PROJECT_NAME}
+  gpio_controller_parameters
+  speed_scaling_state_broadcaster_parameters
+)
 ament_target_dependencies(${PROJECT_NAME}
   ${THIS_PACKAGE_INCLUDE_DEPENDS}
 )

--- a/ur_controllers/include/ur_controllers/gpio_controller.hpp
+++ b/ur_controllers/include/ur_controllers/gpio_controller.hpp
@@ -56,6 +56,7 @@
 #include "rclcpp/time.hpp"
 #include "rclcpp/duration.hpp"
 #include "std_msgs/msg/bool.hpp"
+#include "gpio_controller_parameters.hpp"
 
 namespace ur_controllers
 {
@@ -168,6 +169,10 @@ protected:
   ur_dashboard_msgs::msg::RobotMode robot_mode_msg_;
   ur_dashboard_msgs::msg::SafetyMode safety_mode_msg_;
   std_msgs::msg::Bool program_running_msg_;
+
+  // Parameters from ROS for gpio_controller
+  std::shared_ptr<gpio_controller::ParamListener> param_listener_;
+  gpio_controller::Params params_;
 
   static constexpr double ASYNC_WAITING = 2.0;
   // TODO(anyone) publishers to add: tcp_pose_pub_

--- a/ur_controllers/include/ur_controllers/gpio_controller.hpp
+++ b/ur_controllers/include/ur_controllers/gpio_controller.hpp
@@ -117,6 +117,8 @@ public:
 
   CallbackReturn on_init() override;
 
+  
+
 private:
   bool setIO(ur_msgs::srv::SetIO::Request::SharedPtr req, ur_msgs::srv::SetIO::Response::SharedPtr resp);
 
@@ -140,6 +142,11 @@ private:
   void publishSafetyMode();
 
   void publishProgramRunning();
+
+  /**
+   * @brief wait until a command interface isn't in state ASYNC_WAITING anymore or until the parameter maximum_retries have been reached
+  */
+  bool waitForAsyncCommand(std::function<double(void)> get_value);
 
 protected:
   void initMsgs();

--- a/ur_controllers/include/ur_controllers/speed_scaling_state_broadcaster.hpp
+++ b/ur_controllers/include/ur_controllers/speed_scaling_state_broadcaster.hpp
@@ -48,6 +48,7 @@
 #include "rclcpp/time.hpp"
 #include "rclcpp/duration.hpp"
 #include "std_msgs/msg/float64.hpp"
+#include "speed_scaling_state_broadcaster_parameters.hpp"
 
 namespace ur_controllers
 {
@@ -76,6 +77,11 @@ protected:
 
   std::shared_ptr<rclcpp::Publisher<std_msgs::msg::Float64>> speed_scaling_state_publisher_;
   std_msgs::msg::Float64 speed_scaling_state_msg_;
+
+
+  // Parameters from ROS for SpeedScalingStateBroadcaster
+  std::shared_ptr<speed_scaling_state_broadcaster::ParamListener> param_listener_;
+  speed_scaling_state_broadcaster::Params params_;
 };
 }  // namespace ur_controllers
 #endif  // UR_CONTROLLERS__SPEED_SCALING_STATE_BROADCASTER_HPP_

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -43,7 +43,21 @@ namespace ur_controllers
 {
 controller_interface::CallbackReturn GPIOController::on_init()
 {
-  initMsgs();
+  try
+  {
+    initMsgs();
+    // Create the parameter listener and get the parameters
+    param_listener_ = std::make_shared<gpio_controller::ParamListener>(get_node());
+    params_ = param_listener_->get_params();
+
+   
+  }
+  catch (const std::exception & e)
+  {
+    fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
+    return CallbackReturn::ERROR;
+  }
+
 
   return controller_interface::CallbackReturn::SUCCESS;
 }
@@ -52,37 +66,37 @@ controller_interface::InterfaceConfiguration GPIOController::command_interface_c
 {
   controller_interface::InterfaceConfiguration config;
   config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  RCLCPP_INFO(get_node()->get_logger(), "Configure UR gpio controller with prefix: %s", params_.prefix.c_str());
 
+  const std::string prefix = params_.prefix;
+  RCLCPP_INFO(get_node()->get_logger(), "Configure UR gpio controller with prefix: %s", prefix.c_str());
+
+  
   for (size_t i = 0; i < 18; ++i) {
-    config.names.emplace_back("gpio/standard_digital_output_cmd_" + std::to_string(i));
+    config.names.emplace_back(prefix + "gpio/standard_digital_output_cmd_" + std::to_string(i));
   }
 
   for (size_t i = 0; i < 2; ++i) {
-    config.names.emplace_back("gpio/standard_analog_output_cmd_" + std::to_string(i));
+    config.names.emplace_back(prefix + "gpio/standard_analog_output_cmd_" + std::to_string(i));
   }
+  config.names.emplace_back(prefix + "gpio/tool_voltage_cmd");
 
-  config.names.emplace_back("gpio/tool_voltage_cmd");
+  config.names.emplace_back(prefix + "gpio/io_async_success");
 
-  config.names.emplace_back("gpio/io_async_success");
+  config.names.emplace_back(prefix + "speed_scaling/target_speed_fraction_cmd");
 
-  config.names.emplace_back("speed_scaling/target_speed_fraction_cmd");
+  config.names.emplace_back(prefix + "speed_scaling/target_speed_fraction_async_success");
 
-  config.names.emplace_back("speed_scaling/target_speed_fraction_async_success");
+  config.names.emplace_back(prefix + "resend_robot_program/resend_robot_program_cmd");
 
-  config.names.emplace_back("resend_robot_program/resend_robot_program_cmd");
-
-  config.names.emplace_back("resend_robot_program/resend_robot_program_async_success");
+  config.names.emplace_back(prefix + "resend_robot_program/resend_robot_program_async_success");
 
   // payload stuff
-  config.names.emplace_back("payload/mass");
-  config.names.emplace_back("payload/cog.x");
-  config.names.emplace_back("payload/cog.y");
-  config.names.emplace_back("payload/cog.z");
-  config.names.emplace_back("payload/payload_async_success");
-
-  // zero ft sensor
-  config.names.emplace_back("zero_ftsensor/zero_ftsensor_cmd");
-  config.names.emplace_back("zero_ftsensor/zero_ftsensor_async_success");
+  config.names.emplace_back(prefix + "payload/mass");
+  config.names.emplace_back(prefix + "payload/cog.x");
+  config.names.emplace_back(prefix + "payload/cog.y");
+  config.names.emplace_back(prefix + "payload/cog.z");
+  config.names.emplace_back(prefix + "payload/payload_async_success");
 
   return config;
 }
@@ -92,56 +106,59 @@ controller_interface::InterfaceConfiguration ur_controllers::GPIOController::sta
   controller_interface::InterfaceConfiguration config;
   config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
 
+  const std::string prefix = params_.prefix;
+   
+  
   // digital io
   for (size_t i = 0; i < 18; ++i) {
-    config.names.emplace_back("gpio/digital_output_" + std::to_string(i));
+    config.names.emplace_back(prefix + "gpio/digital_output_" + std::to_string(i));
   }
 
   for (size_t i = 0; i < 18; ++i) {
-    config.names.emplace_back("gpio/digital_input_" + std::to_string(i));
+    config.names.emplace_back(prefix + "gpio/digital_input_" + std::to_string(i));
   }
 
   // analog io
   for (size_t i = 0; i < 2; ++i) {
-    config.names.emplace_back("gpio/standard_analog_output_" + std::to_string(i));
+    config.names.emplace_back(prefix + "gpio/standard_analog_output_" + std::to_string(i));
   }
 
   for (size_t i = 0; i < 2; ++i) {
-    config.names.emplace_back("gpio/standard_analog_input_" + std::to_string(i));
+    config.names.emplace_back(prefix + "gpio/standard_analog_input_" + std::to_string(i));
   }
 
   for (size_t i = 0; i < 4; ++i) {
-    config.names.emplace_back("gpio/analog_io_type_" + std::to_string(i));
+    config.names.emplace_back(prefix + "gpio/analog_io_type_" + std::to_string(i));
   }
 
   // tool
-  config.names.emplace_back("gpio/tool_mode");
-  config.names.emplace_back("gpio/tool_output_voltage");
-  config.names.emplace_back("gpio/tool_output_current");
-  config.names.emplace_back("gpio/tool_temperature");
+  config.names.emplace_back(prefix + "gpio/tool_mode");
+  config.names.emplace_back(prefix + "gpio/tool_output_voltage");
+  config.names.emplace_back(prefix + "gpio/tool_output_current");
+  config.names.emplace_back(prefix + "gpio/tool_temperature");
 
   for (size_t i = 0; i < 2; ++i) {
-    config.names.emplace_back("gpio/tool_analog_input_" + std::to_string(i));
+    config.names.emplace_back(prefix + "gpio/tool_analog_input_" + std::to_string(i));
   }
   for (size_t i = 0; i < 2; ++i) {
-    config.names.emplace_back("gpio/tool_analog_input_type_" + std::to_string(i));
+    config.names.emplace_back(prefix + "gpio/tool_analog_input_type_" + std::to_string(i));
   }
 
   // robot
-  config.names.emplace_back("gpio/robot_mode");
+  config.names.emplace_back(prefix + "gpio/robot_mode");
   for (size_t i = 0; i < 4; ++i) {
-    config.names.emplace_back("gpio/robot_status_bit_" + std::to_string(i));
+    config.names.emplace_back(prefix + "gpio/robot_status_bit_" + std::to_string(i));
   }
 
   // safety
-  config.names.emplace_back("gpio/safety_mode");
+  config.names.emplace_back(prefix + "gpio/safety_mode");
   for (size_t i = 0; i < 11; ++i) {
-    config.names.emplace_back("gpio/safety_status_bit_" + std::to_string(i));
+    config.names.emplace_back(prefix + "gpio/safety_status_bit_" + std::to_string(i));
   }
-  config.names.emplace_back("system_interface/initialized");
+  config.names.emplace_back(prefix + "system_interface/initialized");
 
   // program running
-  config.names.emplace_back("gpio/program_running");
+  config.names.emplace_back(prefix + "gpio/program_running");
 
   return config;
 }
@@ -160,6 +177,20 @@ controller_interface::return_type ur_controllers::GPIOController::update(const r
 controller_interface::CallbackReturn
 ur_controllers::GPIOController::on_configure(const rclcpp_lifecycle::State& /*previous_state*/)
 {
+  const auto logger = get_node()->get_logger();
+
+  if (!param_listener_)
+  {
+    RCLCPP_ERROR(get_node()->get_logger(), "Error encountered during init");
+    return controller_interface::CallbackReturn::ERROR;
+  }
+
+  // update the dynamic map parameters
+  param_listener_->refresh_dynamic_parameters();
+
+  // get parameters from the listener in case they were updated
+  params_ = param_listener_->get_params();
+
   return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
@@ -250,39 +281,45 @@ ur_controllers::GPIOController::on_activate(const rclcpp_lifecycle::State& /*pre
   }
 
   try {
+    std::string prefix = params_.prefix;
+    //If no prefix was given we enforce the old behaviour of prefixing the topics with the controller name
+    if(prefix.empty()) {
+      prefix = "~/";
+    }
+    RCLCPP_INFO(get_node()->get_logger(), "%s", prefix.c_str());
     // register publisher
-    io_pub_ = get_node()->create_publisher<ur_msgs::msg::IOStates>("~/io_states", rclcpp::SystemDefaultsQoS());
+    io_pub_ = get_node()->create_publisher<ur_msgs::msg::IOStates>(prefix+"io_states", rclcpp::SystemDefaultsQoS());
 
     tool_data_pub_ =
-        get_node()->create_publisher<ur_msgs::msg::ToolDataMsg>("~/tool_data", rclcpp::SystemDefaultsQoS());
+        get_node()->create_publisher<ur_msgs::msg::ToolDataMsg>(prefix+"tool_data", rclcpp::SystemDefaultsQoS());
 
     robot_mode_pub_ =
-        get_node()->create_publisher<ur_dashboard_msgs::msg::RobotMode>("~/robot_mode", rclcpp::SystemDefaultsQoS());
+        get_node()->create_publisher<ur_dashboard_msgs::msg::RobotMode>(prefix+"robot_mode", rclcpp::SystemDefaultsQoS());
 
     safety_mode_pub_ =
-        get_node()->create_publisher<ur_dashboard_msgs::msg::SafetyMode>("~/safety_mode", rclcpp::SystemDefaultsQoS());
+        get_node()->create_publisher<ur_dashboard_msgs::msg::SafetyMode>(prefix+"safety_mode", rclcpp::SystemDefaultsQoS());
 
     auto program_state_pub_qos = rclcpp::SystemDefaultsQoS();
     program_state_pub_qos.transient_local();
     program_state_pub_ =
-        get_node()->create_publisher<std_msgs::msg::Bool>("~/robot_program_running", program_state_pub_qos);
+        get_node()->create_publisher<std_msgs::msg::Bool>(prefix+"robot_program_running", program_state_pub_qos);
 
     set_io_srv_ = get_node()->create_service<ur_msgs::srv::SetIO>(
-        "~/set_io", std::bind(&GPIOController::setIO, this, std::placeholders::_1, std::placeholders::_2));
+        prefix+"set_io", std::bind(&GPIOController::setIO, this, std::placeholders::_1, std::placeholders::_2));
 
     set_speed_slider_srv_ = get_node()->create_service<ur_msgs::srv::SetSpeedSliderFraction>(
-        "~/set_speed_slider",
+        prefix+"set_speed_slider",
         std::bind(&GPIOController::setSpeedSlider, this, std::placeholders::_1, std::placeholders::_2));
 
     resend_robot_program_srv_ = get_node()->create_service<std_srvs::srv::Trigger>(
-        "~/resend_robot_program",
+        prefix+"resend_robot_program",
         std::bind(&GPIOController::resendRobotProgram, this, std::placeholders::_1, std::placeholders::_2));
 
     set_payload_srv_ = get_node()->create_service<ur_msgs::srv::SetPayload>(
-        "~/set_payload", std::bind(&GPIOController::setPayload, this, std::placeholders::_1, std::placeholders::_2));
+        prefix+"set_payload", std::bind(&GPIOController::setPayload, this, std::placeholders::_1, std::placeholders::_2));
 
     tare_sensor_srv_ = get_node()->create_service<std_srvs::srv::Trigger>(
-        "~/zero_ftsensor",
+        prefix+"zero_ftsensor",
         std::bind(&GPIOController::zeroFTSensor, this, std::placeholders::_1, std::placeholders::_2));
   } catch (...) {
     return LifecycleNodeInterface::CallbackReturn::ERROR;

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -98,6 +98,10 @@ controller_interface::InterfaceConfiguration GPIOController::command_interface_c
   config.names.emplace_back(prefix + "payload/cog.z");
   config.names.emplace_back(prefix + "payload/payload_async_success");
 
+  //Force torque sensor
+  config.names.emplace_back(prefix+"zero_ftsensor/zero_ftsensor_cmd");
+  config.names.emplace_back(prefix+"zero_ftsensor/zero_ftsensor_async_success");
+
   return config;
 }
 

--- a/ur_controllers/src/gpio_controller_parameters.yaml
+++ b/ur_controllers/src/gpio_controller_parameters.yaml
@@ -4,3 +4,8 @@ gpio_controller:
     default_value: "",
     description: "urdf prefix of the corresponding arm"
    }
+   check_io_successfull_retries: {
+      type: int,
+      default_value: 10,
+      description: "Amount of retries for checking if the selected gpio was set successfully"
+   }

--- a/ur_controllers/src/gpio_controller_parameters.yaml
+++ b/ur_controllers/src/gpio_controller_parameters.yaml
@@ -1,0 +1,6 @@
+gpio_controller:
+   prefix: {
+    type: string,
+    default_value: "",
+    description: "urdf prefix of the corresponding arm"
+   }

--- a/ur_controllers/src/speed_scaling_state_broadcaster_parameters.yaml
+++ b/ur_controllers/src/speed_scaling_state_broadcaster_parameters.yaml
@@ -1,0 +1,11 @@
+speed_scaling_state_broadcaster:
+   prefix: {
+    type: string,
+    default_value: "",
+    description: "urdf prefix of the corresponding arm"
+   }
+   state_publish_rate: {
+    type: double,
+    default_value: 100.0,
+    description: "rate the speedscaling state will be updated"
+   }

--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -29,6 +29,9 @@ speed_scaling_state_broadcaster:
   ros__parameters:
     state_publish_rate: 100.0
 
+io_and_status_controller:
+  ros__parameters:
+    prefix: ""
 
 force_torque_sensor_broadcaster:
   ros__parameters:

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -219,6 +219,9 @@ protected:
 
   std::unique_ptr<urcl::UrDriver> ur_driver_;
   std::shared_ptr<std::thread> async_thread_;
+
+
+  bool rtde_comm_has_been_started_ = false;
 };
 }  // namespace ur_robot_driver
 

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -281,48 +281,49 @@ URPositionHardwareInterface::on_activate(const rclcpp_lifecycle::State& previous
   RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"), "Starting ...please wait...");
 
   // The robot's IP address.
-  std::string robot_ip = info_.hardware_parameters["robot_ip"];
+  const std::string robot_ip = info_.hardware_parameters["robot_ip"];
   // Path to the urscript code that will be sent to the robot
-  std::string script_filename = info_.hardware_parameters["script_filename"];
+  const std::string script_filename = info_.hardware_parameters["script_filename"];
   // Path to the file containing the recipe used for requesting RTDE outputs.
-  std::string output_recipe_filename = info_.hardware_parameters["output_recipe_filename"];
+  const std::string output_recipe_filename = info_.hardware_parameters["output_recipe_filename"];
   // Path to the file containing the recipe used for requesting RTDE inputs.
-  std::string input_recipe_filename = info_.hardware_parameters["input_recipe_filename"];
+  const std::string input_recipe_filename = info_.hardware_parameters["input_recipe_filename"];
   // Start robot in headless mode. This does not require the 'External Control' URCap to be running
   // on the robot, but this will send the URScript to the robot directly. On e-Series robots this
   // requires the robot to run in 'remote-control' mode.
-  bool headless_mode =
+  const bool headless_mode =
       (info_.hardware_parameters["headless_mode"] == "true") || (info_.hardware_parameters["headless_mode"] == "True");
   // Port that will be opened to communicate between the driver and the robot controller.
-  int reverse_port = stoi(info_.hardware_parameters["reverse_port"]);
+  const int reverse_port = stoi(info_.hardware_parameters["reverse_port"]);
   // The driver will offer an interface to receive the program's URScript on this port.
-  int script_sender_port = stoi(info_.hardware_parameters["script_sender_port"]);
-  // IP that will be used for the robot controller to communicate back to the driver.
+  const int script_sender_port = stoi(info_.hardware_parameters["script_sender_port"]);
+  //  std::string tf_prefix = info_.hardware_parameters["tf_prefix"];
+  //  std::string tf_prefix;
+
+  //The ip address of the host the driver runs on 
   std::string reverse_ip = info_.hardware_parameters["reverse_ip"];
   if (reverse_ip == "0.0.0.0") {
     reverse_ip = "";
   }
-  // Port that will be opened to send trajectory points from the driver to the robot. Note: this feature hasn't been
-  // implemented in ROS2
-  int trajectory_port = 50003;
-  // Port that will be opened to forward script commands from the driver to the robot
-  int script_command_port = stoi(info_.hardware_parameters["script_command_port"]);
-  //  std::string tf_prefix = info_.hardware_parameters["tf_prefix"];
-  //  std::string tf_prefix;
+  //Port of the trajectory interface
+  const int trajectory_port = stoi(info_.hardware_parameters["trajectory_port"]);
+
+  const int script_command_port = stoi(info_.hardware_parameters["script_command_port"]);
 
   // Enables non_blocking_read mode. Should only be used with combined_robot_hw. Disables error generated when read
   // returns without any data, sets the read timeout to zero, and synchronises read/write operations. Enabling this when
   // not used with combined_robot_hw can suppress important errors and affect real-time performance.
-  non_blocking_read_ = static_cast<bool>(stoi(info_.hardware_parameters["non_blocking_read"]));
+  non_blocking_read_ = (info_.hardware_parameters["non_blocking_read"] == "true") ||
+                                (info_.hardware_parameters["non_blocking_read"] == "True");
 
   // Specify gain for servoing to position in joint space.
   // A higher gain can sharpen the trajectory.
-  int servoj_gain = stoi(info_.hardware_parameters["servoj_gain"]);
+  const int servoj_gain = stoi(info_.hardware_parameters["servoj_gain"]);
   // Specify lookahead time for servoing to position in joint space.
   // A longer lookahead time can smooth the trajectory.
-  double servoj_lookahead_time = stod(info_.hardware_parameters["servoj_lookahead_time"]);
+  const double servoj_lookahead_time = stod(info_.hardware_parameters["servoj_lookahead_time"]);
 
-  bool use_tool_communication = (info_.hardware_parameters["use_tool_communication"] == "true") ||
+  const bool use_tool_communication = (info_.hardware_parameters["use_tool_communication"] == "true") ||
                                 (info_.hardware_parameters["use_tool_communication"] == "True");
 
   // Hash of the calibration reported by the robot. This is used for validating the robot
@@ -330,76 +331,88 @@ URPositionHardwareInterface::on_activate(const rclcpp_lifecycle::State& previous
   // hash, an error will be printed. You can use the robot as usual, however Cartesian poses of the
   // endeffector might be inaccurate. See the "ur_calibration" package on help how to generate your
   // own hash matching your actual robot.
-  std::string calibration_checksum = info_.hardware_parameters["kinematics/hash"];
+  const std::string calibration_checksum = info_.hardware_parameters["kinematics/hash"];
 
   std::unique_ptr<urcl::ToolCommSetup> tool_comm_setup;
   if (use_tool_communication) {
     tool_comm_setup = std::make_unique<urcl::ToolCommSetup>();
 
     using ToolVoltageT = std::underlying_type<urcl::ToolVoltage>::type;
-    ToolVoltageT tool_voltage;
+
     // Tool voltage that will be set as soon as the UR-Program on the robot is started. Note: This
     // parameter is only evaluated, when the parameter "use_tool_communication" is set to TRUE.
     // Then, this parameter is required.}
-    tool_voltage = std::stoi(info_.hardware_parameters["tool_voltage"]);
-
+    const ToolVoltageT tool_voltage = std::stoi(info_.hardware_parameters["tool_voltage"]);
     tool_comm_setup->setToolVoltage(static_cast<urcl::ToolVoltage>(tool_voltage));
 
     using ParityT = std::underlying_type<urcl::Parity>::type;
-    ParityT parity;
+  
     // Parity used for tool communication. Will be set as soon as the UR-Program on the robot is
     // started. Can be 0 (None), 1 (odd) and 2 (even).
     //
     // Note: This parameter is only evaluated, when the parameter "use_tool_communication"
     // is set to TRUE.  Then, this parameter is required.
-    parity = std::stoi(info_.hardware_parameters["tool_parity"]);
+    const ParityT parity = std::stoi(info_.hardware_parameters["tool_parity"]);
     tool_comm_setup->setParity(static_cast<urcl::Parity>(parity));
 
-    int baud_rate;
     // Baud rate used for tool communication. Will be set as soon as the UR-Program on the robot is
     // started. See UR documentation for valid baud rates.
     //
     // Note: This parameter is only evaluated, when the parameter "use_tool_communication"
     // is set to TRUE.  Then, this parameter is required.
-    baud_rate = std::stoi(info_.hardware_parameters["tool_baud_rate"]);
+    const int baud_rate = std::stoi(info_.hardware_parameters["tool_baud_rate"]);
     tool_comm_setup->setBaudRate(static_cast<uint32_t>(baud_rate));
 
-    int stop_bits;
     // Number of stop bits used for tool communication. Will be set as soon as the UR-Program on the robot is
     // started. Can be 1 or 2.
     //
     // Note: This parameter is only evaluated, when the parameter "use_tool_communication"
     // is set to TRUE.  Then, this parameter is required.
-    stop_bits = std::stoi(info_.hardware_parameters["tool_stop_bits"]);
+    const int stop_bits = std::stoi(info_.hardware_parameters["tool_stop_bits"]);
     tool_comm_setup->setStopBits(static_cast<uint32_t>(stop_bits));
 
-    int rx_idle_chars;
     // Number of idle chars for the RX unit used for tool communication. Will be set as soon as the UR-Program on the
     // robot is started. Valid values: min=1.0, max=40.0
     //
     // Note: This parameter is only evaluated, when the parameter "use_tool_communication"
     // is set to TRUE.  Then, this parameter is required.
-    rx_idle_chars = std::stoi(info_.hardware_parameters["tool_rx_idle_chars"]);
+    const int rx_idle_chars = std::stoi(info_.hardware_parameters["tool_rx_idle_chars"]);
     tool_comm_setup->setRxIdleChars(rx_idle_chars);
 
-    int tx_idle_chars;
+
     // Number of idle chars for the TX unit used for tool communication. Will be set as soon as the UR-Program on the
     // robot is started. Valid values: min=0.0, max=40.0
     //
     // Note: This parameter is only evaluated, when the parameter "use_tool_communication"
     // is set to TRUE.  Then, this parameter is required.
-    tx_idle_chars = std::stoi(info_.hardware_parameters["tool_tx_idle_chars"]);
+    const int tx_idle_chars = std::stoi(info_.hardware_parameters["tool_tx_idle_chars"]);
     tool_comm_setup->setTxIdleChars(tx_idle_chars);
   }
+
+  //Amount of allowed timed out reads before the reverse interface will be dropped
+  const int keep_alive_count = std::stoi(info_.hardware_parameters["keep_alive_count"]);
+
 
   RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"), "Initializing driver...");
   registerUrclLogHandler();
   try {
     ur_driver_ = std::make_unique<urcl::UrDriver>(
-        robot_ip, script_filename, output_recipe_filename, input_recipe_filename,
-        std::bind(&URPositionHardwareInterface::handleRobotProgramState, this, std::placeholders::_1), headless_mode,
-        std::move(tool_comm_setup), (uint32_t)reverse_port, (uint32_t)script_sender_port, servoj_gain,
-        servoj_lookahead_time, non_blocking_read_, reverse_ip, trajectory_port, script_command_port);
+        robot_ip, 
+        script_filename,
+        output_recipe_filename,
+        input_recipe_filename,
+        std::bind(&URPositionHardwareInterface::handleRobotProgramState, this, std::placeholders::_1), 
+        headless_mode,
+        std::move(tool_comm_setup),
+        (uint32_t)reverse_port, 
+        (uint32_t)script_sender_port,
+        servoj_gain,
+        servoj_lookahead_time,
+        non_blocking_read_, 
+        reverse_ip,
+        trajectory_port, 
+        script_command_port);
+    ur_driver_->setKeepaliveCount(keep_alive_count);
   } catch (urcl::ToolCommNotAvailable& e) {
     RCLCPP_FATAL_STREAM(rclcpp::get_logger("URPositionHardwareInterface"), "See parameter use_tool_communication");
 

--- a/ur_robot_driver/src/hardware_interface.cpp.orig
+++ b/ur_robot_driver/src/hardware_interface.cpp.orig
@@ -141,6 +141,7 @@ URPositionHardwareInterface::on_init(const hardware_interface::HardwareInfo& sys
 
 std::vector<hardware_interface::StateInterface> URPositionHardwareInterface::export_state_interfaces()
 {
+  
   std::vector<hardware_interface::StateInterface> state_interfaces;
   for (size_t i = 0; i < info_.joints.size(); ++i) {
     state_interfaces.emplace_back(hardware_interface::StateInterface(
@@ -166,6 +167,8 @@ std::vector<hardware_interface::StateInterface> URPositionHardwareInterface::exp
                                                                        &urcl_ft_sensor_measurements_[j]));
     }
   }
+
+
 
   for (size_t i = 0; i < 18; ++i) {
     state_interfaces.emplace_back(hardware_interface::StateInterface(prefix+"gpio", "digital_output_" + std::to_string(i),
@@ -271,12 +274,12 @@ std::vector<hardware_interface::CommandInterface> URPositionHardwareInterface::e
         prefix +"gpio", "standard_analog_output_cmd_" + std::to_string(i), &standard_analog_output_cmd_[i]));
   }
 
-  command_interfaces.emplace_back(hardware_interface::CommandInterface(prefix + "gpio", "tool_voltage_cmd", &tool_voltage_cmd_));
+  command_interfaces.emplace_back(hardware_interface::CommandInterface("gpio", "tool_voltage_cmd", &tool_voltage_cmd_));
 
   command_interfaces.emplace_back(
-      hardware_interface::CommandInterface(prefix +  "zero_ftsensor", "zero_ftsensor_cmd", &zero_ftsensor_cmd_));
+      hardware_interface::CommandInterface("zero_ftsensor", "zero_ftsensor_cmd", &zero_ftsensor_cmd_));
 
-  command_interfaces.emplace_back(hardware_interface::CommandInterface(prefix + "zero_ftsensor", "zero_ftsensor_async_success",
+  command_interfaces.emplace_back(hardware_interface::CommandInterface("zero_ftsensor", "zero_ftsensor_async_success",
                                                                        &zero_ftsensor_async_success_));
 
   return command_interfaces;
@@ -386,6 +389,7 @@ URPositionHardwareInterface::on_activate(const rclcpp_lifecycle::State& previous
     const int rx_idle_chars = std::stoi(info_.hardware_parameters["tool_rx_idle_chars"]);
     tool_comm_setup->setRxIdleChars(rx_idle_chars);
 
+
     // Number of idle chars for the TX unit used for tool communication. Will be set as soon as the UR-Program on the
     // robot is started. Valid values: min=0.0, max=40.0
     //
@@ -395,13 +399,18 @@ URPositionHardwareInterface::on_activate(const rclcpp_lifecycle::State& previous
     tool_comm_setup->setTxIdleChars(tx_idle_chars);
   }
 
+<<<<<<< HEAD
   //Amount of allowed timed out reads before the reverse interface will be dropped
   const int keep_alive_count = std::stoi(info_.hardware_parameters["keep_alive_count"]);
 
 
   RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"), "Initializing driver...");
+=======
+  RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"), "Initializing driver. Ip: %s, reverse_port: %i, script_sender_port: %i, trajectory_port: %i, script_command_port: %i, non_blocking_read: %s", robot_ip.c_str(), reverse_port, script_sender_port, trajectory_port, script_command_port, non_blocking_read_? "true" : "false");
+>>>>>>> 6536c65 (added prefix in hardware interface and added support for non blocking reads)
   registerUrclLogHandler();
   try {
+    rtde_comm_has_been_started_ = false;
     ur_driver_ = std::make_unique<urcl::UrDriver>(
         robot_ip, 
         script_filename,
@@ -507,6 +516,12 @@ void URPositionHardwareInterface::asyncThread()
 hardware_interface::return_type URPositionHardwareInterface::read(const rclcpp::Time& time,
                                                                   const rclcpp::Duration& period)
 {
+  //We want to start the rtde comm the latest point possible due to the delay times arising from setting up the communication with multiple arms
+  if(!rtde_comm_has_been_started_) {
+    rtde_comm_has_been_started_  = true;
+      ur_driver_->startRTDECommunication();
+  }
+
   std::unique_ptr<rtde::DataPackage> data_pkg = ur_driver_->getDataPackage();
 
   if (data_pkg) {
@@ -640,6 +655,7 @@ void URPositionHardwareInterface::initAsyncIO()
 
 void URPositionHardwareInterface::checkAsyncIO()
 {
+  if(rtde_comm_has_been_started_){
   for (size_t i = 0; i < 18; ++i) {
     if (!std::isnan(standard_dig_out_bits_cmd_[i]) && ur_driver_ != nullptr) {
       if (i <= 7) {
@@ -689,10 +705,13 @@ void URPositionHardwareInterface::checkAsyncIO()
     payload_mass_ = NO_NEW_CMD_;
     payload_center_of_gravity_ = { NO_NEW_CMD_, NO_NEW_CMD_, NO_NEW_CMD_ };
   }
+<<<<<<< HEAD
 
   if (!std::isnan(zero_ftsensor_cmd_) && ur_driver_ != nullptr) {
     zero_ftsensor_async_success_ = ur_driver_->zeroFTSensor();
     zero_ftsensor_cmd_ = NO_NEW_CMD_;
+=======
+>>>>>>> 6536c65 (added prefix in hardware interface and added support for non blocking reads)
   }
 }
 


### PR DESCRIPTION
Probably not related to multiarm support but the gpio controller might hang is using the mock ros2 control interfaces.
This patch introduces a retry counter and a warn message. 

split up of: #567 