### PR TITLE
Switch to "use_fake_hardware" for UR20

### DIFF
--- a/ur_robot_driver/launch/ur20.launch.py
+++ b/ur_robot_driver/launch/ur20.launch.py
@@ -46,17 +46,17 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "use_mock_hardware",
+            "use_fake_hardware",
             default_value="false",
-            description="Start robot with mock hardware mirroring command to its states.",
+            description="Start robot with fake hardware mirroring command to its states.",
         )
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "mock_sensor_commands",
+            "fake_sensor_commands",
             default_value="false",
-            description="Enable mock command interfaces for sensors used for simple simulations. \
-            Used only if 'use_mock_hardware' parameter is true.",
+            description="Enable fake command interfaces for sensors used for simple simulations. \
+            Used only if 'use_fake_hardware' parameter is true.",
         )
     )
     declared_arguments.append(
@@ -82,8 +82,8 @@ def generate_launch_description():
 
     # Initialize Arguments
     robot_ip = LaunchConfiguration("robot_ip")
-    use_mock_hardware = LaunchConfiguration("use_mock_hardware")
-    mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
+    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
     initial_joint_controller = LaunchConfiguration("initial_joint_controller")
     activate_joint_controller = LaunchConfiguration("activate_joint_controller")
 
@@ -92,8 +92,8 @@ def generate_launch_description():
         launch_arguments={
             "ur_type": "ur20",
             "robot_ip": robot_ip,
-            "use_mock_hardware": use_mock_hardware,
-            "mock_sensor_commands": mock_sensor_commands,
+            "use_fake_hardware": use_fake_hardware,
+            "fake_sensor_commands": fake_sensor_commands,
             "initial_joint_controller": initial_joint_controller,
             "activate_joint_controller": activate_joint_controller,
         }.items(),


### PR DESCRIPTION
Currently the UR20 is the only one using "use_mock_hardware" and since the description pkg for humble still has "use_fake_hardware", it doesn't work launching it with the mock_hardware option. 
Maybe it's better to have fake_hardware also for the UR20 and in the future switch all the models together when fake_hardware can't be used anymore.

Also, the same goes for iron, so if this makes sense I will open a PR for the iron branch as well.  