### PR TITLE
Remove extra spaces from start_ursim statement in tests

### DIFF
--- a/ur_robot_driver/test/test_common.py
+++ b/ur_robot_driver/test/test_common.py
@@ -273,8 +273,7 @@ def _ursim_action():
                     "start_ursim.sh",
                 ]
             ),
-            " ",
-            "-m ",
+            "-m",
             ur_type,
         ],
         name="start_ursim",


### PR DESCRIPTION
With those extra spaces the input isn't correctly parsed.

This is basically why the tests in #1009 are failing as that particular version of the script in the client library fails on a non-given model.