### PR TITLE
Perform scheduled runs of the humble source build

### DIFF
--- a/.github/workflows/humble-source-build.yml
+++ b/.github/workflows/humble-source-build.yml
@@ -1,0 +1,41 @@
+name: Humble Source Build
+on:
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '43 1 * * *'
+
+jobs:
+  humble_source:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    container:
+      image: ubuntu:jammy
+    env:
+      ROS_DISTRO: humble
+      ros_version: 2
+    steps:
+      - uses: ros-tooling/setup-ros@v0.3
+        with:
+          required-ros-distributions: ${{ env.ROS_DISTRO }}
+      - uses: actions/checkout@v2
+      - uses: ros-tooling/action-ros-ci@v0.2
+        with:
+          target-ros2-distro: ${{ env.ROS_DISTRO }}
+          # build all packages listed in the meta package
+          package-name:
+            ur
+            ur_bringup
+            ur_controllers
+            ur_dashboard_msgs
+            ur_moveit_config
+            ur_robot_driver
+          vcs-repo-file-url: |
+            https://raw.githubusercontent.com/ros2/ros2/master/ros2.repos
+            https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/Universal_Robots_ROS2_Driver.${{ env.ROS_DISTRO }}.repos
+          colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
+          extra-cmake-args: -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON
+      - uses: actions/upload-artifact@v1
+        with:
+          name: colcon-logs-${{ matrix.os }}
+          path: ros_ws/log


### PR DESCRIPTION
We also run rolling in scheduled builds, so this is more consistent. I find this to be useful, as source builds especially can show errors from different packages and our ci doesn't reflect fixes to those until we push something new to the corresponding branch.