### PR TITLE
Remove dependency to docker.io

### DIFF
--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -51,3 +51,4 @@ jobs:
           ROS_DISTRO: ${{ inputs.ros_distro }}
           ROS_REPO: ${{ inputs.ros_repo }}
           CMAKE_ARGS: -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON
+          ADDITIONAL_DEBS: docker.io  # Needed for integration tests

--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -51,4 +51,4 @@ jobs:
           ROS_DISTRO: ${{ inputs.ros_distro }}
           ROS_REPO: ${{ inputs.ros_repo }}
           CMAKE_ARGS: -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON
-          ADDITIONAL_DEBS: docker.io  # Needed for integration tests
+          ADDITIONAL_DEBS: docker.io netcat-openbsd  # Needed for integration tests

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -59,7 +59,6 @@
   <exec_depend>velocity_controllers</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>docker.io</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
 
   <export>


### PR DESCRIPTION
The dependency was basically added since this is needed to spawn up ursim. However, the start_ursim script catches the case that no docker executable is available and the tests requiring it are behind a compile definition which is off by default.

So, in order to not install docker for users automatically, the dependency shall be removed.

As a side-effect this has always stopped us from releasing the package for RHEL.

This closes #769 
