### PR TITLE
Fix branches of upstream workspaces for semi-binary builds

### DIFF
--- a/Universal_Robots_ROS2_Driver-not-released.iron.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.iron.repos
@@ -4,7 +4,3 @@
 # Once Upstream packages are released and synced to the target distributions in the required
 # version, the entry in this file shall be removed again.
 repositories:
-  Universal_Robots_ROS2_Description:
-    type: git
-    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: ros2

--- a/Universal_Robots_ROS2_Driver.galactic.repos
+++ b/Universal_Robots_ROS2_Driver.galactic.repos
@@ -18,7 +18,7 @@ repositories:
   Universal_Robots_ROS2_Description:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: ros2
+    version: galactic
   ur_msgs:
     type: git
     url: https://github.com/ros-industrial/ur_msgs.git

--- a/Universal_Robots_ROS2_Driver.iron.repos
+++ b/Universal_Robots_ROS2_Driver.iron.repos
@@ -6,7 +6,7 @@ repositories:
   Universal_Robots_ROS2_Description:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: ros2
+    version: iron
   ur_msgs:
     type: git
     url: https://github.com/ros-industrial/ur_msgs.git
@@ -26,4 +26,4 @@ repositories:
   control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
-    version: humble
+    version: master

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -6,7 +6,7 @@ repositories:
   Universal_Robots_ROS2_Description:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: ros2
+    version: rolling
   ur_msgs:
     type: git
     url: https://github.com/ros-industrial/ur_msgs.git


### PR DESCRIPTION
Some branches were not correct anymore and removed description from binary build's upstream ws.