### PR TITLE
Wait longer for controllers to load and activate

### DIFF
--- a/ur_robot_driver/test/robot_driver.py
+++ b/ur_robot_driver/test/robot_driver.py
@@ -149,10 +149,14 @@ class RobotDriverTest(unittest.TestCase):
 
     def init_robot(self):
 
-        # Wait longer for the first service clients (for both the driver and the dashboard client) as the robot driver is still starting up
+        # Wait longer for the first service clients:
+        #  - The robot has to start up
+        #  - The controller_manager has to start
+        #  - The controllers need to load and activate
         service_interfaces_initial = {
             "/dashboard_client/power_on": Trigger,
             "/controller_manager/switch_controller": SwitchController,
+            "/io_and_status_controller/set_io": SetIO,
         }
         self.service_clients = {
             srv_name: waitForService(
@@ -165,7 +169,6 @@ class RobotDriverTest(unittest.TestCase):
         service_interfaces = {
             "/dashboard_client/brake_release": Trigger,
             "/controller_manager/switch_controller": SwitchController,
-            "/io_and_status_controller/set_io": SetIO,
             "/io_and_status_controller/resend_robot_program": Trigger,
         }
         self.service_clients.update(


### PR DESCRIPTION
This came up in the backport of CI fixes https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/647 and seemed to be unrelated to those changes.