### PR TITLE
Do not require building moveit2 from source

### DIFF
--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -27,7 +27,3 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
     version: humble
-  moveit2:
-    type: git
-    url: https://github.com/ros-planning/moveit2.git
-    version: main


### PR DESCRIPTION
As MoveIt2 is not a direct dependency and released upstream, we can remove it again.

This was introduced in #610 but got forgotten to revert in #621.