### PR TITLE
Fixed formatting

### DIFF
--- a/ur_calibration/launch/calibration_correction.launch.py
+++ b/ur_calibration/launch/calibration_correction.launch.py
@@ -36,7 +36,6 @@ from launch_ros.actions import Node
 
 
 def generate_launch_description():
-
     declared_arguments = []
     declared_arguments.append(
         DeclareLaunchArgument(

--- a/ur_controllers/CHANGELOG.rst
+++ b/ur_controllers/CHANGELOG.rst
@@ -25,7 +25,7 @@ Changelog for package ur_controllers
 * Adapt ros control api (`#448 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/448>`_)
   * scaled jtc: Use get_interface_name instead of get_name
   * Migrate from stopped controllers to inactive controllers
-  stopped controllers has been depreated upstream
+  stopped controllers has been deprecated upstream
 * Contributors: Felix Exner
 
 2.2.2 (2022-07-19)

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -42,7 +42,6 @@ from launch.substitutions import Command, FindExecutable, LaunchConfiguration, P
 
 
 def launch_setup(context, *args, **kwargs):
-
     # Initialize Arguments
     ur_type = LaunchConfiguration("ur_type")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
@@ -258,7 +257,6 @@ def launch_setup(context, *args, **kwargs):
 
 
 def generate_launch_description():
-
     declared_arguments = []
     # UR specific arguments
     declared_arguments.append(

--- a/ur_moveit_config/ur_moveit_config/launch_common.py
+++ b/ur_moveit_config/ur_moveit_config/launch_common.py
@@ -70,7 +70,6 @@ def load_yaml(package_name, file_path):
 
 
 def load_yaml_abs(absolute_file_path):
-
     try:
         yaml.SafeLoader.add_constructor("!radians", construct_angle_radians)
         yaml.SafeLoader.add_constructor("!degrees", construct_angle_degrees)

--- a/ur_robot_driver/CHANGELOG.rst
+++ b/ur_robot_driver/CHANGELOG.rst
@@ -88,7 +88,7 @@
 * Adapt ros control api (`#448 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/448>`_)
   * scaled jtc: Use get_interface_name instead of get_name
   * Migrate from stopped controllers to inactive controllers
-  stopped controllers has been depreated upstream
+  stopped controllers has been deprecated upstream
 * Contributors: Felix Exner
 
 2.2.2 (2022-07-19)

--- a/ur_robot_driver/launch/test_forward_velocity_controller.launch.py
+++ b/ur_robot_driver/launch/test_forward_velocity_controller.launch.py
@@ -38,7 +38,6 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-
     velocity_goals = PathJoinSubstitution(
         [FindPackageShare("ur_robot_driver"), "config", "test_velocity_goal_publishers_config.yaml"]
     )

--- a/ur_robot_driver/launch/test_joint_trajectory_controller.launch.py
+++ b/ur_robot_driver/launch/test_joint_trajectory_controller.launch.py
@@ -38,7 +38,6 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-
     position_goals = PathJoinSubstitution(
         [FindPackageShare("ur_robot_driver"), "config", "test_goal_publishers_config.yaml"]
     )

--- a/ur_robot_driver/launch/test_scaled_joint_trajectory_controller.launch.py
+++ b/ur_robot_driver/launch/test_scaled_joint_trajectory_controller.launch.py
@@ -38,7 +38,6 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-
     position_goals = PathJoinSubstitution(
         [FindPackageShare("ur_robot_driver"), "config", "test_goal_publishers_config.yaml"]
     )

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -39,7 +39,6 @@ from launch.substitutions import Command, FindExecutable, LaunchConfiguration, P
 
 
 def launch_setup(context, *args, **kwargs):
-
     # Initialize Arguments
     ur_type = LaunchConfiguration("ur_type")
     robot_ip = LaunchConfiguration("robot_ip")

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -121,7 +121,6 @@ class DashboardClientTest(unittest.TestCase):
         rclpy.shutdown()
 
     def init_robot(self):
-
         # We wait longer for the first client, as the robot is still starting up
         power_on_client = waitForService(
             self.node, "/dashboard_client/power_on", Trigger, timeout=TIMEOUT_WAIT_SERVICE_INITIAL

--- a/ur_robot_driver/test/robot_driver.py
+++ b/ur_robot_driver/test/robot_driver.py
@@ -150,7 +150,6 @@ class RobotDriverTest(unittest.TestCase):
         rclpy.shutdown()
 
     def init_robot(self):
-
         # Wait longer for the first service clients:
         #  - The robot has to start up
         #  - The controller_manager has to start


### PR DESCRIPTION
Black and codespell seem to  be more picky by now, this PR fixes empty lines below function definitions in python files and a typo in our changelogs.

This came up in #640 