### PR TITLE
ScaledJTC - Added support for setting speedscaling factor via topic

### DIFF
--- a/ur_controllers/include/ur_controllers/scaled_joint_trajectory_controller.hpp
+++ b/ur_controllers/include/ur_controllers/scaled_joint_trajectory_controller.hpp
@@ -45,11 +45,15 @@
 #include "rclcpp/duration.hpp"
 #include "scaled_joint_trajectory_controller_parameters.hpp"
 
+#include <std_msgs/msg/float64.hpp>
+
 namespace ur_controllers
 {
 class ScaledJointTrajectoryController : public joint_trajectory_controller::JointTrajectoryController
 {
 public:
+  using ScalingFactorMsg =  std_msgs::msg::Float64;
+
   ScaledJointTrajectoryController() = default;
   ~ScaledJointTrajectoryController() override = default;
 
@@ -73,11 +77,13 @@ protected:
   };
 
 private:
-  double scaling_factor_{};
+  double scaling_factor_{1.0};
   realtime_tools::RealtimeBuffer<TimeData> time_data_;
 
   std::shared_ptr<scaled_joint_trajectory_controller::ParamListener> scaled_param_listener_;
   scaled_joint_trajectory_controller::Params scaled_params_;
+
+  rclcpp::Subscription<ScalingFactorMsg>::SharedPtr scaling_factor_sub_;
 };
 }  // namespace ur_controllers
 

--- a/ur_controllers/include/ur_controllers/scaled_joint_trajectory_controller.hpp
+++ b/ur_controllers/include/ur_controllers/scaled_joint_trajectory_controller.hpp
@@ -52,7 +52,7 @@ namespace ur_controllers
 class ScaledJointTrajectoryController : public joint_trajectory_controller::JointTrajectoryController
 {
 public:
-  using ScalingFactorMsg =  std_msgs::msg::Float64;
+  using ScalingFactorMsg = std_msgs::msg::Float64;
 
   ScaledJointTrajectoryController() = default;
   ~ScaledJointTrajectoryController() override = default;
@@ -77,7 +77,7 @@ protected:
   };
 
 private:
-  double scaling_factor_{1.0};
+  double scaling_factor_{ 1.0 };
   realtime_tools::RealtimeBuffer<TimeData> time_data_;
 
   std::shared_ptr<scaled_joint_trajectory_controller::ParamListener> scaled_param_listener_;

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -58,7 +58,7 @@ controller_interface::InterfaceConfiguration ScaledJointTrajectoryController::st
 {
   controller_interface::InterfaceConfiguration conf;
   conf = JointTrajectoryController::state_interface_configuration();
-  if(!scaled_params_.use_speed_scaling_topic_instead)
+  if (!scaled_params_.use_speed_scaling_topic_instead)
     conf.names.push_back(scaled_params_.speed_scaling_interface_name);
 
   return conf;
@@ -66,12 +66,11 @@ controller_interface::InterfaceConfiguration ScaledJointTrajectoryController::st
 
 controller_interface::CallbackReturn ScaledJointTrajectoryController::on_activate(const rclcpp_lifecycle::State& state)
 {
-  if(scaled_params_.use_speed_scaling_topic_instead){
-    scaling_factor_sub_ = get_node()->create_subscription<ScalingFactorMsg>("~/speed_scaling_factor",10, [&](const ScalingFactorMsg& msg){
-      scaling_factor_ = std::clamp( msg.data/100.0, 0.0,1.0);
-    });
+  if (scaled_params_.use_speed_scaling_topic_instead) {
+    scaling_factor_sub_ = get_node()->create_subscription<ScalingFactorMsg>(
+        "~/speed_scaling_factor", 10,
+        [&](const ScalingFactorMsg& msg) { scaling_factor_ = std::clamp(msg.data / 100.0, 0.0, 1.0); });
   }
-
 
   TimeData time_data;
   time_data.time = get_node()->now();
@@ -83,13 +82,13 @@ controller_interface::CallbackReturn ScaledJointTrajectoryController::on_activat
 
 controller_interface::return_type ScaledJointTrajectoryController::update(const rclcpp::Time& time,
                                                                           const rclcpp::Duration& period)
-{ 
-  if(!scaled_params_.use_speed_scaling_topic_instead){
+{
+  if (!scaled_params_.use_speed_scaling_topic_instead) {
     if (state_interfaces_.back().get_name() == scaled_params_.speed_scaling_interface_name) {
       scaling_factor_ = state_interfaces_.back().get_value();
     } else {
       RCLCPP_ERROR(get_node()->get_logger(), "Speed scaling interface (%s) not found in hardware interface.",
-                  scaled_params_.speed_scaling_interface_name.c_str());
+                   scaled_params_.speed_scaling_interface_name.c_str());
     }
   }
 

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -67,8 +67,11 @@ controller_interface::InterfaceConfiguration ScaledJointTrajectoryController::st
 controller_interface::CallbackReturn ScaledJointTrajectoryController::on_activate(const rclcpp_lifecycle::State& state)
 {
   if (scaled_params_.use_speed_scaling_topic_instead) {
+    auto qos = rclcpp::QoS(10);
+    qos.transient_local();
+
     scaling_factor_sub_ = get_node()->create_subscription<ScalingFactorMsg>(
-        "~/speed_scaling_factor", 10,
+        scaled_params_.speed_scaling_topic_name, qos,
         [&](const ScalingFactorMsg& msg) { scaling_factor_ = std::clamp(msg.data / 100.0, 0.0, 1.0); });
   }
 

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -58,13 +58,21 @@ controller_interface::InterfaceConfiguration ScaledJointTrajectoryController::st
 {
   controller_interface::InterfaceConfiguration conf;
   conf = JointTrajectoryController::state_interface_configuration();
-  conf.names.push_back(scaled_params_.speed_scaling_interface_name);
+  if(!scaled_params_.use_speed_scaling_topic_instead)
+    conf.names.push_back(scaled_params_.speed_scaling_interface_name);
 
   return conf;
 }
 
 controller_interface::CallbackReturn ScaledJointTrajectoryController::on_activate(const rclcpp_lifecycle::State& state)
 {
+  if(scaled_params_.use_speed_scaling_topic_instead){
+    scaling_factor_sub_ = get_node()->create_subscription<ScalingFactorMsg>("~/speed_scaling_factor",10, [&](const ScalingFactorMsg& msg){
+      scaling_factor_ = std::clamp( msg.data/100.0, 0.0,1.0);
+    });
+  }
+
+
   TimeData time_data;
   time_data.time = get_node()->now();
   time_data.period = rclcpp::Duration::from_nanoseconds(0);
@@ -75,12 +83,14 @@ controller_interface::CallbackReturn ScaledJointTrajectoryController::on_activat
 
 controller_interface::return_type ScaledJointTrajectoryController::update(const rclcpp::Time& time,
                                                                           const rclcpp::Duration& period)
-{
-  if (state_interfaces_.back().get_name() == scaled_params_.speed_scaling_interface_name) {
-    scaling_factor_ = state_interfaces_.back().get_value();
-  } else {
-    RCLCPP_ERROR(get_node()->get_logger(), "Speed scaling interface (%s) not found in hardware interface.",
-                 scaled_params_.speed_scaling_interface_name.c_str());
+{ 
+  if(!scaled_params_.use_speed_scaling_topic_instead){
+    if (state_interfaces_.back().get_name() == scaled_params_.speed_scaling_interface_name) {
+      scaling_factor_ = state_interfaces_.back().get_value();
+    } else {
+      RCLCPP_ERROR(get_node()->get_logger(), "Speed scaling interface (%s) not found in hardware interface.",
+                  scaled_params_.speed_scaling_interface_name.c_str());
+    }
   }
 
   if (get_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {

--- a/ur_controllers/src/scaled_joint_trajectory_controller_parameters.yaml
+++ b/ur_controllers/src/scaled_joint_trajectory_controller_parameters.yaml
@@ -7,5 +7,10 @@ scaled_joint_trajectory_controller:
     use_speed_scaling_topic_instead: {
       type: bool,
       default_value: false,
-      description: "Instead of using the speed_scaling_interface_name listen on ~/speed_scaling_factor"
+      description: "Instead of using the speed_scaling_interface_name listen on <speed_scaling_topic_name>"
+    }
+    speed_scaling_topic_name: {
+      type: string,
+      default_value: "~/speed_scaling_factor",
+      description: "Topic name for the speed scaling factor (if enabled)"
     }

--- a/ur_controllers/src/scaled_joint_trajectory_controller_parameters.yaml
+++ b/ur_controllers/src/scaled_joint_trajectory_controller_parameters.yaml
@@ -4,3 +4,8 @@ scaled_joint_trajectory_controller:
       default_value: "speed_scaling/speed_scaling_factor",
       description: "Fully qualified name of the speed scaling interface name"
     }
+    use_speed_scaling_topic_instead: {
+      type: bool,
+      default_value: false,
+      description: "Instead of using the speed_scaling_interface_name listen on ~/speed_scaling_factor"
+    }


### PR DESCRIPTION
Hi,
this PR adds support for setting the speed scaling factor via `~/speed_scaling_factor`.

The behavior can be activated by specifying `use_speed_scaling_topic_instead` in the controller configuration. Not specifying or setting the variable to false will keep the default behavior. 

This feature allows using the controller in multi arm setups or for usage with different hardware which doesn't have any `speed_scaling state`. 

EDIT: Just saw that I based the PR on the iron branch. If I should rebase it on the main branch let me know

EDIT2: As an alternative we could expose it as a parameter which would make a bit more similar to the `cartesian controllers`

EDIT3: The topic can now be changed via the config file. This allows to have one speed_scaling_factor topic for multiple controllers. Default is still `~/speed_scaling_factor`. 
The topic is now transient_local.