### PR TITLE
FollowJointTrajecotry Test Configuration

### DIFF
--- a/ur_robot_driver/config/test_action_goals_config.yaml
+++ b/ur_robot_driver/config/test_action_goals_config.yaml
@@ -1,0 +1,28 @@
+action_client_position_trajectory_controller:
+  ros__parameters:
+
+    controller_name: "joint_trajectory_controller"
+    wait_sec_between_publish: 6
+
+    goal_names: ["pos1", "pos2", "pos3", "pos4"]
+    pos1: [0.785, -1.57, 0.785, 0.785, 0.785, 0.785]
+    pos2: [0.0, -1.57, 0.0, 0.0, 0.0, 0.0]
+    pos3: [0.0, -1.57, 0.0, 0.0, -0.785, 0.0]
+    pos4: [0.0, -1.57, 0.0, 0.0, 0.0, 0.0]
+
+    joints:
+      - shoulder_pan_joint
+      - shoulder_lift_joint
+      - elbow_joint
+      - wrist_1_joint
+      - wrist_2_joint
+      - wrist_3_joint
+
+    check_starting_point: true
+    starting_point_limits:
+      shoulder_pan_joint: [-0.1,0.1]
+      shoulder_lift_joint: [-1.6,-1.5]
+      elbow_joint: [-0.1,0.1]
+      wrist_1_joint: [-1.6,-1.5]
+      wrist_2_joint: [-0.1,0.1]
+      wrist_3_joint: [-0.1,0.1]

--- a/ur_robot_driver/launch/test_action_follow_joint_trajectory.launch.py
+++ b/ur_robot_driver/launch/test_action_follow_joint_trajectory.launch.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2023 PickNik, Inc.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+#
+# Author: Lovro Ivanov
+#
+
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    position_goals = PathJoinSubstitution(
+        [FindPackageShare("ur_robot_driver"), "config", "test_action_goals_config.yaml"]
+    )
+
+    return LaunchDescription(
+        [
+            Node(
+                package="ros2_controllers_test_nodes",
+                executable="action_client_joint_trajectory_controller",
+                name="action_client_position_trajectory_controller",
+                parameters=[position_goals],
+                output="screen",
+            )
+        ]
+    )


### PR DESCRIPTION
# Description
- PR depends on https://github.com/eholum/ros2_controllers/pull/1 which also needs to be moved to the main repo
- PR introduces launch and configuration files for testing action interface for JTC