### PR TITLE
Added ur_moveit_config.launch.py arguments for publishing robot description and robot description semantic

### DIFF
--- a/Universal_Robots_ROS2_Driver.galactic.repos
+++ b/Universal_Robots_ROS2_Driver.galactic.repos
@@ -6,7 +6,7 @@ repositories:
   Universal_Robots_ROS2_Description:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: ros2
+    version: galactic
   ur_msgs:
     type: git
     url: https://github.com/ros-industrial/ur_msgs.git

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -57,7 +57,7 @@ def launch_setup(context, *args, **kwargs):
     launch_rviz = LaunchConfiguration("launch_rviz")
     launch_servo = LaunchConfiguration("launch_servo")
     publish_robot_description = LaunchConfiguration("publish_robot_description")
-    publish_robot_description_semantic = LaunchConfiguration("publish_robot_decsription_semantic")
+    publish_robot_description_semantic = LaunchConfiguration("publish_robot_description_semantic")
 
     joint_limit_params = PathJoinSubstitution(
         [FindPackageShare(description_package), "config", ur_type, "joint_limits.yaml"]

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -358,7 +358,7 @@ def generate_launch_description():
         DeclareLaunchArgument("publish_robot_description", default_value="true", description="MoveGroup publishes robot description")
     )
     declared_arguments.append(
-        DeclareLaunchArgument("publish_robot_description", default_value="true", description="MoveGroup publishes robot descripion semantic")
+        DeclareLaunchArgument("publish_robot_description_semantic", default_value="true", description="MoveGroup publishes robot descripion semantic")
     )
 
     return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -355,10 +355,10 @@ def generate_launch_description():
         DeclareLaunchArgument("launch_servo", default_value="true", description="Launch Servo?")
     )
     declared_arguments.append(
-        DeclareLaunchArgument("publish_robot_description", default_value="true", "MoveGroup publishes robot description")
+        DeclareLaunchArgument("publish_robot_description", default_value="true", description="MoveGroup publishes robot description")
     )
     declared_arguments.append(
-        DeclareLaunchArgument("publish_robot_description", default_value="true", "MoveGroup publishes robot descripion semantic")
+        DeclareLaunchArgument("publish_robot_description", default_value="true", description="MoveGroup publishes robot descripion semantic")
     )
 
     return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -56,6 +56,8 @@ def launch_setup(context, *args, **kwargs):
     use_sim_time = LaunchConfiguration("use_sim_time")
     launch_rviz = LaunchConfiguration("launch_rviz")
     launch_servo = LaunchConfiguration("launch_servo")
+    publish_robot_description = LaunchConfiguration("publish_robot_description")
+    publish_robot_description_semantic = LaunchConfiguration("publish_robot_decsription_semantic")
 
     joint_limit_params = PathJoinSubstitution(
         [FindPackageShare(description_package), "config", ur_type, "joint_limits.yaml"]
@@ -199,7 +201,9 @@ def launch_setup(context, *args, **kwargs):
             trajectory_execution,
             moveit_controllers,
             planning_scene_monitor_parameters,
-            {"use_sim_time": use_sim_time},
+            {"use_sim_time": use_sim_time,
+            "publish_robot_description": publish_robot_description,
+            "publish_robot_description_semantic": publish_robot_description_semantic},
         ],
     )
 
@@ -349,6 +353,12 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument("launch_servo", default_value="true", description="Launch Servo?")
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument("publish_robot_description", default_value="true", "MoveGroup publishes robot description")
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument("publish_robot_description", default_value="true", "MoveGroup publishes robot descripion semantic")
     )
 
     return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])


### PR DESCRIPTION
Hi,

I am working with a project where I use the MoveGroupInterface for moving the Universal Robot. To use it you either have to load the robot description and the robot description semantic (as you already do in the ur_moveit_config.launch.py) into the node that will utilize the MoveGroupInterface, or you can pull it from the move_group automatically. The latter is better in my view but for this to work I need to instruct the move_group node to publish them. This would make it easier for people to use MoveGroupInterface with your driver. 

Relevant resources: 
https://github.com/ros-planning/moveit2_tutorials/issues/525
https://moveit.picknik.ai/humble/doc/examples/urdf_srdf/urdf_srdf_tutorial.html

This solution should work also in other branches other than galactic. For galactic to build tho, I had to update the .repos file setting the UR Description package to galactic instead of ros2.