### PR TITLE
Urscript interface

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -187,5 +187,9 @@ if(BUILD_TESTING)
       TIMEOUT
         500
     )
+    add_launch_test(test/urscript_interface.py
+      TIMEOUT
+        500
+    )
   endif()
 endif()

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -103,8 +103,13 @@ add_executable(controller_stopper_node
 )
 ament_target_dependencies(controller_stopper_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${THIS_PACKAGE_INCLUDE_DEPENDS})
 
+add_executable(urscript_interface
+  src/urscript_interface.cpp
+)
+ament_target_dependencies(urscript_interface ${${PROJECT_NAME}_EXPORTED_TARGETS} ${THIS_PACKAGE_INCLUDE_DEPENDS})
+
 install(
-  TARGETS dashboard_client ur_ros2_control_node controller_stopper_node
+  TARGETS dashboard_client ur_ros2_control_node controller_stopper_node urscript_interface
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ur_robot_driver/doc/usage.rst
+++ b/ur_robot_driver/doc/usage.rst
@@ -233,6 +233,10 @@ restarted again. Depending whether you use headless mode or not, you'll have to 
 ``resend_program`` service or press the ``play`` button on the teach panel to start the
 external_control program again.
 
+.. note::
+  Currently, there is no feedback on the code's correctness. If the code sent to the
+  robot is incorrect, it will silently not get executed. Make sure that you send valid URScript code!
+
 Multi-line programs
 ^^^^^^^^^^^^^^^^^^^
 

--- a/ur_robot_driver/doc/usage.rst
+++ b/ur_robot_driver/doc/usage.rst
@@ -214,3 +214,57 @@ are a couple of things to know:
   additional tool configured on the Teach pendant (TP), this should be equivalent to ``tool0`` given that
   the URDF uses the specific robot's :ref:`calibration <calibration_extraction>`. If a tool is
   configured on the TP, then the additional transformation will show in ``base`` -> ``tool0``.
+
+Custom URScript commands
+------------------------
+
+The driver's package contains a ``urscript_interface`` node that allows sending URScript snippets
+directly to the robot. It gets started in the driver's launchfiles by default. To use it, simply
+publish a message to its interface:
+
+.. code-block:: bash
+
+  # simple popup
+  ros2 topic pub /urscript_interface/script_command std_msgs/msg/String '{data: popup("hello")}' --once
+
+Be aware, that running a program on this interface (meaning publishing script code to that interface) stops any running program on the robot.
+Thus, the motion-interpreting program that is started by the driver gets stopped and has to be
+restarted again. Depending whether you use headless mode or not, you'll have to call the
+``resend_program`` service or press the ``play`` button on the teach panel to start the
+external_control program again.
+
+Multi-line programs
+^^^^^^^^^^^^^^^^^^^
+
+When you want to define multi-line programs, make sure to check that newlines are correctly
+interpreted from your message. For this purpose the driver prints the program as it is being sent to
+the robot. When sending a multi-line program from the command line, you can use an empty line
+between each statement:
+
+.. code-block:: bash
+
+   ros2 topic pub --once /urscript_interface/script_command std_msgs/msg/String '{data:
+   "def my_prog():
+
+     set_digital_out(1, True)
+
+     movej(p[0.2, 0.3, 0.8, 0, 0, 3.14], a=1.2, v=0.25, r=0)
+
+     textmsg(\"motion finished\")
+
+   end"}'
+
+Non-interrupting programs
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To prevent interrupting the main program, you can send certain commands as `secondary programs
+<https://www.universal-robots.com/articles/ur/programming/secondary-program/>`_.
+
+.. code-block:: bash
+
+   ros2 topic pub --once /urscript_interface/script_command std_msgs/msg/String '{data:
+     "sec my_prog():
+
+       textmsg(\"This is a log message\")
+
+     end"}'

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -242,6 +242,13 @@ def launch_setup(context, *args, **kwargs):
         ],
     )
 
+    urscript_interface = Node(
+        package="ur_robot_driver",
+        executable="urscript_interface",
+        parameters=[{"robot_ip": robot_ip}],
+        output="screen",
+    )
+
     controller_stopper_node = Node(
         package="ur_robot_driver",
         executable="controller_stopper_node",
@@ -340,6 +347,7 @@ def launch_setup(context, *args, **kwargs):
         dashboard_client_node,
         tool_communication_node,
         controller_stopper_node,
+        urscript_interface,
         robot_state_publisher_node,
         rviz_node,
         initial_joint_controller_spawner_stopped,

--- a/ur_robot_driver/src/urscript_interface.cpp
+++ b/ur_robot_driver/src/urscript_interface.cpp
@@ -77,7 +77,6 @@ public:
     size_t written;
     m_secondary_stream->write(data, len, written);
   }
-  ~URScriptInterface() override = default;
 
 private:
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr m_script_sub;

--- a/ur_robot_driver/src/urscript_interface.cpp
+++ b/ur_robot_driver/src/urscript_interface.cpp
@@ -1,0 +1,87 @@
+// Copyright 2023, FZI Forschungszentrum Informatik, Created on behalf of Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner exner@fzi.de
+ * \date    2023-06-20
+ *
+ */
+//----------------------------------------------------------------------
+
+#include <ur_client_library/comm/stream.h>
+#include <ur_client_library/primary/primary_package.h>
+
+#include <memory>
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+
+class URScriptInterface : public rclcpp::Node
+{
+public:
+  URScriptInterface()
+    : Node("urscript_interface")
+    , m_script_sub(this->create_subscription<std_msgs::msg::String>(
+          "~/script_command", 1, [this](const std_msgs::msg::String::SharedPtr msg) {
+            auto program_with_newline = msg->data + '\n';
+
+            RCLCPP_INFO_STREAM(this->get_logger(), program_with_newline);
+
+            size_t len = program_with_newline.size();
+            const auto* data = reinterpret_cast<const uint8_t*>(program_with_newline.c_str());
+            size_t written;
+
+            if (m_secondary_stream->write(data, len, written)) {
+              URCL_LOG_INFO("Sent program to robot:\n%s", program_with_newline.c_str());
+              return true;
+            }
+            URCL_LOG_ERROR("Could not send program to robot");
+            return false;
+          }))
+  {
+    this->declare_parameter("robot_ip", rclcpp::PARAMETER_STRING);
+    m_secondary_stream = std::make_unique<urcl::comm::URStream<urcl::primary_interface::PrimaryPackage>>(
+        this->get_parameter("robot_ip").as_string(), urcl::primary_interface::UR_SECONDARY_PORT);
+    m_secondary_stream->connect();
+  }
+  ~URScriptInterface() override = default;
+
+private:
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr m_script_sub;
+  std::unique_ptr<urcl::comm::URStream<urcl::primary_interface::PrimaryPackage>> m_secondary_stream;
+};
+
+int main(int argc, char** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_unique<URScriptInterface>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/ur_robot_driver/src/urscript_interface.cpp
+++ b/ur_robot_driver/src/urscript_interface.cpp
@@ -70,6 +70,12 @@ public:
     m_secondary_stream = std::make_unique<urcl::comm::URStream<urcl::primary_interface::PrimaryPackage>>(
         this->get_parameter("robot_ip").as_string(), urcl::primary_interface::UR_SECONDARY_PORT);
     m_secondary_stream->connect();
+
+    auto program_with_newline = std::string("textmsg(\"urscript_interface connected\")\n");
+    size_t len = program_with_newline.size();
+    const auto* data = reinterpret_cast<const uint8_t*>(program_with_newline.c_str());
+    size_t written;
+    m_secondary_stream->write(data, len, written);
   }
   ~URScriptInterface() override = default;
 

--- a/ur_robot_driver/test/urscript_interface.py
+++ b/ur_robot_driver/test/urscript_interface.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python
+# Copyright 2023, FZI Forschungszentrum Informatik
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import pytest
+import time
+import unittest
+
+import rclpy
+import rclpy.node
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    ExecuteProcess,
+    IncludeLaunchDescription,
+    RegisterEventHandler,
+)
+from launch.event_handlers import OnProcessExit
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.substitutions import FindPackagePrefix, FindPackageShare
+from launch_testing.actions import ReadyToTest
+from std_srvs.srv import Trigger
+from std_msgs.msg import String as StringMsg
+from ur_dashboard_msgs.srv import (
+    GetLoadedProgram,
+    GetProgramState,
+    GetRobotMode,
+    IsProgramRunning,
+    Load,
+)
+from ur_msgs.msg import IOStates
+
+
+ROBOT_IP = "192.168.56.101"
+TIMEOUT_WAIT_SERVICE = 10
+# If we download the docker image simultaneously to the tests, it can take quite some time until the
+# dashboard server is reachable and usable.
+TIMEOUT_WAIT_SERVICE_INITIAL = 120
+
+
+@pytest.mark.launch_test
+def generate_test_description():
+    declared_arguments = []
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "ur_type",
+            default_value="ur5e",
+            description="Type/series of used UR robot.",
+            choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e"],
+        )
+    )
+
+    ur_type = LaunchConfiguration("ur_type")
+
+    robot_driver = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [FindPackageShare("ur_robot_driver"), "launch", "ur_control.launch.py"]
+            )
+        ),
+        launch_arguments={
+            "robot_ip": "192.168.56.101",
+            "ur_type": ur_type,
+            "launch_rviz": "false",
+            "controller_spawner_timeout": str(TIMEOUT_WAIT_SERVICE_INITIAL),
+            "initial_joint_controller": "scaled_joint_trajectory_controller",
+            "headless_mode": "true",
+            "launch_dashboard_client": "false",
+            "start_joint_controller": "false",
+        }.items(),
+    )
+
+    ursim = ExecuteProcess(
+        cmd=[
+            PathJoinSubstitution(
+                [
+                    FindPackagePrefix("ur_robot_driver"),
+                    "lib",
+                    "ur_robot_driver",
+                    "start_ursim.sh",
+                ]
+            ),
+            " ",
+            "-m ",
+            ur_type,
+        ],
+        name="start_ursim",
+        output="screen",
+    )
+
+    wait_dashboard_server = ExecuteProcess(
+        cmd=[
+            PathJoinSubstitution(
+                [FindPackagePrefix("ur_robot_driver"), "bin", "wait_dashboard_server.sh"]
+            )
+        ],
+        name="wait_dashboard_server",
+        output="screen",
+    )
+
+    driver_starter = RegisterEventHandler(
+        OnProcessExit(target_action=wait_dashboard_server, on_exit=robot_driver)
+    )
+
+    return LaunchDescription(
+        declared_arguments + [ReadyToTest(), wait_dashboard_server, driver_starter, ursim]
+    )
+
+
+class URScriptInterfaceTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Initialize the ROS context
+        rclpy.init()
+        cls.node = rclpy.node.Node("urscript_interface_test")
+        cls.init_robot(cls)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Shutdown the ROS context
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def init_robot(self):
+        # We wait longer for the first client, as the robot is still starting up
+        power_on_client = waitForService(
+            self.node, "/dashboard_client/power_on", Trigger, timeout=TIMEOUT_WAIT_SERVICE_INITIAL
+        )
+
+        # Connect to all other expected services
+        dashboard_interfaces = {
+            "power_off": Trigger,
+            "brake_release": Trigger,
+            "unlock_protective_stop": Trigger,
+            "restart_safety": Trigger,
+            "get_robot_mode": GetRobotMode,
+            "load_installation": Load,
+            "load_program": Load,
+            "close_popup": Trigger,
+            "get_loaded_program": GetLoadedProgram,
+            "program_state": GetProgramState,
+            "program_running": IsProgramRunning,
+            "play": Trigger,
+            "stop": Trigger,
+        }
+        self.dashboard_clients = {
+            srv_name: waitForService(self.node, f"/dashboard_client/{srv_name}", srv_type)
+            for (srv_name, srv_type) in dashboard_interfaces.items()
+        }
+
+        # Add first client to dict
+        self.dashboard_clients["power_on"] = power_on_client
+
+        self.urscript_pub = self.node.create_publisher(
+            StringMsg, "/urscript_interface/script_command", 1
+        )
+
+    def setUp(self):
+        # Start robot
+        empty_req = Trigger.Request()
+        self.dashboard_call("power_on", empty_req)
+        self.dashboard_call("brake_release", empty_req)
+
+    def test_set_io(self):
+        """Test setting an IO using a direct program call."""
+        self.io_states_sub = self.node.create_subscription(
+            IOStates,
+            "/io_and_status_controller/io_states",
+            self.io_msg_cb,
+            rclpy.qos.qos_profile_system_default,
+        )
+
+        self.set_digout_checked(0, True)
+        time.sleep(1)
+        self.set_digout_checked(0, False)
+
+    def io_msg_cb(self, msg):
+        self.io_msg = msg
+
+    def set_digout_checked(self, pin, state):
+        self.io_msg = None
+
+        script_msg = StringMsg(data=f"set_digital_out({pin}, {state})")
+        self.urscript_pub.publish(script_msg)
+
+        self.check_pin_states([pin], [state])
+
+    def check_pin_states(self, pins, states):
+        pin_states = [not x for x in states]
+        end_time = time.time() + 5
+        while pin_states != states and time.time() < end_time:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+            if self.io_msg is not None:
+                for i, pin_id in enumerate(pins):
+                    pin_states[i] = self.io_msg.digital_out_states[pin_id].state
+        self.assertEqual(pin_states, states)
+
+    def test_multiline_script(self):
+        """Tests sending a multiline script as secondary program."""
+        self.io_msg = None
+        self.io_states_sub = self.node.create_subscription(
+            IOStates,
+            "/io_and_status_controller/io_states",
+            self.io_msg_cb,
+            rclpy.qos.qos_profile_system_default,
+        )
+
+        script_msg = StringMsg(
+            data="sec my_program():\n  set_digital_out(0, False)\n  set_digital_out(1,True)\nend"
+        )
+        self.urscript_pub.publish(script_msg)
+        self.check_pin_states([0, 1], [False, True])
+
+        script_msg = StringMsg(
+            data="sec my_program():\n  set_digital_out(0, True)\n  set_digital_out(1,False)\nend"
+        )
+        self.urscript_pub.publish(script_msg)
+        self.check_pin_states([0, 1], [True, False])
+
+    def dashboard_call(self, srv_name, request):
+        self.node.get_logger().info(f"Calling service '{srv_name}' with request {request}")
+        future = self.dashboard_clients[srv_name].call_async(request)
+        rclpy.spin_until_future_complete(self.node, future)
+        if future.result() is not None:
+            self.node.get_logger().info(f"Received result {future.result()}")
+            return future.result()
+        else:
+            raise Exception(f"Exception while calling service: {future.exception()}")
+
+
+def waitForService(node, srv_name, srv_type, timeout=TIMEOUT_WAIT_SERVICE):
+    client = node.create_client(srv_type, srv_name)
+    if client.wait_for_service(timeout) is False:
+        raise Exception(f"Could not reach service '{srv_name}' within timeout of {timeout}")
+
+    node.get_logger().info(f"Successfully connected to service '{srv_name}'")
+    return client

--- a/ur_robot_driver/test/urscript_interface.py
+++ b/ur_robot_driver/test/urscript_interface.py
@@ -170,12 +170,18 @@ class URScriptInterfaceTest(unittest.TestCase):
             "/dashboard_client/program_running": IsProgramRunning,
             "/dashboard_client/play": Trigger,
             "/dashboard_client/stop": Trigger,
-            "/controller_manager/list_controllers": ListControllers,
         }
         self.service_clients = {
             srv_name: waitForService(self.node, f"{srv_name}", srv_type)
             for (srv_name, srv_type) in dashboard_interfaces.items()
         }
+
+        self.service_clients["/controller_manager/list_controllers"] = waitForService(
+            self.node,
+            "/controller_manager/list_controllers",
+            ListControllers(),
+            timeout=TIMEOUT_WAIT_SERVICE_INITIAL,
+        )
 
         # Add first client to dict
         self.service_clients["/dashboard_client/power_on"] = power_on_client

--- a/ur_robot_driver/test/urscript_interface.py
+++ b/ur_robot_driver/test/urscript_interface.py
@@ -55,6 +55,7 @@ from ur_dashboard_msgs.srv import (
     Load,
 )
 from ur_msgs.msg import IOStates
+from controller_manager_msgs.srv import ListControllers
 
 
 ROBOT_IP = "192.168.56.101"
@@ -156,27 +157,28 @@ class URScriptInterfaceTest(unittest.TestCase):
 
         # Connect to all other expected services
         dashboard_interfaces = {
-            "power_off": Trigger,
-            "brake_release": Trigger,
-            "unlock_protective_stop": Trigger,
-            "restart_safety": Trigger,
-            "get_robot_mode": GetRobotMode,
-            "load_installation": Load,
-            "load_program": Load,
-            "close_popup": Trigger,
-            "get_loaded_program": GetLoadedProgram,
-            "program_state": GetProgramState,
-            "program_running": IsProgramRunning,
-            "play": Trigger,
-            "stop": Trigger,
+            "/dashboard_client/power_off": Trigger,
+            "/dashboard_client/brake_release": Trigger,
+            "/dashboard_client/unlock_protective_stop": Trigger,
+            "/dashboard_client/restart_safety": Trigger,
+            "/dashboard_client/get_robot_mode": GetRobotMode,
+            "/dashboard_client/load_installation": Load,
+            "/dashboard_client/load_program": Load,
+            "/dashboard_client/close_popup": Trigger,
+            "/dashboard_client/get_loaded_program": GetLoadedProgram,
+            "/dashboard_client/program_state": GetProgramState,
+            "/dashboard_client/program_running": IsProgramRunning,
+            "/dashboard_client/play": Trigger,
+            "/dashboard_client/stop": Trigger,
+            "/controller_manager/list_controllers": ListControllers,
         }
-        self.dashboard_clients = {
-            srv_name: waitForService(self.node, f"/dashboard_client/{srv_name}", srv_type)
+        self.service_clients = {
+            srv_name: waitForService(self.node, f"{srv_name}", srv_type)
             for (srv_name, srv_type) in dashboard_interfaces.items()
         }
 
         # Add first client to dict
-        self.dashboard_clients["power_on"] = power_on_client
+        self.service_clients["/dashboard_client/power_on"] = power_on_client
 
         self.urscript_pub = self.node.create_publisher(
             StringMsg, "/urscript_interface/script_command", 1
@@ -185,8 +187,19 @@ class URScriptInterfaceTest(unittest.TestCase):
     def setUp(self):
         # Start robot
         empty_req = Trigger.Request()
-        self.dashboard_call("power_on", empty_req)
-        self.dashboard_call("brake_release", empty_req)
+        self.call_service("/dashboard_client/power_on", empty_req)
+        self.call_service("/dashboard_client/brake_release", empty_req)
+
+        io_controller_running = False
+
+        while not io_controller_running:
+            time.sleep(1)
+            response = self.call_service(
+                "/controller_manager/list_controllers", ListControllers.Request()
+            )
+            for controller in response.controller:
+                if controller.name == "io_and_status_controller":
+                    io_controller_running = controller.state == "active"
 
     def test_set_io(self):
         """Test setting an IO using a direct program call."""
@@ -242,11 +255,12 @@ class URScriptInterfaceTest(unittest.TestCase):
             if self.io_msg is not None:
                 for i, pin_id in enumerate(pins):
                     pin_states[i] = self.io_msg.digital_out_states[pin_id].state
+        self.assertIsNotNone(self.io_msg, "Did not receive an IO state in requested time.")
         self.assertEqual(pin_states, states)
 
-    def dashboard_call(self, srv_name, request):
+    def call_service(self, srv_name, request):
         self.node.get_logger().info(f"Calling service '{srv_name}' with request {request}")
-        future = self.dashboard_clients[srv_name].call_async(request)
+        future = self.service_clients[srv_name].call_async(request)
         rclpy.spin_until_future_complete(self.node, future)
         if future.result() is not None:
             self.node.get_logger().info(f"Received result {future.result()}")


### PR DESCRIPTION
This PR adds a bare URScript interface using the `ur_client_library`. This should implement #387 and #251.

In this first version I did a 1to1 sending of the script code towards the robot. If the script code contains an error, it will simply not get executed.

This could get extended in the future, but that should be an easy non-intrusive extension that gets the job done in a lot of situations.