### PR TITLE
Add test reports

### DIFF
--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -51,3 +51,10 @@ jobs:
           ROS_DISTRO: ${{ inputs.ros_distro }}
           ROS_REPO: ${{ inputs.ros_repo }}
           CMAKE_ARGS: -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON
+          BASEDIR: ${{ github.workspace }}/.build
+      - name: Publish Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: |
+            ${{ github.workspace }}/.build/target_ws/build/**/test_results/**/*.xml


### PR DESCRIPTION
Add a test report stage to the ICI. This should get a summary of our tests to the status page and show failed tests in PRs directly. Also, with this we will get statistics about flaky tests (if there are).