### PR TITLE
Add ur_moveit.launch.py arguments to control whether the move_group node publishes robot description and robot semantic description

### DIFF
--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -60,6 +60,8 @@ def launch_setup(context, *args, **kwargs):
     use_sim_time = LaunchConfiguration("use_sim_time")
     launch_rviz = LaunchConfiguration("launch_rviz")
     launch_servo = LaunchConfiguration("launch_servo")
+    publish_robot_description = LaunchConfiguration("publish_robot_description")
+    publish_robot_description_semantic = LaunchConfiguration("publish_robot_description_semantic")
 
     joint_limit_params = PathJoinSubstitution(
         [FindPackageShare(description_package), "config", ur_type, "joint_limits.yaml"]
@@ -211,8 +213,11 @@ def launch_setup(context, *args, **kwargs):
             trajectory_execution,
             moveit_controllers,
             planning_scene_monitor_parameters,
-            {"use_sim_time": use_sim_time},
+            {"use_sim_time": use_sim_time,
+            "publish_robot_description": publish_robot_description,
++           "publish_robot_description_semantic": publish_robot_description_semantic},
             warehouse_ros_config,
+
         ],
     )
 
@@ -362,6 +367,12 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument("launch_servo", default_value="true", description="Launch Servo?")
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument("publish_robot_description", default_value="true", description="MoveGroup publishes robot description")
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument("publish_robot_description_semantic", default_value="true", description="MoveGroup publishes robot descripion semantic")
     )
 
     return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])


### PR DESCRIPTION
Users can now pass arguments to the launch file to make the move_group node publish descriptions needed for using the MoveGroupInterface.

Until now, if you want to use the MoveGroupInterface in a custom node, you'd have to copy the entire ur_moveit.launch.py to load and construct the urdf and srdf information needed for the move_group node and the MoveGroupInterface node. This results in a rather huge launch file for the single MoveGroupInterface-node to work.

This PR is a quality of life change so that other people wanting to use MoveGroupInterface with the UR can do so by including the existing ur_moveit.launch.py in their own file using IncludeLaunchDescription and then launch their MoveGroupInterface on top of that which pulls the required urdf and srdf from the move_group-node.
