### PR TITLE
Port execution tests to launch_pytest

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -177,12 +177,9 @@ if(BUILD_TESTING)
   find_package(ur_description REQUIRED)
   find_package(ur_msgs REQUIRED)
   find_package(launch_testing_ament_cmake)
+  find_package(ament_cmake_pytest)
 
   if(${UR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS})
-    add_launch_test(test/dashboard_client.py
-      TIMEOUT
-        180
-    )
     add_launch_test(test/robot_driver.py
       TIMEOUT
         500
@@ -190,6 +187,12 @@ if(BUILD_TESTING)
     add_launch_test(test/urscript_interface.py
       TIMEOUT
         500
+    )
+    ament_add_pytest_test(dashboard_client
+      test/dashboard_client.py
+      ENV
+        "PYTEST_ADDOPTS=-s --log-cli-level=INFO"
+      TIMEOUT 180
     )
   endif()
 endif()

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -180,16 +180,18 @@ if(BUILD_TESTING)
   find_package(ament_cmake_pytest)
 
   if(${UR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS})
-    add_launch_test(test/robot_driver.py
-      TIMEOUT
-        500
-    )
     add_launch_test(test/urscript_interface.py
       TIMEOUT
         500
     )
     ament_add_pytest_test(dashboard_client
       test/dashboard_client.py
+      ENV
+        "PYTEST_ADDOPTS=-s --log-cli-level=INFO"
+      TIMEOUT 180
+    )
+    ament_add_pytest_test(robot_driver
+      test/robot_driver.py
       ENV
         "PYTEST_ADDOPTS=-s --log-cli-level=INFO"
       TIMEOUT 180

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -59,7 +59,9 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>docker.io</test_depend>
+  <test_depend>launch_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ur_robot_driver/test/conftest.py
+++ b/ur_robot_driver/test/conftest.py
@@ -1,0 +1,143 @@
+# Copyright 2023, FZI Forschungszentrum Informatik
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import logging
+
+import pytest
+import rclpy.node
+from std_srvs.srv import Trigger
+from ur_dashboard_msgs.srv import (
+    GetLoadedProgram,
+    GetProgramState,
+    GetRobotMode,
+    IsProgramRunning,
+    Load,
+)
+
+TIMEOUT_WAIT_SERVICE = 10
+# If we download the docker image simultaneously to the tests, it can take quite some time until the
+# dashboard server is reachable and usable.
+TIMEOUT_WAIT_SERVICE_INITIAL = 120
+
+
+def wait_for_service(node, srv_name, srv_type, timeout=TIMEOUT_WAIT_SERVICE):
+    client = node.create_client(srv_type, srv_name)
+
+    logging.info("Waiting for service '%s' with timeout %fs...", srv_name, timeout)
+    if client.wait_for_service(timeout) is False:
+        raise Exception(f"Could not reach service '{srv_name}' within timeout of {timeout}")
+    logging.info("  done")
+
+    return client
+
+
+@pytest.fixture(scope="module")
+def rclpy_init():
+    """
+    Initializes and finalizes rclpy.
+
+    This ensures that rclpy.init() has been called before, but is not called more than once.
+    """
+    logging.info("Initializing rclpy")
+    rclpy.init()
+
+    yield
+
+    logging.info("Shutting down rclpy")
+    rclpy.shutdown()
+
+
+@pytest.fixture()
+def node(request, rclpy_init):
+    """
+    Creates a node with a given name.
+
+    The name needs to be passed in as a parameter
+    """
+    logging.info("Creating node with name '%s'", request.param)
+    rclpy_node = rclpy.node.Node(request.param)
+
+    yield rclpy_node
+
+    logging.info("Destroying node '%s'", request.param)
+    rclpy_node.destroy_node()
+
+
+class DashboardClient:
+    def __init__(self, node, service_interfaces):
+        self._node = node
+        self._service_interfaces = service_interfaces
+
+    def call_service(self, name, request):
+        logging.info("Calling dashboard service '%s' with request: %s", name, request)
+
+        future = self._service_interfaces[name].call_async(request)
+        rclpy.spin_until_future_complete(self._node, future)
+
+        if future.result() is None:
+            raise Exception(f"Exception while calling service: {future.exception()}")
+
+        logging.info("  Received result: %s", future.result())
+        return future.result()
+
+
+@pytest.fixture()
+def dashboard_interface(node):
+    # We wait longer for the first client, as the robot is still starting up
+    power_on_client = wait_for_service(
+        node,
+        "/dashboard_client/power_on",
+        Trigger,
+        timeout=TIMEOUT_WAIT_SERVICE_INITIAL,
+    )
+
+    # Connect to all other expected services
+    dashboard_interfaces = {
+        "power_off": Trigger,
+        "brake_release": Trigger,
+        "unlock_protective_stop": Trigger,
+        "restart_safety": Trigger,
+        "get_robot_mode": GetRobotMode,
+        "load_installation": Load,
+        "load_program": Load,
+        "close_popup": Trigger,
+        "get_loaded_program": GetLoadedProgram,
+        "program_state": GetProgramState,
+        "program_running": IsProgramRunning,
+        "play": Trigger,
+        "stop": Trigger,
+    }
+
+    dashboard_clients = {
+        srv_name: wait_for_service(node, f"/dashboard_client/{srv_name}", srv_type)
+        for (srv_name, srv_type) in dashboard_interfaces.items()
+    }
+
+    # Add first client to dict
+    dashboard_clients["power_on"] = power_on_client
+
+    return DashboardClient(node, dashboard_clients)

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -26,29 +26,17 @@
 # CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
-
-
+import os
+import sys
 import time
-import unittest
 
 import pytest
-import rclpy
-from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.substitutions import FindPackagePrefix, FindPackageShare
-from launch_testing.actions import ReadyToTest
-from rclpy.node import Node
 from std_srvs.srv import Trigger
 from ur_dashboard_msgs.msg import RobotMode
-from ur_dashboard_msgs.srv import (
-    GetLoadedProgram,
-    GetProgramState,
-    GetRobotMode,
-    IsProgramRunning,
-    Load,
-)
+from ur_dashboard_msgs.srv import GetRobotMode
+
+sys.path.append(os.path.dirname(__file__))
+from robot_launch_descriptions import *  # noqa: E402, F403
 
 TIMEOUT_WAIT_SERVICE = 10
 # If we download the docker image simultaneously to the tests, it can take quite some time until the
@@ -56,164 +44,46 @@ TIMEOUT_WAIT_SERVICE = 10
 TIMEOUT_WAIT_SERVICE_INITIAL = 120
 
 
-@pytest.mark.launch_test
-def generate_test_description():
-    declared_arguments = []
-
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "ur_type",
-            default_value="ur5e",
-            description="Type/series of used UR robot.",
-            choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e"],
-        )
-    )
-
-    ur_type = LaunchConfiguration("ur_type")
-
-    dashboard_client = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            PathJoinSubstitution(
-                [
-                    FindPackageShare("ur_robot_driver"),
-                    "launch",
-                    "ur_dashboard_client.launch.py",
-                ]
-            )
-        ),
-        launch_arguments={
-            "robot_ip": "192.168.56.101",
-        }.items(),
-    )
-    ursim = ExecuteProcess(
-        cmd=[
-            PathJoinSubstitution(
-                [
-                    FindPackagePrefix("ur_robot_driver"),
-                    "lib",
-                    "ur_robot_driver",
-                    "start_ursim.sh",
-                ]
-            ),
-            " ",
-            "-m ",
-            ur_type,
-        ],
-        name="start_ursim",
-        output="screen",
-    )
-
-    return LaunchDescription(declared_arguments + [ReadyToTest(), dashboard_client, ursim])
-
-
-class DashboardClientTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        # Initialize the ROS context
-        rclpy.init()
-        cls.node = Node("dashboard_client_test")
-        cls.init_robot(cls)
-
-    @classmethod
-    def tearDownClass(cls):
-        # Shutdown the ROS context
-        cls.node.destroy_node()
-        rclpy.shutdown()
-
-    def init_robot(self):
-        # We wait longer for the first client, as the robot is still starting up
-        power_on_client = waitForService(
-            self.node, "/dashboard_client/power_on", Trigger, timeout=TIMEOUT_WAIT_SERVICE_INITIAL
-        )
-
-        # Connect to all other expected services
-        dashboard_interfaces = {
-            "power_off": Trigger,
-            "brake_release": Trigger,
-            "unlock_protective_stop": Trigger,
-            "restart_safety": Trigger,
-            "get_robot_mode": GetRobotMode,
-            "load_installation": Load,
-            "load_program": Load,
-            "close_popup": Trigger,
-            "get_loaded_program": GetLoadedProgram,
-            "program_state": GetProgramState,
-            "program_running": IsProgramRunning,
-            "play": Trigger,
-            "stop": Trigger,
-        }
-        self.dashboard_clients = {
-            srv_name: waitForService(self.node, f"/dashboard_client/{srv_name}", srv_type)
-            for (srv_name, srv_type) in dashboard_interfaces.items()
-        }
-
-        # Add first client to dict
-        self.dashboard_clients["power_on"] = power_on_client
-
-    #
-    # Test functions
-    #
-
-    def test_switch_on(self):
+@pytest.mark.launch(fixture=launch_dashboard_client)  # noqa: F405
+@pytest.mark.parametrize("node", [("dashboard_client_test")], indirect=True)
+class TestDashboardClient:
+    def test_switch_on(self, dashboard_interface):
         """Test power on a robot."""
         # Wait until the robot is booted completely
         end_time = time.time() + 10
         mode = RobotMode.DISCONNECTED
         while mode != RobotMode.POWER_OFF and time.time() < end_time:
             time.sleep(0.1)
-            result = self.call_dashboard_service("get_robot_mode", GetRobotMode.Request())
-            self.assertTrue(result.success)
+
+            result = dashboard_interface.call_service("get_robot_mode", GetRobotMode.Request())
+            assert result.success
             mode = result.robot_mode.mode
 
         # Power on robot
-        self.assertTrue(self.call_dashboard_service("power_on", Trigger.Request()).success)
+        assert dashboard_interface.call_service("power_on", Trigger.Request()).success
 
         # Wait until robot mode changes
         end_time = time.time() + 10
         mode = RobotMode.DISCONNECTED
         while mode not in (RobotMode.IDLE, RobotMode.RUNNING) and time.time() < end_time:
             time.sleep(0.1)
-            result = self.call_dashboard_service("get_robot_mode", GetRobotMode.Request())
-            self.assertTrue(result.success)
+
+            result = dashboard_interface.call_service("get_robot_mode", GetRobotMode.Request())
+            assert result.success
             mode = result.robot_mode.mode
 
-        self.assertIn(mode, (RobotMode.IDLE, RobotMode.RUNNING))
+        assert mode in (RobotMode.IDLE, RobotMode.RUNNING)
 
         # Release robot brakes
-        self.assertTrue(self.call_dashboard_service("brake_release", Trigger.Request()).success)
+        assert dashboard_interface.call_service("brake_release", Trigger.Request()).success
 
         # Wait until robot mode is RUNNING
         end_time = time.time() + 10
         mode = RobotMode.DISCONNECTED
         while mode != RobotMode.RUNNING and time.time() < end_time:
             time.sleep(0.1)
-            result = self.call_dashboard_service("get_robot_mode", GetRobotMode.Request())
-            self.assertTrue(result.success)
+            result = dashboard_interface.call_service("get_robot_mode", GetRobotMode.Request())
+            assert result.success
             mode = result.robot_mode.mode
 
-        self.assertEqual(mode, RobotMode.RUNNING)
-
-    #
-    # Utility functions
-    #
-
-    def call_dashboard_service(self, srv_name, request):
-        self.node.get_logger().info(
-            f"Calling dashboard service '{srv_name}' with request {request}"
-        )
-        future = self.dashboard_clients[srv_name].call_async(request)
-        rclpy.spin_until_future_complete(self.node, future)
-        if future.result() is not None:
-            self.node.get_logger().info(f"Received result {future.result()}")
-            return future.result()
-        else:
-            raise Exception(f"Exception while calling service: {future.exception()}")
-
-
-def waitForService(node, srv_name, srv_type, timeout=TIMEOUT_WAIT_SERVICE):
-    client = node.create_client(srv_type, srv_name)
-    if client.wait_for_service(timeout) is False:
-        raise Exception(f"Could not reach service '{srv_name}' within timeout of {timeout}")
-
-    node.get_logger().info(f"Successfully connected to service '{srv_name}'")
-    return client
+        assert mode == RobotMode.RUNNING

--- a/ur_robot_driver/test/robot_launch_descriptions.py
+++ b/ur_robot_driver/test/robot_launch_descriptions.py
@@ -1,0 +1,91 @@
+# Copyright 2023, FZI Forschungszentrum Informatik
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import launch_pytest
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_pytest.actions import ReadyToTest
+from launch_ros.substitutions import FindPackagePrefix, FindPackageShare
+
+
+@launch_pytest.fixture(scope="class")
+def launch_dashboard_client():
+    """
+    Start a robot arm in ursim and a dashboard client connected to it.
+
+    This is deliberately scoped at class level, as you might want to have tests that require
+    completely resetting the robot afterwards. This can be done by putting these into a separate
+    class.
+    """
+    declared_arguments = []
+
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "ur_type",
+            default_value="ur5e",
+            description="Type/series of used UR robot.",
+            choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e"],
+        )
+    )
+
+    ur_type = LaunchConfiguration("ur_type")
+
+    dashboard_client = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("ur_robot_driver"),
+                    "launch",
+                    "ur_dashboard_client.launch.py",
+                ]
+            )
+        ),
+        launch_arguments={
+            "robot_ip": "192.168.56.101",
+        }.items(),
+    )
+    ursim = ExecuteProcess(
+        cmd=[
+            PathJoinSubstitution(
+                [
+                    FindPackagePrefix("ur_robot_driver"),
+                    "lib",
+                    "ur_robot_driver",
+                    "start_ursim.sh",
+                ]
+            ),
+            " ",
+            "-m ",
+            ur_type,
+        ],
+        name="start_ursim",
+        output="screen",
+    )
+
+    return LaunchDescription(declared_arguments + [ReadyToTest(), dashboard_client, ursim])


### PR DESCRIPTION
Our tests currently have some redundant parts like launch descriptions, service interfaces and initialization code. Before working on more tests i think we should clean that up and make our current tests more maintainable in the process. This should result in the following tasks:
- [x] Move launch descriptions for just the dashboard client and the full robot driver to `robot_launch_descriptions` so they can be resued among all tests.
- [x] Move core rclpy (init, node) into fixtures to replace `unittest` initialization structure.
- [ ] Move the common robot interfaces (to dashboard client, controller manager, common controllers, ...) into fixtures.
- [ ] Port all tests to use these fixtures.

This also enables easily adding more paremetrization options (like testing all robot models for future moveit tests).

I decided to use `logging` for all test output instead of (as previously) using the node logger. This allows us to only show logging output from our tests or from the tested ROS nodes based on pytest arguments.

I am not quite happy with having to include `*` from `robot_launch_descriptions` in every test file, but i could not find a way to use these launch fixtures without this that did not result in `ScopeError`s. The tests also always show a warning `Warning: There is no current event loop` at the end for me that i don't quite understand yet, but the tests still seem to work fine for me.