### PR TITLE
moveit_servo is currently not available on rolling

### DIFF
--- a/Universal_Robots_ROS2_Driver-not-released.rolling.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.rolling.repos
@@ -4,3 +4,7 @@
 # Once Upstream packages are released and synced to the target distributions in the required
 # version, the entry in this file shall be removed again.
 repositories:
+  moveit2:
+    type: git
+    url: https://github.com/ros-planning/moveit2.git
+    version: main

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -23,3 +23,7 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
     version: humble
+  moveit2:
+    type: git
+    url: https://github.com/ros-planning/moveit2.git
+    version: main


### PR DESCRIPTION
This is pretty late to do this, but [moveit_servo was removed from rolling](https://discourse.ros.org/t/new-packages-for-ros-2-rolling-ridley-2023-01-06/29094). Hopefully it will be back in with the next sync, but until then this should help.