### PR TITLE
moveit_servo package executabe name has changed

### DIFF
--- a/ur_moveit_config/config/ur_servo.yaml
+++ b/ur_moveit_config/config/ur_servo.yaml
@@ -40,7 +40,7 @@ move_group_name:  ur_manipulator  # Often 'manipulator' or 'arm'
 planning_frame: base_link  # The MoveIt planning frame. Often 'base_link' or 'world'
 
 ## Other frames
-ee_frame_name: tool0  # The name of the end effector link, used to return the EE pose
+ee_frame: tool0  # The name of the end effector link, used to return the EE pose
 robot_link_command_frame:  tool0  # commands must be given in the frame of a robot link. Usually either the base or end effector
 
 ## Stopping behaviour

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -242,7 +242,7 @@ def launch_setup(context, *args, **kwargs):
     servo_node = Node(
         package="moveit_servo",
         condition=IfCondition(launch_servo),
-        executable="servo_node_main",
+        executable="servo_node",
         parameters=[
             servo_params,
             robot_description,


### PR DESCRIPTION
The moveit_servo package executable 'servo_node_main' was renamed to 'servo_node'. 