### PR TITLE
Publish controller flange frame

### DIFF
--- a/ur_controllers/CMakeLists.txt
+++ b/ur_controllers/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(angles REQUIRED)
 find_package(controller_interface REQUIRED)
+find_package(hardware_interface REQUIRED)
 find_package(joint_trajectory_controller REQUIRED)
 find_package(lifecycle_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
@@ -16,6 +17,8 @@ find_package(rcutils REQUIRED)
 find_package(realtime_tools REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_msgs REQUIRED)
 find_package(ur_dashboard_msgs REQUIRED)
 find_package(ur_msgs REQUIRED)
 find_package(generate_parameter_library REQUIRED)
@@ -23,6 +26,7 @@ find_package(generate_parameter_library REQUIRED)
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   angles
   controller_interface
+  hardware_interface
   joint_trajectory_controller
   lifecycle_msgs
   pluginlib
@@ -31,6 +35,8 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   realtime_tools
   std_msgs
   std_srvs
+  tf2_geometry_msgs
+  tf2_msgs
   ur_dashboard_msgs
   ur_msgs
   generate_parameter_library
@@ -54,7 +60,13 @@ generate_parameter_library(
   src/scaled_joint_trajectory_controller_parameters.yaml
 )
 
+generate_parameter_library(
+  pose_broadcaster_parameters
+  src/pose_broadcaster_parameters.yaml
+)
+
 add_library(${PROJECT_NAME} SHARED
+  src/pose_broadcaster.cpp
   src/scaled_joint_trajectory_controller.cpp
   src/speed_scaling_state_broadcaster.cpp
   src/gpio_controller.cpp)
@@ -64,8 +76,9 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 )
 target_link_libraries(${PROJECT_NAME}
   gpio_controller_parameters
-  speed_scaling_state_broadcaster_parameters
+  pose_broadcaster_parameters
   scaled_joint_trajectory_controller_parameters
+  speed_scaling_state_broadcaster_parameters
 )
 ament_target_dependencies(${PROJECT_NAME}
   ${THIS_PACKAGE_INCLUDE_DEPENDS}

--- a/ur_controllers/controller_plugins.xml
+++ b/ur_controllers/controller_plugins.xml
@@ -14,4 +14,9 @@
       This controller publishes the Tool IO.
     </description>
   </class>
+  <class name="ur_controllers/PoseBroadcaster" type="ur_controllers::PoseBroadcaster" base_class_type="controller_interface::ControllerInterface">
+    <description>
+      This controller publishes a tf2 message.
+    </description>
+  </class>
 </library>

--- a/ur_controllers/include/ur_controllers/pose_broadcaster.hpp
+++ b/ur_controllers/include/ur_controllers/pose_broadcaster.hpp
@@ -1,0 +1,84 @@
+// Copyright 2023, FZI Forschungszentrum Informatik
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner <exner@fzi.de>
+ * \date    2023-09-11
+ *
+ */
+//----------------------------------------------------------------------
+
+#ifndef UR_CONTROLLERS__POSE_BROADCASTER_HPP
+#define UR_CONTROLLERS__POSE_BROADCASTER_HPP
+
+#include "geometry_msgs/msg/pose.hpp"
+#include "pose_broadcaster_parameters.hpp"
+#include "tf2_msgs/msg/tf_message.hpp"
+
+#include <controller_interface/controller_interface.hpp>
+#include <realtime_tools/realtime_publisher.h>
+#include <ur_controllers/sc_pose.hpp>
+#include <tf2_msgs/msg/tf_message.hpp>
+
+namespace ur_controllers
+{
+class PoseBroadcaster : public controller_interface::ControllerInterface
+{
+public:
+  PoseBroadcaster();
+  virtual ~PoseBroadcaster() = default;
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  controller_interface::return_type update(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+
+  controller_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
+
+  controller_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
+
+  controller_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+
+  controller_interface::CallbackReturn on_init() override;
+
+private:
+  std::unique_ptr<ur_controllers::PoseComponent> pose_component_;
+  std::shared_ptr<pose_broadcaster::ParamListener> param_listener_;
+  pose_broadcaster::Params params_;
+
+  using StatePublisher = realtime_tools::RealtimePublisher<tf2_msgs::msg::TFMessage>;
+  rclcpp::Publisher<tf2_msgs::msg::TFMessage>::SharedPtr sensor_state_publisher_;
+  std::unique_ptr<StatePublisher> realtime_publisher_;
+
+  geometry_msgs::msg::Pose pose_;
+};
+}  // namespace ur_controllers
+
+#endif  // ifndef UR_CONTROLLERS__POSE_BROADCASTER_HPP

--- a/ur_controllers/include/ur_controllers/sc_pose.hpp
+++ b/ur_controllers/include/ur_controllers/sc_pose.hpp
@@ -1,0 +1,123 @@
+// Copyright 2023, FZI Forschungszentrum Informatik
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner <exner@fzi.de>
+ * \date    2023-09-11
+ *
+ */
+//----------------------------------------------------------------------
+
+#include <tf2/tf2/LinearMath/Quaternion.h>
+#ifndef UR_CONTROLLERS__SC_POSE_HPP_
+#include <geometry_msgs/msg/pose.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <limits>
+#include <string>
+#include <vector>
+
+#include <hardware_interface/loaned_state_interface.hpp>
+#include <semantic_components/semantic_component_interface.hpp>
+
+namespace ur_controllers
+{
+class PoseComponent : public semantic_components::SemanticComponentInterface<geometry_msgs::msg::Pose>
+{
+public:
+  explicit PoseComponent(const std::string& name) : SemanticComponentInterface(name, 6)
+  {
+    interface_names_.emplace_back(name_ + "/" + "x");
+    interface_names_.emplace_back(name_ + "/" + "y");
+    interface_names_.emplace_back(name_ + "/" + "z");
+    interface_names_.emplace_back(name_ + "/" + "rx");
+    interface_names_.emplace_back(name_ + "/" + "ry");
+    interface_names_.emplace_back(name_ + "/" + "rz");
+
+    std::fill(position_.begin(), position_.end(), std::numeric_limits<double>::quiet_NaN());
+    std::fill(orientation_.begin(), orientation_.end(), std::numeric_limits<double>::quiet_NaN());
+  }
+
+  virtual ~PoseComponent() = default;
+
+  /**
+   * Return Pose message with full pose, parent and child frame
+   *
+   * \return Pose from values;
+   */
+  bool get_values_as_message(geometry_msgs::msg::Pose& message)
+  {
+    get_position();
+    get_orientation();
+
+    std::cout << orientation_[0] << std::endl;
+
+    // update the message values
+    message.position.x = position_[0];
+    message.position.y = position_[1];
+    message.position.z = position_[2];
+
+    tf2::Quaternion q;
+    q.setEuler(orientation_[2], orientation_[1], orientation_[0]);
+
+    message.orientation.w = q.w();
+    message.orientation.x = q.x();
+    message.orientation.y = q.y();
+    message.orientation.z = q.z();
+
+    return true;
+  }
+
+protected:
+  std::array<double, 3> get_position()
+  {
+    size_t interface_counter = 0;
+    for (size_t i = 0; i < 3; ++i) {
+      position_[i] = state_interfaces_[interface_counter].get().get_value();
+      ++interface_counter;
+    }
+    return position_;
+  }
+  std::array<double, 3> get_orientation()
+  {
+    size_t interface_counter = 0;
+    for (size_t i = 3; i < 6; ++i) {
+      orientation_[i] = state_interfaces_[interface_counter].get().get_value();
+      ++interface_counter;
+    }
+    return orientation_;
+  }
+  std::array<double, 3> position_;
+  std::array<double, 3> orientation_;
+};
+
+}  // namespace ur_controllers
+#define UR_CONTROLLERS__SC_POSE_HPP_
+#endif  // ifndef UR_CONTROLLERS__SC_POSE_HPP_

--- a/ur_controllers/include/ur_controllers/sc_pose.hpp
+++ b/ur_controllers/include/ur_controllers/sc_pose.hpp
@@ -35,14 +35,16 @@
  */
 //----------------------------------------------------------------------
 
+#pragma once
+
 #include <tf2/tf2/LinearMath/Quaternion.h>
-#ifndef UR_CONTROLLERS__SC_POSE_HPP_
-#include <geometry_msgs/msg/pose.hpp>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <limits>
 #include <string>
 #include <vector>
+
+#include <geometry_msgs/msg/pose.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <hardware_interface/loaned_state_interface.hpp>
 #include <semantic_components/semantic_component_interface.hpp>
@@ -54,12 +56,13 @@ class PoseComponent : public semantic_components::SemanticComponentInterface<geo
 public:
   explicit PoseComponent(const std::string& name) : SemanticComponentInterface(name, 6)
   {
-    interface_names_.emplace_back(name_ + "/" + "x");
-    interface_names_.emplace_back(name_ + "/" + "y");
-    interface_names_.emplace_back(name_ + "/" + "z");
-    interface_names_.emplace_back(name_ + "/" + "rx");
-    interface_names_.emplace_back(name_ + "/" + "ry");
-    interface_names_.emplace_back(name_ + "/" + "rz");
+    interface_names_.emplace_back(name_ + "/" + "position.x");
+    interface_names_.emplace_back(name_ + "/" + "position.y");
+    interface_names_.emplace_back(name_ + "/" + "position.z");
+    interface_names_.emplace_back(name_ + "/" + "orientation.x");
+    interface_names_.emplace_back(name_ + "/" + "orientation.y");
+    interface_names_.emplace_back(name_ + "/" + "orientation.z");
+    interface_names_.emplace_back(name_ + "/" + "orientation.w");
 
     std::fill(position_.begin(), position_.end(), std::numeric_limits<double>::quiet_NaN());
     std::fill(orientation_.begin(), orientation_.end(), std::numeric_limits<double>::quiet_NaN());
@@ -77,20 +80,15 @@ public:
     get_position();
     get_orientation();
 
-    std::cout << orientation_[0] << std::endl;
-
     // update the message values
     message.position.x = position_[0];
     message.position.y = position_[1];
     message.position.z = position_[2];
 
-    tf2::Quaternion q;
-    q.setEuler(orientation_[2], orientation_[1], orientation_[0]);
-
-    message.orientation.w = q.w();
-    message.orientation.x = q.x();
-    message.orientation.y = q.y();
-    message.orientation.z = q.z();
+    message.orientation.x = orientation_[0];
+    message.orientation.y = orientation_[1];
+    message.orientation.z = orientation_[2];
+    message.orientation.w = orientation_[3];
 
     return true;
   }
@@ -105,19 +103,17 @@ protected:
     }
     return position_;
   }
-  std::array<double, 3> get_orientation()
+  std::array<double, 4> get_orientation()
   {
-    size_t interface_counter = 0;
-    for (size_t i = 3; i < 6; ++i) {
+    size_t interface_counter = 3;
+    for (size_t i = 0; i < 4; ++i) {
       orientation_[i] = state_interfaces_[interface_counter].get().get_value();
       ++interface_counter;
     }
     return orientation_;
   }
   std::array<double, 3> position_;
-  std::array<double, 3> orientation_;
+  std::array<double, 4> orientation_;
 };
 
 }  // namespace ur_controllers
-#define UR_CONTROLLERS__SC_POSE_HPP_
-#endif  // ifndef UR_CONTROLLERS__SC_POSE_HPP_

--- a/ur_controllers/package.xml
+++ b/ur_controllers/package.xml
@@ -22,6 +22,7 @@
 
   <depend>angles</depend>
   <depend>controller_interface</depend>
+  <depend>hardware_interface</depend>
   <depend>joint_trajectory_controller</depend>
   <depend>lifecycle_msgs</depend>
   <depend>pluginlib</depend>
@@ -30,6 +31,8 @@
   <depend>realtime_tools</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_msgs</depend>
   <depend>ur_dashboard_msgs</depend>
   <depend>ur_msgs</depend>
 

--- a/ur_controllers/src/pose_broadcaster.cpp
+++ b/ur_controllers/src/pose_broadcaster.cpp
@@ -1,0 +1,134 @@
+// Copyright 2023, FZI Forschungszentrum Informatik
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+//----------------------------------------------------------------------
+/*!\file
+ *
+ * \author  Felix Exner <exner@fzi.de>
+ * \date    2023-09-11
+ *
+ */
+//----------------------------------------------------------------------
+//
+#include "ur_controllers/pose_broadcaster.hpp"
+#include <rclcpp/logging.hpp>
+#include "tf2_msgs/msg/tf_message.hpp"
+
+namespace ur_controllers
+{
+
+PoseBroadcaster::PoseBroadcaster() : controller_interface::ControllerInterface()
+{
+}
+
+controller_interface::InterfaceConfiguration PoseBroadcaster::command_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration command_interfaces_config;
+  command_interfaces_config.type = controller_interface::interface_configuration_type::NONE;
+  return command_interfaces_config;
+}
+
+controller_interface::InterfaceConfiguration PoseBroadcaster::state_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration state_interfaces_config;
+  state_interfaces_config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  state_interfaces_config.names = pose_component_->get_state_interface_names();
+  return state_interfaces_config;
+}
+
+controller_interface::return_type PoseBroadcaster::update(const rclcpp::Time& time, const rclcpp::Duration& period)
+{
+  if (realtime_publisher_ && realtime_publisher_->trylock()) {
+    pose_component_->get_values_as_message(pose_);
+    realtime_publisher_->msg_.transforms[0].header.stamp = time;
+    realtime_publisher_->msg_.transforms[0].transform.translation.x = pose_.position.x;
+    realtime_publisher_->msg_.transforms[0].transform.translation.y = pose_.position.y;
+    realtime_publisher_->msg_.transforms[0].transform.translation.z = pose_.position.z;
+    realtime_publisher_->msg_.transforms[0].transform.rotation.w = pose_.orientation.w;
+    realtime_publisher_->msg_.transforms[0].transform.rotation.x = pose_.orientation.x;
+    realtime_publisher_->msg_.transforms[0].transform.rotation.y = pose_.orientation.y;
+    realtime_publisher_->msg_.transforms[0].transform.rotation.z = pose_.orientation.z;
+    realtime_publisher_->unlockAndPublish();
+  }
+
+  return controller_interface::return_type::OK;
+}
+
+controller_interface::CallbackReturn PoseBroadcaster::on_configure(const rclcpp_lifecycle::State& previous_state)
+{
+  try {
+    param_listener_ = std::make_shared<pose_broadcaster::ParamListener>(get_node());
+    params_ = param_listener_->get_params();
+  } catch (const std::exception& e) {
+    fprintf(stderr, "Exception thrown during configure stage with message: %s \n", e.what());
+    return controller_interface::CallbackReturn::ERROR;
+  }
+
+  pose_component_ = std::make_unique<ur_controllers::PoseComponent>(ur_controllers::PoseComponent(params_.sensor_name));
+
+  try {
+    // register sensor data publisher
+    sensor_state_publisher_ =
+        get_node()->create_publisher<tf2_msgs::msg::TFMessage>("/tf", rclcpp::SystemDefaultsQoS());
+    realtime_publisher_ = std::make_unique<StatePublisher>(sensor_state_publisher_);
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR(get_node()->get_logger(), "Could not create publisher: %s \n", e.what());
+    return controller_interface::CallbackReturn::ERROR;
+  }
+
+  realtime_publisher_->lock();
+  realtime_publisher_->msg_.transforms.resize(1);
+  realtime_publisher_->msg_.transforms[0].header.frame_id = params_.parent_frame_id;
+  realtime_publisher_->msg_.transforms[0].child_frame_id = params_.child_frame_id;
+  realtime_publisher_->unlock();
+
+  RCLCPP_DEBUG(get_node()->get_logger(), "configure successful");
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn PoseBroadcaster::on_activate(const rclcpp_lifecycle::State& previous_state)
+{
+  pose_component_->assign_loaned_state_interfaces(state_interfaces_);
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn PoseBroadcaster::on_deactivate(const rclcpp_lifecycle::State& previous_state)
+{
+  pose_component_->release_interfaces();
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn PoseBroadcaster::on_init()
+{
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+}  // namespace ur_controllers
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(ur_controllers::PoseBroadcaster, controller_interface::ControllerInterface)

--- a/ur_controllers/src/pose_broadcaster_parameters.yaml
+++ b/ur_controllers/src/pose_broadcaster_parameters.yaml
@@ -1,0 +1,16 @@
+pose_broadcaster:
+  sensor_name: {
+    type: string,
+    default_value: "tcp_pose",
+    description: "State interface used to encode the pose."
+  }
+  parent_frame_id: {
+    type: string,
+    default_value: "base",
+    description: "Parent frame id of the published transform."
+  }
+  child_frame_id: {
+    type: string,
+    default_value: "tool0_controller",
+    description: "Child frame id of the published transform."
+  }

--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -52,8 +52,8 @@ force_torque_sensor_broadcaster:
 
 tcp_pose_broadcaster:
   ros__parameters:
-    sensor_name: $(var tf_prefix)tcp_pose_sensor
-    child_frame_id: $(var tf_prefix)tool0_controller
+    sensor_name: $(var tf_prefix)flange_pose_sensor
+    child_frame_id: $(var tf_prefix)flange_controller
     parent_frame_id: $(var tf_prefix)base
 
 

--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -12,6 +12,9 @@ controller_manager:
     force_torque_sensor_broadcaster:
       type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
 
+    tcp_pose_broadcaster:
+      type: ur_controllers/PoseBroadcaster
+
     joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
@@ -46,6 +49,12 @@ force_torque_sensor_broadcaster:
       - torque.z
     frame_id: $(var tf_prefix)tool0
     topic_name: ft_data
+
+tcp_pose_broadcaster:
+  ros__parameters:
+    sensor_name: $(var tf_prefix)tcp_pose_sensor
+    child_frame_id: $(var tf_prefix)tool0_controller
+    parent_frame_id: $(var tf_prefix)base
 
 
 joint_trajectory_controller:

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -40,6 +40,8 @@
 #define UR_ROBOT_DRIVER__HARDWARE_INTERFACE_HPP_
 
 // System
+#include <tf2/LinearMath/Quaternion.h>
+#include <ur_client_library/types.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -127,6 +129,7 @@ protected:
   template <typename T, size_t N>
   void readBitsetData(const std::unique_ptr<urcl::rtde_interface::DataPackage>& data_pkg, const std::string& var_name,
                       std::bitset<N>& data);
+  tf2::Quaternion quaternionFromURPose(const urcl::vector6d_t& rotation_vec);
 
   void initAsyncIO();
   void checkAsyncIO();
@@ -142,6 +145,10 @@ protected:
   urcl::vector6d_t urcl_joint_efforts_;
   urcl::vector6d_t urcl_ft_sensor_measurements_;
   urcl::vector6d_t urcl_tcp_pose_;
+  urcl::vector6d_t urcl_tcp_target_pose_;
+  urcl::vector6d_t urcl_tcp_offset_;
+  urcl::vector3d_t urcl_flange_position_;
+  std::array<double, 4> urcl_flange_orientation_;
 
   bool packet_read_;
 

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -330,7 +330,7 @@ def launch_setup(context, *args, **kwargs):
         "io_and_status_controller",
         "speed_scaling_state_broadcaster",
         "force_torque_sensor_broadcaster",
-        # "tcp_pose_broadcaster"
+        "tcp_pose_broadcaster",
     ]
     controller_spawner_inactive_names = ["forward_position_controller"]
 

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -285,6 +285,7 @@ def launch_setup(context, *args, **kwargs):
                 "consistent_controllers": [
                     "io_and_status_controller",
                     "force_torque_sensor_broadcaster",
+                    "tcp_pose_broadcaster",
                     "joint_state_broadcaster",
                     "speed_scaling_state_broadcaster",
                 ]
@@ -329,6 +330,7 @@ def launch_setup(context, *args, **kwargs):
         "io_and_status_controller",
         "speed_scaling_state_broadcaster",
         "force_torque_sensor_broadcaster",
+        # "tcp_pose_broadcaster"
     ]
     controller_spawner_inactive_names = ["forward_position_controller"]
 

--- a/ur_robot_driver/resources/rtde_output_recipe.txt
+++ b/ur_robot_driver/resources/rtde_output_recipe.txt
@@ -6,6 +6,8 @@ target_speed_fraction
 runtime_state
 actual_TCP_force
 actual_TCP_pose
+target_TCP_pose
+tcp_offset
 actual_digital_input_bits
 actual_digital_output_bits
 standard_analog_input0


### PR DESCRIPTION
This PR adds publishing the controller's flange frame as suggested in #571.

It still needs some cleanup work as the code is currently far from being optimal in terms of memory allocation. Also, I'd like to add some tests and probably also want to move the pose_broadcaster directly to ros2_controllers.