### PR TITLE
Change install instructions to install metapackage

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ that will behave almost exactly like the real robot.
       branches.
 2. Install the driver using
    ```
-   sudo apt-get install ros-${ROS_DISTRO}-ur-robot-driver
+   sudo apt-get install ros-${ROS_DISTRO}-ur
    ```
 
 ### Build from source


### PR DESCRIPTION
Before we were telling users to install the driver package only. However, it probably makes sense suggesting to install the ur meta package.

this is closing #734 