### PR TITLE
Add servo node config to disable advertising /get_planning_scene

### DIFF
--- a/ur_moveit_config/config/ur_servo.yaml
+++ b/ur_moveit_config/config/ur_servo.yaml
@@ -32,6 +32,12 @@ publish_joint_accelerations: false
 ## Plugins for smoothing outgoing commands
 smoothing_filter_plugin_name: "online_signal_smoothing::ButterworthFilterPlugin"
 
+# If is_primary_planning_scene_monitor is set to true, the Servo server's PlanningScene advertises the /get_planning_scene service,
+# which other nodes can use as a source for information about the planning environment.
+# NOTE: If a different node in your system is responsible for the "primary" planning scene instance (e.g. the MoveGroup node),
+# then is_primary_planning_scene_monitor needs to be set to false.
+is_primary_planning_scene_monitor: false
+
 ## Incoming Joint State properties
 low_pass_filter_coeff: 10.0  # Larger --> trust the filtered data more, trust the measurements less.
 


### PR DESCRIPTION
Disables the servo node from advertising `/get_planning_scene`, which in the default launchfile, conflicts with `move_group`'s `/get_planning_scene`. See https://github.com/moveit/moveit2/issues/2731 for discussion.

Tested on a Humble branch.