### PR TITLE
Added option to publish SRDF file.

### DIFF
--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -52,6 +52,7 @@ def launch_setup(context, *args, **kwargs):
     # General arguments
     description_package = LaunchConfiguration("description_package")
     description_file = LaunchConfiguration("description_file")
+    _publish_robot_description_semantic = LaunchConfiguration("publish_robot_description_semantic")
     moveit_config_package = LaunchConfiguration("moveit_config_package")
     moveit_joint_limits_file = LaunchConfiguration("moveit_joint_limits_file")
     moveit_config_file = LaunchConfiguration("moveit_config_file")
@@ -143,6 +144,8 @@ def launch_setup(context, *args, **kwargs):
     )
     robot_description_semantic = {"robot_description_semantic": robot_description_semantic_content}
 
+    publish_robot_description_semantic = {"publish_robot_description_semantic": _publish_robot_description_semantic}
+
     robot_description_kinematics = PathJoinSubstitution(
         [FindPackageShare(moveit_config_package), "config", "kinematics.yaml"]
     )
@@ -205,6 +208,7 @@ def launch_setup(context, *args, **kwargs):
         parameters=[
             robot_description,
             robot_description_semantic,
+            publish_robot_description_semantic,
             robot_description_kinematics,
             robot_description_planning,
             ompl_planning_pipeline_config,
@@ -310,6 +314,13 @@ def generate_launch_description():
             "description_file",
             default_value="ur.urdf.xacro",
             description="URDF/XACRO description file with the robot.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "publish_robot_description_semantic",
+            default_value="False",
+            description="Whether to publish the SRDF description on topic /robot_description_semantic."
         )
     )
     declared_arguments.append(

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -319,7 +319,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "publish_robot_description_semantic",
-            default_value="False",
+            default_value="True",
             description="Whether to publish the SRDF description on topic /robot_description_semantic."
         )
     )


### PR DESCRIPTION
Added argument to the launch file that can toggle the ability to publish the contents of the SRDF on the topic /robot_description_semantic. This allows the launch file to be used with custom moveit2 projects without having to source the SRDF for every launched node.

See following link for details: https://moveit.picknik.ai/humble/doc/examples/urdf_srdf/urdf_srdf_tutorial.html#string-topic-specification

Note: The default behaviour of not publishing this topic has been maintained, but now users have the option publish it if needed.