### PR TITLE
Switched out a deprecated header to avoid buildfarm warnings.

### DIFF
--- a/ur_controllers/src/speed_scaling_state_broadcaster.cpp
+++ b/ur_controllers/src/speed_scaling_state_broadcaster.cpp
@@ -41,7 +41,7 @@
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/clock.hpp"
 #include "rclcpp/qos.hpp"
-#include "rclcpp/qos_event.hpp"
+#include "rclcpp/event_handler.hpp"
 #include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
 #include "rcpputils/split.hpp"


### PR DESCRIPTION
This should make our buildfarm builds stable again. See [this run](https://build.ros2.org/job/Rdev__ur_robot_driver__ubuntu_jammy_amd64/48/) for instance showing the warning.

Additionally, I'd like to raise the question, whether we should activate `-Wall` for this repo. I think it makes sense in order to track these kind of warnings early in the process.