### PR TITLE
Update maintainers team

### DIFF
--- a/ur/package.xml
+++ b/ur/package.xml
@@ -6,7 +6,6 @@
   <description>Metapackage for universal robots</description>
   <maintainer email="exner@fzi.de">Felix Exner</maintainer>
   <maintainer email="dipentima@fzi.de">Vincenzo Di Pentima</maintainer>
-  <maintainer email="wilbrandt@fzi.de">Robert Wilbrandt</maintainer>
   <license>BSD-3-Clause</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/ur/package.xml
+++ b/ur/package.xml
@@ -5,6 +5,7 @@
   <version>2.4.9</version>
   <description>Metapackage for universal robots</description>
   <maintainer email="exner@fzi.de">Felix Exner</maintainer>
+  <maintainer email="dipentima@fzi.de">Vincenzo Di Pentima</maintainer>
   <maintainer email="wilbrandt@fzi.de">Robert Wilbrandt</maintainer>
   <license>BSD-3-Clause</license>
 

--- a/ur_calibration/package.xml
+++ b/ur_calibration/package.xml
@@ -5,10 +5,11 @@
   <description>Package for extracting the factory calibration from a UR robot and change it such that it can be used by ur_description to gain a correct URDF</description>
 
   <maintainer email="exner@fzi.de">Felix Exner</maintainer>
-  <maintainer email="wilbrandt@fzi.de">Robert Wilbrandt</maintainer>
+  <maintainer email="dipentima@fzi.de">Vincenzo Di Pentima</maintainer>
 
   <license>BSD-3-Clause</license>
 
+  <author email="wilbrandt@fzi.de">Robert Wilbrandt</author>
   <author email="lovro.ivanov@gmail.com">Lovro Ivanov</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/ur_controllers/package.xml
+++ b/ur_controllers/package.xml
@@ -7,13 +7,14 @@
 
   <maintainer email="denis@stoglrobotics.de">Denis Stogl</maintainer>
   <maintainer email="exner@fzi.de">Felix Exner</maintainer>
-  <maintainer email="wilbrandt@fzi.de">Robert Wilbrandt</maintainer>
+  <maintainer email="dipentima@fzi.de">Vincenzo Di Pentima</maintainer>
 
   <license>BSD-3-Clause</license>
 
   <url type="bugtracker">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues</url>
   <url type="repository">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver</url>
 
+  <author email="wilbrandt@fzi.de">Robert Wilbrandt</author>
   <author email="grosse@fzi.de">Marvin Große Besselmann</author>
   <author email="lovro.ivanov@gmail.com">Lovro Ivanov</author>
   <author email="zelenak@picknik.ai">Andy Zelenak</author>

--- a/ur_controllers/package.xml
+++ b/ur_controllers/package.xml
@@ -5,7 +5,6 @@
   <version>2.4.9</version>
   <description>Provides controllers that use the speed scaling interface of Universal Robots.</description>
 
-  <maintainer email="denis@stoglrobotics.de">Denis Stogl</maintainer>
   <maintainer email="exner@fzi.de">Felix Exner</maintainer>
   <maintainer email="dipentima@fzi.de">Vincenzo Di Pentima</maintainer>
 
@@ -14,6 +13,7 @@
   <url type="bugtracker">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues</url>
   <url type="repository">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver</url>
 
+  <author email="denis@stoglrobotics.de">Denis Stogl</author>
   <author email="wilbrandt@fzi.de">Robert Wilbrandt</author>
   <author email="grosse@fzi.de">Marvin Große Besselmann</author>
   <author email="lovro.ivanov@gmail.com">Lovro Ivanov</author>

--- a/ur_dashboard_msgs/package.xml
+++ b/ur_dashboard_msgs/package.xml
@@ -6,13 +6,14 @@
   <description>Messages around the UR Dashboard server.</description>
 
   <maintainer email="exner@fzi.de">Felix Exner</maintainer>
-  <maintainer email="wilbrandt@fzi.de">Robert Wilbrandt</maintainer>
+  <maintainer email="dipentima@fzi.de">Vincenzo Di Pentima</maintainer>
 
   <license>BSD-3-Clause</license>
 
   <url type="bugtracker">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues</url>
   <url type="repository">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver</url>
 
+  <author email="wilbrandt@fzi.de">Robert Wilbrandt</author>
   <author email="denis@stoglrobotics.de">Denis Stogl</author>
   <author email="lovro.ivanov@gmail.com">Lovro Ivanov</author>
   <author email="zelenak@picknik.ai">Andy Zelenak</author>

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -7,13 +7,14 @@
 
   <maintainer email="denis@stoglrobotics.de">Denis Stogl</maintainer>
   <maintainer email="exner@fzi.de">Felix Exner</maintainer>
-  <maintainer email="wilbrandt@fzi.de">Robert Wilbrandt</maintainer>
+  <maintainer email="dipentima@fzi.de">Vincenzo Di Pentima</maintainer>
 
   <license>BSD-3-Clause</license>
 
   <url type="bugtracker">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues</url>
   <url type="repository">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver</url>
 
+  <author email="wilbrandt@fzi.de">Robert Wilbrandt</author>
   <author email="grosse@fzi.de">Marvin Große Besselmann</author>
   <author email="lovro.ivanov@gmail.com">Lovro Ivanov</author>
   <author email="zelenak@picknik.ai">Andy Zelenak</author>

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -5,7 +5,6 @@
   <version>2.4.9</version>
   <description>The new driver for Universal Robots UR3, UR5 and UR10 robots with CB3 controllers and the e-series.</description>
 
-  <maintainer email="denis@stoglrobotics.de">Denis Stogl</maintainer>
   <maintainer email="exner@fzi.de">Felix Exner</maintainer>
   <maintainer email="dipentima@fzi.de">Vincenzo Di Pentima</maintainer>
 
@@ -14,6 +13,7 @@
   <url type="bugtracker">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues</url>
   <url type="repository">https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver</url>
 
+  <author email="denis@stoglrobotics.de">Denis Stogl</author>
   <author email="wilbrandt@fzi.de">Robert Wilbrandt</author>
   <author email="grosse@fzi.de">Marvin Große Besselmann</author>
   <author email="lovro.ivanov@gmail.com">Lovro Ivanov</author>


### PR DESCRIPTION
Since I am going through the steps of doing a binary release of the [GZ simulation package](https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation), I need first of all to be added into the release team on `ros2-gbp` and, to create an issue for that, it's necessary to show that you belong to the maintainers team. 
So I updated things around also moving Robert to the authors section :)