### PR TITLE
Added dynamics tag when using mock_components/GenericSystem

### DIFF
--- a/ur_robot_driver/urdf/ur.ros2_control.xacro
+++ b/ur_robot_driver/urdf/ur.ros2_control.xacro
@@ -42,6 +42,7 @@
           <plugin>mock_components/GenericSystem</plugin>
           <param name="mock_sensor_commands">${mock_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
+          <param name="calculate_dynamics">true</param>
         </xacro:if>
         <xacro:unless value="${use_mock_hardware}">
           <plugin>ur_robot_driver/URPositionHardwareInterface</plugin>


### PR DESCRIPTION
This goes in line with https://github.com/UniversalRobots/Universal_Robots_ROS2_Description/pull/175