### PR TITLE
Ci automatic issues

### DIFF
--- a/.github/issue_template_failed_ci.md
+++ b/.github/issue_template_failed_ci.md
@@ -1,0 +1,32 @@
+---
+title: Failed build job {{ env.UPSTREAM_TYPE }} ({{ env.DISTRO }}/{{ env.REPO }})
+labels: CI
+---
+The scheduled build for branch `{{ env.REF }}` failed.
+
+**Upstream build type:** {{ env.UPSTREAM_TYPE }}
+**ROS DISTRO:** {{ env.DISTRO }}
+**Repo:** {{ env.REPO }}
+
+Please check the log output for details: {{ env.URL }}
+
+Please note that this issue has different implications based on the build type. To get an idea of
+the complete situation, please have a look at the [current build
+status](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/blob/main/ci_status.md)
+
+- If the *Upstream build type* is "binary":
+  - If the *Repo* is "testing", it is well possible that an upstream package did make an
+    API-breaking change that hasn't been released, yet. If the semi-binary builds are OK, this
+    package has made the necessary changes, already. It is expected to sort itself out by itself,
+    once the upstream package has been released. If the semi-binary builds are failing, as well,
+    this package has to be updated.
+  - If the *Repo* is "main", but the "testing" builds are green, we are only waiting for a Sync
+    to happen.
+- If the *Upstream build type* is "semi-binary":
+  - If both, main and testing, are failing, there has been an API-breaking change in an upstream
+    package. This package should get updated soon. If the upstream package gets released without
+    updating this package, the "binary / testing" builds will also fail. In this case, this package
+    needs to get updated and released ASAP.
+  - If not both, main and testing, are failing, there is an upstream dependency with an API-breaking
+    change that is not part of the upstream workspace. This should rarely happen and needs action
+    from the package maintainers.

--- a/.github/workflows/humble-binary-main.yml
+++ b/.github/workflows/humble-binary-main.yml
@@ -14,5 +14,6 @@ jobs:
     with:
       ros_distro: humble
       ros_repo: main
+      upstream_type: binary
       upstream_workspace: Universal_Robots_ROS2_Driver-not-released.humble.repos
       ref_for_scheduled_build: humble

--- a/.github/workflows/humble-binary-testing.yml
+++ b/.github/workflows/humble-binary-testing.yml
@@ -14,5 +14,6 @@ jobs:
     with:
       ros_distro: humble
       ros_repo: testing
+      upstream_type: binary
       upstream_workspace: Universal_Robots_ROS2_Driver-not-released.humble.repos
       ref_for_scheduled_build: humble

--- a/.github/workflows/humble-semi-binary-main.yml
+++ b/.github/workflows/humble-semi-binary-main.yml
@@ -14,5 +14,6 @@ jobs:
     with:
       ros_distro: humble
       ros_repo: main
+      upstream_type: semi-binary
       upstream_workspace: Universal_Robots_ROS2_Driver.humble.repos
       ref_for_scheduled_build: humble

--- a/.github/workflows/humble-semi-binary-testing.yml
+++ b/.github/workflows/humble-semi-binary-testing.yml
@@ -14,5 +14,6 @@ jobs:
     with:
       ros_distro: humble
       ros_repo: testing
+      upstream_type: semi-binary
       upstream_workspace: Universal_Robots_ROS2_Driver.humble.repos
       ref_for_scheduled_build: humble

--- a/.github/workflows/iron-binary-main.yml
+++ b/.github/workflows/iron-binary-main.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: iron
       ros_repo: main
+      upstream_type: binary
       upstream_workspace: Universal_Robots_ROS2_Driver-not-released.iron.repos
       ref_for_scheduled_build: iron

--- a/.github/workflows/iron-binary-testing.yml
+++ b/.github/workflows/iron-binary-testing.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: iron
       ros_repo: testing
+      upstream_type: binary
       upstream_workspace: Universal_Robots_ROS2_Driver-not-released.iron.repos
       ref_for_scheduled_build: iron

--- a/.github/workflows/iron-semi-binary-main.yml
+++ b/.github/workflows/iron-semi-binary-main.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: iron
       ros_repo: main
+      upstream_type: semi-binary
       upstream_workspace: Universal_Robots_ROS2_Driver.iron.repos
       ref_for_scheduled_build: iron

--- a/.github/workflows/iron-semi-binary-testing.yml
+++ b/.github/workflows/iron-semi-binary-testing.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: iron
       ros_repo: testing
+      upstream_type: semi-binary
       upstream_workspace: Universal_Robots_ROS2_Driver.iron.repos
       ref_for_scheduled_build: iron

--- a/.github/workflows/jazzy-binary-main.yml
+++ b/.github/workflows/jazzy-binary-main.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: main
+      upstream_type: binary
       upstream_workspace: Universal_Robots_ROS2_Driver-not-released.jazzy.repos
       ref_for_scheduled_build: main

--- a/.github/workflows/jazzy-binary-testing.yml
+++ b/.github/workflows/jazzy-binary-testing.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: testing
+      upstream_type: binary
       upstream_workspace: Universal_Robots_ROS2_Driver-not-released.jazzy.repos
       ref_for_scheduled_build: main

--- a/.github/workflows/jazzy-semi-binary-main.yml
+++ b/.github/workflows/jazzy-semi-binary-main.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: main
+      upstream_type: semi-binary
       upstream_workspace: Universal_Robots_ROS2_Driver.jazzy.repos
       ref_for_scheduled_build: main

--- a/.github/workflows/jazzy-semi-binary-testing.yml
+++ b/.github/workflows/jazzy-semi-binary-testing.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: testing
+      upstream_type: semi-binary
       upstream_workspace: Universal_Robots_ROS2_Driver.jazzy.repos
       ref_for_scheduled_build: main

--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -56,7 +56,8 @@ jobs:
           CMAKE_ARGS: -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON
           ADDITIONAL_DEBS: docker.io netcat-openbsd  # Needed for integration tests
       - uses: JasonEtco/create-an-issue@v2
-        if: ${{ always() && (steps.ici.outputs.build_target_workspace == '2' || steps.ici.outputs.target_test_results == '1') && github.event_name == 'schedule'}}
+        #if: ${{ always() && (steps.ici.outputs.build_target_workspace == '2' || steps.ici.outputs.target_test_results == '1') && github.event_name == 'schedule'}}
+        if: ${{ always() && (steps.ici.outputs.build_target_workspace == '2' || steps.ici.outputs.target_test_results == '1') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UPSTREAM_TYPE: ${{ inputs.upstream_type }}

--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -9,7 +9,10 @@ on:
         default: ''
         required: false
         type: string
-
+      upstream_type:
+        description: 'Binary or semi-binary build'
+        required: true
+        type: string
       upstream_workspace:
         description: 'UPSTREAM_WORKSPACE variable for industrial_ci. Usually path to local .repos file.'
         required: true
@@ -52,3 +55,15 @@ jobs:
           ROS_REPO: ${{ inputs.ros_repo }}
           CMAKE_ARGS: -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON
           ADDITIONAL_DEBS: docker.io netcat-openbsd  # Needed for integration tests
+      - uses: JasonEtco/create-an-issue@v2
+        if: ${{ always() && (steps.ici.outputs.build_target_workspace == '2' || steps.ici.outputs.target_test_results == '1') && github.event_name == 'schedule'}}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPSTREAM_TYPE: ${{ inputs.upstream_type }}
+          REF: ${{ inputs.ref_for_scheduled_build }}
+          DISTRO: ${{ inputs.ros_distro }}
+          REPO: ${{ inputs.ros_repo }}
+          URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          update_existing: true
+          filename: .github/issue_template_failed_ci.md

--- a/.github/workflows/rolling-binary-main.yml
+++ b/.github/workflows/rolling-binary-main.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: rolling
       ros_repo: main
+      upstream_type: binary
       upstream_workspace: Universal_Robots_ROS2_Driver-not-released.rolling.repos
       ref_for_scheduled_build: main

--- a/.github/workflows/rolling-binary-testing.yml
+++ b/.github/workflows/rolling-binary-testing.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: rolling
       ros_repo: testing
+      upstream_type: binary
       upstream_workspace: Universal_Robots_ROS2_Driver-not-released.rolling.repos
       ref_for_scheduled_build: main

--- a/.github/workflows/rolling-semi-binary-main.yml
+++ b/.github/workflows/rolling-semi-binary-main.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: rolling
       ros_repo: main
+      upstream_type: semi-binary
       upstream_workspace: Universal_Robots_ROS2_Driver.rolling.repos
       ref_for_scheduled_build: main

--- a/.github/workflows/rolling-semi-binary-testing.yml
+++ b/.github/workflows/rolling-semi-binary-testing.yml
@@ -19,5 +19,6 @@ jobs:
     with:
       ros_distro: rolling
       ros_repo: testing
+      upstream_type: semi-binary
       upstream_workspace: Universal_Robots_ROS2_Driver.rolling.repos
       ref_for_scheduled_build: main


### PR DESCRIPTION
This creates issues on failed (scheduled) CI runs. This way, we will have one issue per failing CI. There, we can add a statement why this is failing, e.g. some upstream dependency changed API.