### PR TITLE
Update get_state to get_lifecycle_state

### DIFF
--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -83,7 +83,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
                  scaled_params_.speed_scaling_interface_name.c_str());
   }
 
-  if (get_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+  if (get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
     return controller_interface::return_type::OK;
   }
 


### PR DESCRIPTION
This PR updates the name of `get_state()` according to the [commit](https://github.com/ros-controls/ros2_controllers/commit/ce12694c6c948509a470783fd3b770cfab60a26e) that changes it to `get_lifecycle_state()` in ros2_controllers. In this way the CI for rolling and jazzy (Semi Binary) won't fail during building.