### PR TITLE
Add sleep between controller stopper's controller queries

### DIFF
--- a/ur_robot_driver/src/controller_stopper.cpp
+++ b/ur_robot_driver/src/controller_stopper.cpp
@@ -42,6 +42,8 @@
 #include <string>
 #include <vector>
 
+#include <rclcpp/utilities.hpp>
+
 #include "ur_robot_driver/controller_stopper.hpp"
 
 ControllerStopper::ControllerStopper(const rclcpp::Node::SharedPtr& node, bool stop_controllers_on_startup)
@@ -89,6 +91,7 @@ ControllerStopper::ControllerStopper(const rclcpp::Node::SharedPtr& node, bool s
           }
         }
       }
+      rclcpp::sleep_for(std::chrono::milliseconds(100));
     }
     auto request_switch_controller = std::make_shared<controller_manager_msgs::srv::SwitchController::Request>();
     request_switch_controller->strictness = request_switch_controller->STRICT;


### PR DESCRIPTION
Fixes the issue reported in #1037 

I've chosen a rather arbitrary 100ms of sleep. Maybe a shorter period would be desirable to avoid "long" periods where the controller seems to be running?

@kjjpc do you have an opinion on the sleep period?