### PR TITLE
Also install srdf folder

### DIFF
--- a/ur_moveit_config/CMakeLists.txt
+++ b/ur_moveit_config/CMakeLists.txt
@@ -6,6 +6,6 @@ find_package(ament_cmake REQUIRED)
 ament_package()
 
 install(
-  DIRECTORY config launch
+  DIRECTORY config launch srdf
   DESTINATION share/${PROJECT_NAME}
 )


### PR DESCRIPTION
Since we use the srdf from that folder, we should also install that.

This was broken in #998.