### PR TITLE
Define default maximum accelerations for MoveIt

### DIFF
--- a/ur_moveit_config/config/joint_limits.yaml
+++ b/ur_moveit_config/config/joint_limits.yaml
@@ -1,0 +1,25 @@
+# These limits are used by MoveIt and augment/override the definitions in ur_description.
+#
+# While the robot does not inherently have any limits on joint accelerations (only on torques),
+# MoveIt needs them for time parametrization. They were chosen conservatively to work in most use
+# cases. For specific applications, higher values might lead to better execution performance.
+
+joint_limits:
+  shoulder_pan_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  shoulder_lift_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  elbow_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  wrist_1_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  wrist_2_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0
+  wrist_3_joint:
+    has_acceleration_limits: true
+    max_acceleration: 5.0


### PR DESCRIPTION
This defines default values for maximum joint accelerations, as MoveIt is otherwise not able to perform time parametrization. The 5rad/s² are from the discussion in https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/issues/46.

This patch only passes these limits to MoveIt. While we could also add them in `ur_description`, this seems incorrect. The robot does not inherently have any limits on joint accelerations (only on torques), and other software using `ur_description` might be able to handle this differently.