### PR TITLE
Branch out for Iron

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,21 +7,18 @@ pull_request_rules:
       backport:
         branches:
           - humble
+      label:
+        add:
+          - humble
 
-  - name: Backport to galactic branch
+  - name: Backport to iron branch
     conditions:
       - base=main
-      - label=backport-galactic
+      - label=backport-iron
     actions:
       backport:
         branches:
-          - galactic
-
-  - name: Backport to foxy branch
-    conditions:
-      - base=main
-      - label=backport-foxy
-    actions:
-      backport:
-        branches:
-          - foxy
+          - iron
+      label:
+        add:
+          - iron


### PR DESCRIPTION
Since #739 effectively is a break in the user's API we should not forward the iron branch to this change. Hence, we need to branch out and add a mergify rule to make our life easier.

I left the iron workflows running in main PRs on purpose, as in fact iron and rolling are currently still fully compatible. 