### PR TITLE
Use tf prefix properly

### DIFF
--- a/Universal_Robots_ROS2_Driver-not-released.humble.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.humble.repos
@@ -8,3 +8,11 @@ repositories:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
     version: ros2
+  ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control.git
+    version: humble
+  ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers
+    version: humble

--- a/Universal_Robots_ROS2_Driver-not-released.rolling.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.rolling.repos
@@ -8,3 +8,11 @@ repositories:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
     version: ros2
+  ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control.git
+    version: master
+  ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers
+    version: master

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -156,8 +156,7 @@ std::vector<hardware_interface::StateInterface> URPositionHardwareInterface::exp
   // Obtain the tf_prefix from the urdf so that we can have the general interface multiple times
   // NOTE using the tf_prefix at this point is some kind of workaround. One should actually go through the list of gpio
   // state interface in info_ and match them accordingly
-  std::string tf_prefix = info_.hardware_parameters.at("tf_prefix");
-  tf_prefix.erase(0, 1);
+  const std::string tf_prefix = info_.hardware_parameters.at("tf_prefix");
   state_interfaces.emplace_back(hardware_interface::StateInterface(tf_prefix + "speed_scaling", "speed_scaling_factor",
                                                                    &speed_scaling_combined_));
 


### PR DESCRIPTION
Since https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/66 is merged, we'll have to revert the workaround in the driver as well.