### PR TITLE
Fix flaky tests

### DIFF
--- a/ur_robot_driver/test/robot_driver.py
+++ b/ur_robot_driver/test/robot_driver.py
@@ -183,13 +183,14 @@ class RobotDriverTest(unittest.TestCase):
             for (action_name, action_type) in action_interfaces.items()
         }
 
+    def setUp(self):
         # Start robot
         empty_req = Trigger.Request()
-        self.call_service(self, "/dashboard_client/power_on", empty_req)
-        self.call_service(self, "/dashboard_client/brake_release", empty_req)
-        self.call_service(self, "/io_and_status_controller/resend_robot_program", empty_req)
+        self.call_service("/dashboard_client/power_on", empty_req)
+        self.call_service("/dashboard_client/brake_release", empty_req)
+        self.call_service("/io_and_status_controller/resend_robot_program", empty_req)
         time.sleep(1)
-        self.call_service(self, "/io_and_status_controller/resend_robot_program", empty_req)
+        self.call_service("/io_and_status_controller/resend_robot_program", empty_req)
 
     #
     # Test functions

--- a/ur_robot_driver/test/robot_driver.py
+++ b/ur_robot_driver/test/robot_driver.py
@@ -54,6 +54,8 @@ from std_srvs.srv import Trigger
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
 from ur_msgs.msg import IOStates
 from ur_msgs.srv import SetIO
+from ur_dashboard_msgs.msg import RobotMode
+from ur_dashboard_msgs.srv import GetRobotMode
 
 TIMEOUT_WAIT_SERVICE = 10
 TIMEOUT_WAIT_SERVICE_INITIAL = 60
@@ -164,6 +166,8 @@ class RobotDriverTest(unittest.TestCase):
         # Connect to the rest of the required interfaces
         service_interfaces = {
             "/dashboard_client/brake_release": Trigger,
+            "/dashboard_client/stop": Trigger,
+            "/dashboard_client/get_robot_mode": GetRobotMode,
             "/controller_manager/switch_controller": SwitchController,
             "/io_and_status_controller/set_io": SetIO,
             "/io_and_status_controller/resend_robot_program": Trigger,
@@ -188,7 +192,12 @@ class RobotDriverTest(unittest.TestCase):
         empty_req = Trigger.Request()
         self.call_service("/dashboard_client/power_on", empty_req)
         self.call_service("/dashboard_client/brake_release", empty_req)
-        self.call_service("/io_and_status_controller/resend_robot_program", empty_req)
+        time.sleep(1)
+        robot_mode_resp = self.call_service(
+            "/dashboard_client/get_robot_mode", GetRobotMode.Request()
+        )
+        self.assertEqual(robot_mode_resp.robot_mode.mode, RobotMode.RUNNING)
+        self.call_service("/dashboard_client/stop", empty_req)
         time.sleep(1)
         self.call_service("/io_and_status_controller/resend_robot_program", empty_req)
 


### PR DESCRIPTION
This should hopefully fix our flaky tests.

Basically the scenario causing problems was that after startup the program running on the robot was in a `paused` state.  This was causing the scaled JTC to not progress forever leading the test into a timeout.
This PR re-arranges the robot-startup in the test file such that the program should always be running.

Basically, the program is started in each test's `setUp()` method after the robot has been put into `RUNNING` mode which is checked.

I have this running [on my fork](https://github.com/fmauch/Universal_Robots_ROS2_Driver/actions/workflows/rolling-binary-build.yml?query=branch%3Adebug_tests) for quite some runs now (since run 111) and this seems to be working fine.