### PR TITLE
Assure the description is loaded as string

### DIFF
--- a/ur_robot_driver/launch/ur_rsp.launch.py
+++ b/ur_robot_driver/launch/ur_rsp.launch.py
@@ -31,6 +31,7 @@
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
+from launch_ros.parameter_descriptions import ParameterValue
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -185,7 +186,9 @@ def generate_launch_description():
             " ",
         ]
     )
-    robot_description = {"robot_description": robot_description_content}
+    robot_description = {
+        "robot_description": ParameterValue(robot_description_content, value_type=str)
+    }
 
     declared_arguments = []
     # UR specific arguments


### PR DESCRIPTION
If this isn't explicitly specified, the description string might be interpreted as a yaml content, which leads to problems, obviously.

This was mentioned in #1103 and needs to get backported. However, since we refactored loading the description this will not be a straightforward backport, I'll open a separate PR.