### PR TITLE
remove use_mock_hardware from moveit launchfile 

### DIFF
--- a/ur_moveit_config/config/controllers.yaml
+++ b/ur_moveit_config/config/controllers.yaml
@@ -1,10 +1,24 @@
 controller_names:
   - scaled_joint_trajectory_controller
+  - joint_trajectory_controller
 
 scaled_joint_trajectory_controller:
   action_ns: follow_joint_trajectory
   type: FollowJointTrajectory
-  default: true
+  default: false
+  joints:
+    - shoulder_pan_joint
+    - shoulder_lift_joint
+    - elbow_joint
+    - wrist_1_joint
+    - wrist_2_joint
+    - wrist_3_joint
+
+
+joint_trajectory_controller:
+  action_ns: follow_joint_trajectory
+  type: FollowJointTrajectory
+  default: false
   joints:
     - shoulder_pan_joint
     - shoulder_lift_joint

--- a/ur_moveit_config/config/controllers.yaml
+++ b/ur_moveit_config/config/controllers.yaml
@@ -1,25 +1,10 @@
 controller_names:
   - scaled_joint_trajectory_controller
-  - joint_trajectory_controller
-
 
 scaled_joint_trajectory_controller:
   action_ns: follow_joint_trajectory
   type: FollowJointTrajectory
   default: true
-  joints:
-    - shoulder_pan_joint
-    - shoulder_lift_joint
-    - elbow_joint
-    - wrist_1_joint
-    - wrist_2_joint
-    - wrist_3_joint
-
-
-joint_trajectory_controller:
-  action_ns: follow_joint_trajectory
-  type: FollowJointTrajectory
-  default: false
   joints:
     - shoulder_pan_joint
     - shoulder_lift_joint

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -166,7 +166,7 @@ def launch_setup(context, *args, **kwargs):
     servo_node = Node(
         package="moveit_servo",
         condition=IfCondition(launch_servo),
-        executable="servo_node",
+        executable="servo_node_main",
         parameters=[
             servo_params,
             robot_description_semantic,

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -44,7 +44,6 @@ from launch.substitutions import Command, FindExecutable, LaunchConfiguration, P
 def launch_setup(context, *args, **kwargs):
     # Initialize Arguments
     ur_type = LaunchConfiguration("ur_type")
-    use_mock_hardware = LaunchConfiguration("use_mock_hardware")
     safety_limits = LaunchConfiguration("safety_limits")
     safety_pos_margin = LaunchConfiguration("safety_pos_margin")
     safety_k_position = LaunchConfiguration("safety_k_position")
@@ -166,11 +165,6 @@ def launch_setup(context, *args, **kwargs):
 
     # Trajectory Execution Configuration
     controllers_yaml = load_yaml("ur_moveit_config", "config/controllers.yaml")
-    # the scaled_joint_trajectory_controller does not work on mock hardware
-    change_controllers = context.perform_substitution(use_mock_hardware)
-    if change_controllers == "true":
-        controllers_yaml["scaled_joint_trajectory_controller"]["default"] = False
-        controllers_yaml["joint_trajectory_controller"]["default"] = True
 
     moveit_controllers = {
         "moveit_simple_controller_manager": controllers_yaml,
@@ -264,13 +258,6 @@ def generate_launch_description():
             "ur_type",
             description="Type/series of used UR robot.",
             choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e", "ur20"],
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "use_mock_hardware",
-            default_value="false",
-            description="Indicate whether robot is running with mock hardware mirroring command to its states.",
         )
     )
     declared_arguments.append(

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -44,6 +44,7 @@ from launch.substitutions import Command, FindExecutable, LaunchConfiguration, P
 def launch_setup(context, *args, **kwargs):
     # Initialize Arguments
     ur_type = LaunchConfiguration("ur_type")
+    initial_joint_controller = LaunchConfiguration("initial_joint_controller")
     # General arguments
     moveit_config_package = LaunchConfiguration("moveit_config_package")
     moveit_joint_limits_file = LaunchConfiguration("moveit_joint_limits_file")
@@ -53,7 +54,6 @@ def launch_setup(context, *args, **kwargs):
     use_sim_time = LaunchConfiguration("use_sim_time")
     launch_rviz = LaunchConfiguration("launch_rviz")
     launch_servo = LaunchConfiguration("launch_servo")
-
     # MoveIt Configuration
     robot_description_semantic_content = Command(
         [
@@ -97,6 +97,8 @@ def launch_setup(context, *args, **kwargs):
 
     # Trajectory Execution Configuration
     controllers_yaml = load_yaml("ur_moveit_config", "config/controllers.yaml")
+    initial_controller = context.perform_substitution(initial_joint_controller)
+    controllers_yaml[initial_controller]["default"] = True
 
     moveit_controllers = {
         "moveit_simple_controller_manager": controllers_yaml,
@@ -109,7 +111,6 @@ def launch_setup(context, *args, **kwargs):
         "trajectory_execution.allowed_goal_duration_margin": 0.5,
         "trajectory_execution.allowed_start_tolerance": 0.01,
     }
-
     planning_scene_monitor_parameters = {
         "publish_planning_scene": True,
         "publish_geometry_updates": True,
@@ -187,6 +188,14 @@ def generate_launch_description():
             "ur_type",
             description="Type/series of used UR robot.",
             choices=["ur3", "ur3e", "ur5", "ur5e", "ur10", "ur10e", "ur16e", "ur20"],
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "initial_joint_controller",
+            default_value="scaled_joint_trajectory_controller",
+            description="Initial controller used by MoveIt!.",
+            choices=["scaled_joint_trajectory_controller", "joint_trajectory_controller"],
         )
     )
     declared_arguments.append(

--- a/ur_moveit_config/srdf/ur.srdf.xacro
+++ b/ur_moveit_config/srdf/ur.srdf.xacro
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <robot xmlns:xacro="http://wiki.ros.org/xacro" name="$(arg name)">
 
-  <!-- robot name parameter -->
-  <xacro:arg name="name" default="ur"/>
   <!-- parameters -->
   <xacro:arg name="prefix" default="" />
 
   <xacro:include filename="$(find ur_moveit_config)/srdf/ur_macro.srdf.xacro"/>
 
-  <xacro:ur_srdf name="$(arg name)" prefix="$(arg prefix)"/>
+  <xacro:ur_srdf prefix="$(arg prefix)"/>
 
 </robot>

--- a/ur_moveit_config/srdf/ur_macro.srdf.xacro
+++ b/ur_moveit_config/srdf/ur_macro.srdf.xacro
@@ -4,17 +4,17 @@
     This is a format for representing semantic information about the robot structure.
     A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
 -->
-  <xacro:macro name="ur_srdf" params="name prefix">
+  <xacro:macro name="ur_srdf" params="prefix">
     <!--GROUPS - Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
     <!--LINKS - When a link is specified, the parent joint of that link (if it exists) is automatically included-->
     <!--JOINTS - When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
     <!--CHAINS - When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS - Groups can also be formed by referencing to already defined group names-->
-    <group name="${prefix}${name}_manipulator">
+    <group name="${prefix}ur_manipulator">
       <chain base_link="${prefix}base_link" tip_link="${prefix}tool0" />
     </group>
     <!--GROUP STATES - Purpose - Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
-    <group_state name="${prefix}home" group="${prefix}${name}_manipulator">
+    <group_state name="${prefix}home" group="${prefix}ur_manipulator">
       <joint name="${prefix}elbow_joint" value="0" />
       <joint name="${prefix}shoulder_lift_joint" value="-1.5707" />
       <joint name="${prefix}shoulder_pan_joint" value="0" />
@@ -22,7 +22,7 @@
       <joint name="${prefix}wrist_2_joint" value="0" />
       <joint name="${prefix}wrist_3_joint" value="0" />
     </group_state>
-    <group_state name="${prefix}up" group="${prefix}${name}_manipulator">
+    <group_state name="${prefix}up" group="${prefix}ur_manipulator">
       <joint name="${prefix}elbow_joint" value="0" />
       <joint name="${prefix}shoulder_lift_joint" value="-1.5707" />
       <joint name="${prefix}shoulder_pan_joint" value="0" />
@@ -30,7 +30,7 @@
       <joint name="${prefix}wrist_2_joint" value="0" />
       <joint name="${prefix}wrist_3_joint" value="0" />
     </group_state>
-    <group_state name="${prefix}test_configuration" group="${prefix}${name}_manipulator">
+    <group_state name="${prefix}test_configuration" group="${prefix}ur_manipulator">
       <joint name="${prefix}elbow_joint" value="1.4" />
       <joint name="${prefix}shoulder_lift_joint" value="-1.62" />
       <joint name="${prefix}shoulder_pan_joint" value="1.54" />

--- a/ur_robot_driver/doc/usage.rst
+++ b/ur_robot_driver/doc/usage.rst
@@ -73,7 +73,7 @@ outside of this driver's scope.
    * - mode
      - available controllers
    * - mock_hardware
-     - :raw-html-m2r:`<ul><li>joint_trajectory_controller</li><li>forward_velocity_controller</li><li>forward_position_controller</li></ul>`
+     - :raw-html-m2r:`<ul><li>joint_trajectory_controller</li><li>scaled_joint_trajectory_controller </li><li>forward_velocity_controller</li><li>forward_position_controller</li></ul>`
    * - real hardware / URSim
      - :raw-html-m2r:`<ul><li>joint_trajectory_controller</li><li>scaled_joint_trajectory_controller </li><li>forward_velocity_controller</li><li>forward_position_controller</li></ul>`
 
@@ -194,14 +194,18 @@ robot as explained `here <https://moveit.picknik.ai/galactic/doc/tutorials/quick
 Mock hardware
 ^^^^^^^^^^^^^
 
-Currently, the ``scaled_joint_trajectory_controller`` does not work with ros2_control mock_hardware. There is an
-`upstream Merge-Request <https://github.com/ros-controls/ros2_control/pull/822>`_ pending to fix that. Until this is merged and released, you'll have to fallback to the ``joint_trajectory_controller`` by passing ``initial_controller:=joint_trajectory_controller`` to the driver's startup. Also, you'll have to tell MoveIt! that you're using mock_hardware as it then has to map to the other controller:
+To test the driver on mock hardware with the example MoveIt-setup, first start the driver as described
+`above <#start-hardware-simulator-or-mockup>`_.
 
 .. code-block::
 
-   ros2 launch ur_robot_driver ur_control.launch.py ur_type:=ur5e robot_ip:=yyy.yyy.yyy.yyy use_mock_hardware:=true launch_rviz:=false initial_joint_controller:=joint_trajectory_controller
+   ros2 launch ur_robot_driver ur_control.launch.py ur_type:=ur5e robot_ip:=yyy.yyy.yyy.yyy use_mock_hardware:=true launch_rviz:=false
    # and in another shell
-   ros2 launch ur_moveit_config ur_moveit.launch.py ur_type:=ur5e launch_rviz:=true use_mock_hardware:=true
+   ros2 launch ur_moveit_config ur_moveit.launch.py ur_type:=ur5e launch_rviz:=true
+
+Now you should be able to use the MoveIt Plugin in rviz2 to plan and execute trajectories with the
+robot as explained `here <https://moveit.picknik.ai/galactic/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html>`_.
+
 
 Robot frames
 ------------

--- a/ur_robot_driver/doc/usage.rst
+++ b/ur_robot_driver/doc/usage.rst
@@ -204,7 +204,7 @@ To test the driver on mock hardware with the example MoveIt-setup, first start t
    ros2 launch ur_moveit_config ur_moveit.launch.py ur_type:=ur5e launch_rviz:=true
 
 Now you should be able to use the MoveIt Plugin in rviz2 to plan and execute trajectories with the
-robot as explained `here <https://moveit.picknik.ai/galactic/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html>`_.
+robot as explained `in the MoveIt! documentation <https://moveit.picknik.ai/galactic/doc/tutorials/quickstart_in_rviz/quickstart_in_rviz_tutorial.html>`_.
 
 
 Robot frames


### PR DESCRIPTION
The scaled JTC can be used on fake hardware as well. Therefore, there is no real reason for keeping the use_mock_hardware argument in the MoveIt launch file.