### PR TITLE
Fixed dependency for ur_msgs from upstream

### DIFF
--- a/Universal_Robots_ROS2_Driver-not-released.humble.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.humble.repos
@@ -8,3 +8,7 @@ repositories:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
     version: humble
+  ur_msgs:
+    type: git
+    url: https://github.com/ros-industrial/ur_msgs.git
+    version: humble-devel

--- a/Universal_Robots_ROS2_Driver-not-released.humble.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.humble.repos
@@ -11,4 +11,4 @@ repositories:
   ur_msgs:
     type: git
     url: https://github.com/ros-industrial/ur_msgs.git
-    version: humble-devel
+    version: humble


### PR DESCRIPTION
## Problem
As of today, 10/10/24, it is **impossible** to binary build this repo using `src/Universal_Robots_ROS2_Driver/Universal_Robots_ROS2_Driver-not-released.<ros-distro>.repos`.

Also your CI [shows the problem](https://github.com/pucciland95/Universal_Robots_ROS2_Driver/blob/main/ci_status.md).
It issues and error since it fails to get the latest `ur_msgs` changes. Indeed, when getting the latest binary of `ur_msgs` from rosdep it pulls version 2.0.0 despite the latest is version 2.0.1. I don't get why honestly...

## Proposed solution
As a temporary fix, It is necessary to clone `ur_msgs` from upstream.