### PR TITLE
Replace keepalive count

### DIFF
--- a/ur_robot_driver/doc/migration/jazzy.rst
+++ b/ur_robot_driver/doc/migration/jazzy.rst
@@ -1,0 +1,10 @@
+ur_robot_driver
+^^^^^^^^^^^^^^^
+
+keep_alive_count -> robot_receive_timeout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Doing real-time control with a robot requires the control pc to conform to certain timing
+constraints. For this ``keep_alive_count`` was used to estimate the tolerance that was given to the
+ROS controller in terms of multiples of 20 ms. Now the timeout is directly configured using the
+``robot_receive_timeout`` parameter of the hardware interface.

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -53,6 +53,7 @@
 
 // UR stuff
 #include "ur_client_library/ur/ur_driver.h"
+#include "ur_client_library/ur/robot_receive_timeout.h"
 #include "ur_robot_driver/dashboard_client_ros.hpp"
 #include "ur_dashboard_msgs/msg/robot_mode.hpp"
 
@@ -225,6 +226,8 @@ protected:
   std::shared_ptr<std::thread> async_thread_;
 
   std::atomic_bool rtde_comm_has_been_started_ = false;
+
+  urcl::RobotReceiveTimeout receive_timeout_ = urcl::RobotReceiveTimeout::millisec(20);
 };
 }  // namespace ur_robot_driver
 

--- a/ur_robot_driver/urdf/ur.ros2_control.xacro
+++ b/ur_robot_driver/urdf/ur.ros2_control.xacro
@@ -25,7 +25,7 @@
     script_command_port:=50004
     trajectory_port:=50003
     non_blocking_read:=true
-    keep_alive_count:=2
+    robot_receive_timeout:=0.04
     ">
 
     <xacro:property name="config_kinematics_parameters" value="${xacro.load_yaml(kinematics_parameters_file)}"/>
@@ -69,7 +69,7 @@
           <param name="tool_tx_idle_chars">${tool_tx_idle_chars}</param>
           <param name="tool_device_name">${tool_device_name}</param>
           <param name="tool_tcp_port">${tool_tcp_port}</param>
-          <param name="keep_alive_count">${keep_alive_count}</param>
+          <param name="robot_receive_timeout">${robot_receive_timeout}</param>
         </xacro:unless>
       </hardware>
 


### PR DESCRIPTION
The `keepalive_count` has been deprecated in the ur_client_library for quite some time now. This PR removes it also from the driver and replaces it by `robot_receive_timeout`.

Note: This cannot be directly backported, since for iron and humble we need to do it backwards-compatible. I will provide a separate PR for this.