### PR TITLE
Set branch when cloning ROS2 Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ ROS2 Distro | Foxy  | Galactic | Rolling
 4. Pull relevant packages, install dependencies, compile, and source the workspace by using:
    ```
    cd $COLCON_WS
-   git clone https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git src/Universal_Robots_ROS2_Driver
+   git clone -b foxy-ursim https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git src/Universal_Robots_ROS2_Driver
    vcs import src --skip-existing --input src/Universal_Robots_ROS2_Driver/Universal_Robots_ROS2_Driver.repos
    rosdep install --ignore-src --from-paths src -y -r
    colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
Branch was missing on foxy-ursim readme