### PR TITLE
Forcing committer and author in automatic create PR workflow

### DIFF
--- a/.github/workflows/update-ci.yml
+++ b/.github/workflows/update-ci.yml
@@ -33,6 +33,8 @@ jobs:
           branch: update-ci/pre-commit-autoupdate
           delete-branch: true
           title: Auto-update pre-commit hooks
+          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
           commit-message: Auto-update pre-commit hooks
           labels: CI
       - name: Check outputs


### PR DESCRIPTION
Resolves: #678 
Changes:
- Forcing committer and author in automatic create PR workflow
- Using `github-actions[bot] <github-actions[bot]@users.noreply.github.com>` in committer + author fields

This was tested on my forked repo as shown below:
- PR: https://github.com/tungbq/Universal_Robots_ROS2_Driver/pull/1
 ![image](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/assets/85242618/227595b9-1a27-4341-8ab9-e25a77b00124)
- Log: https://github.com/tungbq/Universal_Robots_ROS2_Driver/actions/runs/5065138063/jobs/9093387898
 ![image](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/assets/85242618/2385f0e3-ef2f-492e-965e-a9db2db42cf4)
