### PR TITLE
Add ros2_control as direct dependency

### DIFF
--- a/Universal_Robots_ROS2_Driver.humble.repos
+++ b/Universal_Robots_ROS2_Driver.humble.repos
@@ -11,6 +11,10 @@ repositories:
     type: git
     url: https://github.com/ros-industrial/ur_msgs.git
     version: foxy-devel
+  ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control.git
+    version: humble
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers


### PR DESCRIPTION
Only directly using ros2_controllers in semi-binary builds is prone to breakage