### PR TITLE
Pass `use_sim_time` to MoveIt's RViz instance

### DIFF
--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -175,6 +175,9 @@ def generate_launch_description():
             moveit_config.planning_pipelines,
             moveit_config.joint_limits,
             warehouse_ros_config,
+            {
+                "use_sim_time": use_sim_time,
+            },
         ],
     )
 


### PR DESCRIPTION
When running with sim_time, we need to pass that to the RViz instance, as well.

This is a part of fixing https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/57