### PR TITLE
Use binary released packages for binary builds only.

### DIFF
--- a/Universal_Robots_ROS2_Driver-not-released.humble.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.humble.repos
@@ -4,19 +4,3 @@
 # Once Upstream packages are released and synced to the target distributions in the required
 # version, the entry in this file shall be removed again.
 repositories:
-  Universal_Robots_ROS2_Description:
-    type: git
-    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: ros2
-  ros2_control:
-    type: git
-    url: https://github.com/ros-controls/ros2_control.git
-    version: humble
-  ros2_controllers:
-    type: git
-    url: https://github.com/ros-controls/ros2_controllers
-    version: humble
-  control_msgs:
-    type: git
-    url: https://github.com/ros-controls/control_msgs.git
-    version: humble

--- a/Universal_Robots_ROS2_Driver-not-released.rolling.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.rolling.repos
@@ -4,19 +4,3 @@
 # Once Upstream packages are released and synced to the target distributions in the required
 # version, the entry in this file shall be removed again.
 repositories:
-  Universal_Robots_ROS2_Description:
-    type: git
-    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: ros2
-  ros2_control:
-    type: git
-    url: https://github.com/ros-controls/ros2_control.git
-    version: master
-  ros2_controllers:
-    type: git
-    url: https://github.com/ros-controls/ros2_controllers
-    version: master
-  control_msgs:
-    type: git
-    url: https://github.com/ros-controls/control_msgs.git
-    version: master

--- a/Universal_Robots_ROS2_Driver.humble.repos
+++ b/Universal_Robots_ROS2_Driver.humble.repos
@@ -6,7 +6,7 @@ repositories:
   Universal_Robots_ROS2_Description:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: ros2
+    version: humble
   ur_msgs:
     type: git
     url: https://github.com/ros-industrial/ur_msgs.git

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -26,4 +26,4 @@ repositories:
   control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
-    version: humble
+    version: master


### PR DESCRIPTION
The idea behind this is basically this:
 * If we require direct upstream dependencies in a more recent version, we have the semi-binary builds. With this, it would be acceptable, that the binary builds turn failed if there has been an upstream breaking change, that we already adapted to.
 * For development the semi-binary builds are the actually interesting ones. They will keep building upstream dependencies from their most recent versions.
 * The binary builds should give us feedback whether the driver will work with the currently released packages. This is only a valid feedback if it is actually built against the released state.

This way, situations like it just happened that our humble release was failing should pop up in the binary-testing earlier in the process, so that we can react on this. If we build our binary builds against upstream master, this migh get (and was) hidden.