### PR TITLE
CI: Add labels from backports to target PR, not the original PR

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,8 +7,7 @@ pull_request_rules:
       backport:
         branches:
           - humble
-      label:
-        add:
+        labels:
           - humble
 
   - name: Backport to iron branch
@@ -19,6 +18,5 @@ pull_request_rules:
       backport:
         branches:
           - iron
-      label:
-        add:
+        labels:
           - iron


### PR DESCRIPTION
I've configured that wrong in the past. Looking at the [docs](https://docs.mergify.com/actions/backport/) this should be the correct settings.