### PR TITLE
Controller spawner timeout

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
     rev: 3.9.0
     hooks:
     - id: flake8
-      args: ["--ignore=E501"]
+      args: ["--ignore=E501,W503"]
 
   # CPP hooks
   # The same options as in ament_cppcheck are used, but its not working...

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -54,6 +54,7 @@ def launch_setup(context, *args, **kwargs):
     prefix = LaunchConfiguration("prefix")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
+    controller_spawner_timeout = LaunchConfiguration("controller_spawner_timeout")
     initial_joint_controller = LaunchConfiguration("initial_joint_controller")
     activate_joint_controller = LaunchConfiguration("activate_joint_controller")
     launch_rviz = LaunchConfiguration("launch_rviz")
@@ -285,7 +286,14 @@ def launch_setup(context, *args, **kwargs):
         return Node(
             package="controller_manager",
             executable="spawner",
-            arguments=[name, "--controller-manager", "/controller_manager"] + inactive_flags,
+            arguments=[
+                name,
+                "--controller-manager",
+                "/controller_manager",
+                "--controller-manager-timeout",
+                controller_spawner_timeout,
+            ]
+            + inactive_flags,
         )
 
     controller_spawner_names = [
@@ -304,13 +312,26 @@ def launch_setup(context, *args, **kwargs):
     initial_joint_controller_spawner_started = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=[initial_joint_controller, "-c", "/controller_manager"],
+        arguments=[
+            initial_joint_controller,
+            "-c",
+            "/controller_manager",
+            "--controller-manager-timeout",
+            controller_spawner_timeout,
+        ],
         condition=IfCondition(activate_joint_controller),
     )
     initial_joint_controller_spawner_stopped = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=[initial_joint_controller, "-c", "/controller_manager", "--inactive"],
+        arguments=[
+            initial_joint_controller,
+            "-c",
+            "/controller_manager",
+            "--controller-manager-timeout",
+            controller_spawner_timeout,
+            "--inactive",
+        ],
         condition=UnlessCondition(activate_joint_controller),
     )
 
@@ -425,6 +446,13 @@ def generate_launch_description():
             "headless_mode",
             default_value="false",
             description="Enable headless mode for robot control",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "controller_spawner_timeout",
+            default_value="10",
+            description="Timeout used when spawning controllers.",
         )
     )
     declared_arguments.append(

--- a/ur_robot_driver/test/robot_driver.py
+++ b/ur_robot_driver/test/robot_driver.py
@@ -94,6 +94,7 @@ def generate_test_description():
             "robot_ip": "192.168.56.101",
             "ur_type": ur_type,
             "launch_rviz": "false",
+            "controller_spawner_timeout": str(TIMEOUT_WAIT_SERVICE_INITIAL),
             "initial_joint_controller": "scaled_joint_trajectory_controller",
             "headless_mode": "true",
             "launch_dashboard_client": "false",


### PR DESCRIPTION
After merging #605 the controller spawner timeout quite often leads to CI failures: If the initial RTDE connection fails, the driver waits 10 seconds for a retry, leading to timeouts in the controller spawners. This PR fixes that problem by allowing a longer timeout for controller spawners.