### PR TITLE
Do not start urscipt_interface when using mock hardware

### DIFF
--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -256,6 +256,7 @@ def launch_setup(context, *args, **kwargs):
         executable="urscript_interface",
         parameters=[{"robot_ip": robot_ip}],
         output="screen",
+        condition=UnlessCondition(use_mock_hardware),
     )
 
     controller_stopper_node = Node(


### PR DESCRIPTION
As the urscript_interface tries to establish a connection to a robot we should not attempt to start it when use_mock_hardware is set to true.

Since the startup will not fail but simply block forever, I did not add a failing test beforehand. 