### PR TITLE
Fix humble source CI through `ros2_tracing`

### DIFF
--- a/Universal_Robots_ROS2_Driver-not-released.rolling.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.rolling.repos
@@ -4,6 +4,10 @@
 # Once Upstream packages are released and synced to the target distributions in the required
 # version, the entry in this file shall be removed again.
 repositories:
+  ros2_tracing:
+    type: git
+    url: https://github.com/ros2/ros2_tracing.git
+    version: 8096196
   moveit2:
     type: git
     url: https://github.com/ros-planning/moveit2.git

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -1,4 +1,8 @@
 repositories:
+  ros2_tracing:
+    type: git
+    url: https://github.com/ros2/ros2_tracing.git
+    version: 8096196
   Universal_Robots_Client_Library:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git


### PR DESCRIPTION
## Problem
We get `/opt/ros/rolling/lib/libcontroller_manager.so: undefined reference to tracetools::detail::get_symbol_funcptr(void*)`
in our CI on *Rolling* from source.

## Workaround
It seems that `ros2_tracing` recently changed their function signature from

`const char * get_symbol_funcptr(void * funcptr)` to
`char * get_symbol_funcptr(const void * funcptr)`
in [faf6c27](https://github.com/ros2/ros2_tracing/commit/faf6c278faa23ab2f66ecd6e8fcc674138193a20).

For some reason, the dependent packages don't seem to have updated yet.

Let's see if the previous version fixes the from-source build.