### PR TITLE
fix: recreate urcl log handler pointer if necessary

### DIFF
--- a/ur_robot_driver/src/urcl_log_handler.cpp
+++ b/ur_robot_driver/src/urcl_log_handler.cpp
@@ -82,6 +82,9 @@ void UrclLogHandler::log(const char* file, int line, urcl::LogLevel loglevel, co
 void registerUrclLogHandler(const std::string& tf_prefix)
 {
   if (g_registered == false) {
+    if (g_log_handler == nullptr) {
+      g_log_handler = std::make_unique<UrclLogHandler>();
+    }
     g_log_handler->setTFPrefix(tf_prefix);
     // Log level is decided by ROS2 log level
     urcl::setLogLevel(urcl::LogLevel::DEBUG);


### PR DESCRIPTION
We have discovered an [issue](https://github.com/aica-technology/api/issues/187) with the `UrclLogHandler` that occurs when a resource manager is creating the UR hardware interface twice in a row without stopping ROS in between. I'm not sure if that can be recreated on your side easily but you could try:
1. create controller manager for UR
2. destroy controller manager while keeping ros2 alive
3. recreate controller manager for UR, this will result in a segmentation fault

You will realize that the `g_log_handler` pointer has in fact been reset and not recreated properly, since it's initialization is to be found in the source file. My null pointer check should avoid that segfault.

Side question, what was the design intent of the `UrclLogHandler`? Were you going for a Singleton? That influences maybe how this problem could be fixed.