### PR TITLE
Fix for forward_velocity_controller test

### DIFF
--- a/ur_robot_driver/config/test_velocity_goal_publishers_config.yaml
+++ b/ur_robot_driver/config/test_velocity_goal_publishers_config.yaml
@@ -1,10 +1,10 @@
 publisher_forward_velocity_controller:
   ros__parameters:
 
-    controller_name: "forward_velocity_controller"
+    publish_topic: "forward_velocity_controller/commands"
     wait_sec_between_publish: 5
 
-    goal_names: ["pos1", "pos2", "pos3"]
-    pos1: [0.0, 0.0, 0.0, 0.0, 0.0, 0.05]
-    pos2: [0.0, 0.0, 0.0, 0.0, 0.0, -0.05]
-    pos3: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    goal_names: ["vel1", "vel2", "vel3"]
+    vel1: [0.0, 0.0, 0.0, 0.0, 0.0, 0.5]
+    vel2: [0.0, 0.0, 0.0, 0.0, 0.0, -0.5]
+    vel3: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]

--- a/ur_robot_driver/launch/test_forward_velocity_controller.launch.py
+++ b/ur_robot_driver/launch/test_forward_velocity_controller.launch.py
@@ -38,7 +38,7 @@ from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
-    velocity_goals = PathJoinSubstitution(
+    velocity_config = PathJoinSubstitution(
         [FindPackageShare("ur_robot_driver"), "config", "test_velocity_goal_publishers_config.yaml"]
     )
 
@@ -48,7 +48,7 @@ def generate_launch_description():
                 package="ros2_controllers_test_nodes",
                 executable="publisher_forward_position_controller",
                 name="publisher_forward_velocity_controller",
-                parameters=[velocity_goals],
+                parameters=[velocity_config],
                 output="screen",
             )
         ]


### PR DESCRIPTION
This PR aims to fix the test for the `forward_velocity_controller`: basically the related config file was missing the `publish_topic` parameter. Now when the controller is active, the velocity goals are correctly sent by launching `test_forward_velocity_controller.launch.py`.