### PR TITLE
do not start tool communication if using mock hardware

### DIFF
--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -260,7 +260,7 @@ def launch_setup(context, *args, **kwargs):
 
     tool_communication_node = Node(
         package="ur_robot_driver",
-        condition=IfCondition(use_tool_communication),
+        condition=IfCondition(use_tool_communication) and UnlessCondition(use_mock_hardware),
         executable="tool_communication.py",
         name="ur_tool_comm",
         output="screen",


### PR DESCRIPTION
the tool communication node is started without taking consideration of the `use_mock_hardware` flag, this adds it to the condition for starting, otherwise you'd see that when starting mock hardware:

```
[ur_ros2_control_node-1] [INFO] [1711293300.071767372] [io_and_status_controller]: Waiting for system interface to initialize...
[ur_ros2_control_node-1] [INFO] [1711293300.121983638] [io_and_status_controller]: Waiting for system interface to initialize...
[ur_ros2_control_node-1] [INFO] [1711293300.172223320] [io_and_status_controller]: Waiting for system interface to initialize...
...
```
