### PR TITLE
Added workflows for iron

### DIFF
--- a/.github/workflows/iron-binary-main.yml
+++ b/.github/workflows/iron-binary-main.yml
@@ -1,0 +1,24 @@
+name: Iron Binary Build Main
+on:
+  workflow_dispatch:
+    branches:
+      - iron
+  pull_request:
+    branches:
+      - iron
+      - main # as long as rolling and iron should be compatible
+  push:
+    branches:
+      - iron
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '13 5 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: iron
+      ros_repo: main
+      upstream_workspace: Universal_Robots_ROS2_Driver-not-released.iron.repos
+      ref_for_scheduled_build: iron

--- a/.github/workflows/iron-binary-testing.yml
+++ b/.github/workflows/iron-binary-testing.yml
@@ -1,0 +1,24 @@
+name: Iron Binary Build Testing
+on:
+  workflow_dispatch:
+    branches:
+      - iron
+  pull_request:
+    branches:
+      - iron
+      - main # as long as rolling and iron should be compatible
+  push:
+    branches:
+      - iron
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '13 5 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: iron
+      ros_repo: testing
+      upstream_workspace: Universal_Robots_ROS2_Driver-not-released.iron.repos
+      ref_for_scheduled_build: iron

--- a/.github/workflows/iron-semi-binary-main.yml
+++ b/.github/workflows/iron-semi-binary-main.yml
@@ -1,0 +1,24 @@
+name: Iron Semi Binary Build Main
+on:
+  workflow_dispatch:
+    branches:
+      - iron
+  pull_request:
+    branches:
+      - iron
+      - main # as long as rolling and iron should be compatible
+  push:
+    branches:
+      - iron
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '13 5 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: iron
+      ros_repo: main
+      upstream_workspace: Universal_Robots_ROS2_Driver.iron.repos
+      ref_for_scheduled_build: iron

--- a/.github/workflows/iron-semi-binary-testing.yml
+++ b/.github/workflows/iron-semi-binary-testing.yml
@@ -1,0 +1,24 @@
+name: Iron Semi Binary Build Testing
+on:
+  workflow_dispatch:
+    branches:
+      - iron
+  pull_request:
+    branches:
+      - iron
+      - main # as long as rolling and iron should be compatible
+  push:
+    branches:
+      - iron
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '13 5 * * *'
+
+jobs:
+  binary:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: iron
+      ros_repo: testing
+      upstream_workspace: Universal_Robots_ROS2_Driver.iron.repos
+      ref_for_scheduled_build: iron

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
     <th>Foxy</th>
     <th>Galactic</th>
     <th>Humble</th>
+    <th>Iron</th>
     <th>Rolling</th>
   </tr>
   <tr>
@@ -28,6 +29,7 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/foxy">foxy</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/galactic">galactic</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/humble">humble</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/iron">iron</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
   </tr>
   <tr>
@@ -68,6 +70,24 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
       <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/humble-semi-binary-testing.yml?query=event%3Aschedule++">
          <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/humble-semi-binary-testing.yml/badge.svg?event=schedule"
               alt="Humble Semi-Binary Testing"/>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/iron-binary-main.yml?query=event%3Aschedule++">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/iron-binary-main.yml/badge.svg?event=schedule"
+              alt="Iron Binary Main"/>
+      </a> <br />
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/iron-binary-testing.yml?query=event%3Aschedule++">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/iron-binary-testing.yml/badge.svg?event=schedule"
+              alt="Iron Binary Testing"/>
+      </a> <br />
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/iron-semi-binary-main.yml?query=event%3Aschedule++">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/iron-semi-binary-main.yml/badge.svg?event=schedule"
+              alt="Iron Semi-Binary Main"/>
+      </a> <br />
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/iron-semi-binary-testing.yml?query=event%3Aschedule++">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/iron-semi-binary-testing.yml/badge.svg?event=schedule"
+              alt="Iron Semi-Binary Testing"/>
       </a>
     </td>
     <td>

--- a/Universal_Robots_ROS2_Driver-not-released.iron.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.iron.repos
@@ -1,0 +1,10 @@
+# The not-released files are meant to use upstream packages in binary form whenever possible.
+# Packages get added here, if they are not released at all or when the repo's current version
+# requires a newer version than the one currently released to the target distributions.
+# Once Upstream packages are released and synced to the target distributions in the required
+# version, the entry in this file shall be removed again.
+repositories:
+  Universal_Robots_ROS2_Description:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+    version: ros2

--- a/Universal_Robots_ROS2_Driver.iron.repos
+++ b/Universal_Robots_ROS2_Driver.iron.repos
@@ -1,0 +1,29 @@
+repositories:
+  Universal_Robots_Client_Library:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+    version: master
+  Universal_Robots_ROS2_Description:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+    version: ros2
+  ur_msgs:
+    type: git
+    url: https://github.com/ros-industrial/ur_msgs.git
+    version: foxy-devel
+  ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control.git
+    version: master
+  ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers
+    version: master
+  kinematics_interface:
+    type: git
+    url: https://github.com/ros-controls/kinematics_interface.git
+    version: master
+  control_msgs:
+    type: git
+    url: https://github.com/ros-controls/control_msgs.git
+    version: humble


### PR DESCRIPTION
This PR adds CI builds for Iron. The idea is that we create an iron branch once this is merged onto main and we keep the iron branch up-to-date with main as long as rolling is compatible with iron.