### PR TITLE
Disable link checks for architecture_coarse.svg

### DIFF
--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -16,4 +16,4 @@ jobs:
           .github/helpers/check_urls.sh \
             -d ".git build CMakeModules debian" \
             -f "package.xml ursim_docker.rst architecture_coarse.svg" \
-            -p "vnc\.html"
+            -p "vnc\.html opensource\.org\/licenses\/BSD-3-Clause"

--- a/.github/workflows/check_links.yml
+++ b/.github/workflows/check_links.yml
@@ -15,5 +15,5 @@ jobs:
         run: |
           .github/helpers/check_urls.sh \
             -d ".git build CMakeModules debian" \
-            -f "package.xml ursim_docker.rst" \
+            -f "package.xml ursim_docker.rst architecture_coarse.svg" \
             -p "vnc\.html"


### PR DESCRIPTION
When adding the link checks in #1137, this actually slipped through. 