### PR TITLE
[doc] Note about required OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ receive no more updates and may be lacking features.
 
 Please see the [requirements for the Universal_Robots_Client_Library](https://github.com/UniversalRobots/Universal_Robots_Client_Library#requirements), as this driver is build on top of Universal_Robots_Client_Library.
 
-**Note**: a fundamental requirement for the driver is using Linux, there is no support for any other OS.
+**Note**: A fundamental requirement for the driver is using Linux. Currently, there is no support for any other OS.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ receive no more updates and may be lacking features.
 
 Please see the [requirements for the Universal_Robots_Client_Library](https://github.com/UniversalRobots/Universal_Robots_Client_Library#requirements), as this driver is build on top of Universal_Robots_Client_Library.
 
+**Note**: a fundamental requirement for the driver is using Linux, there is no support for any other OS.
+
 ## Getting Started
 
 For getting started, you'll basically need three steps:


### PR DESCRIPTION
This PR specifies that the driver requires a Linux OS to work, improving in clarity for doubts about a possible Windows support [#549 ](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/549).