### PR TITLE
fix move_group_node crash during initialization

### DIFF
--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -156,9 +156,18 @@ def launch_setup(context, *args, **kwargs):
     # Planning Configuration
     ompl_planning_pipeline_config = {
         "move_group": {
-            "planning_plugin": "ompl_interface/OMPLPlanner",
-            "request_adapters": """default_planner_request_adapters/AddTimeOptimalParameterization default_planner_request_adapters/FixWorkspaceBounds default_planner_request_adapters/FixStartStateBounds default_planner_request_adapters/FixStartStateCollision default_planner_request_adapters/FixStartStatePathConstraints""",
-            "start_state_max_bounds_error": 0.1,
+            "planning_plugins": ["ompl_interface/OMPLPlanner"],
+            "request_adapters": [
+                "default_planning_request_adapters/ResolveConstraintFrames",
+                "default_planning_request_adapters/ValidateWorkspaceBounds",
+                "default_planning_request_adapters/CheckStartStateBounds",
+                "default_planning_request_adapters/CheckStartStateCollision",
+            ],
+            "response_adapters": [
+                "default_planning_response_adapters/AddTimeOptimalParameterization",
+                "default_planning_response_adapters/ValidateSolution",
+                "default_planning_response_adapters/DisplayMotionPath",
+            ],
         }
     }
     ompl_planning_yaml = load_yaml("ur_moveit_config", "config/ompl_planning.yaml")


### PR DESCRIPTION
fix #903

Moveit2 recently refactored planning pipeline, we need to change the config file correspondingly. See https://github.com/ros-planning/moveit2/blob/1fb4041e690c64b847d2df1e844c8de148796c86/MIGRATION.md

- Change planning plugin to a list of plugins, according to the change introduced in 10/2023 in moveit rolling.
- Split request_adapters to request_adapters and response_adapters, according to the refactor of planning pipeline introduced in 10/2023 in moveit rolling.

I tested it locally with URSim. Planning and execution works well.