### PR TITLE
Fix set receive timeout

### DIFF
--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -269,7 +269,11 @@ bool DashboardClientROS::connect()
   tv.tv_sec = time_buffer;
   tv.tv_usec = 0;
   client_.setReceiveTimeout(tv);
-  return client_.connect();
+  bool success = client_.connect();
+  if (success) {
+    client_.setReceiveTimeout(tv);
+  }
+  return success;
 }
 
 bool DashboardClientROS::handleRunningQuery(const ur_dashboard_msgs::srv::IsProgramRunning::Request::SharedPtr req,


### PR DESCRIPTION
The receive timeout is overwritten in client library's connect function.
This fix sets the configured timeout after a successful connect. 

This PR refers to the issue [#761](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/761)