### PR TITLE
Add launch argument to optionally omit the controller_stopper node

### DIFF
--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -66,6 +66,7 @@ def launch_setup(context):
     use_tool_communication = LaunchConfiguration("use_tool_communication")
     tool_device_name = LaunchConfiguration("tool_device_name")
     tool_tcp_port = LaunchConfiguration("tool_tcp_port")
+    use_controller_stopper = LaunchConfiguration("use_controller_stopper")
 
     control_node = Node(
         package="controller_manager",
@@ -120,7 +121,9 @@ def launch_setup(context):
         name="controller_stopper",
         output="screen",
         emulate_tty=True,
-        condition=UnlessCondition(use_mock_hardware),
+        condition=IfCondition(
+            AndSubstitution(use_controller_stopper, NotSubstitution(use_mock_hardware))
+        ),
         parameters=[
             {"headless_mode": headless_mode},
             {"joint_controller_active": activate_joint_controller},
@@ -468,6 +471,14 @@ def generate_launch_description():
                 LaunchConfiguration("ur_type"),
                 "_update_rate.yaml",
             ],
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_controller_stopper",
+            default_value="true",
+            description="Use the controller stopper node to start and stop ROS 2 controllers "
+            "based on the robot's running state topic."
         )
     )
     return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])


### PR DESCRIPTION
Adds an argument to [ur_control.launch.py](https://github.com/eholum/Universal_Robots_ROS2_Driver/blob/controller-stopper-option/ur_robot_driver/launch/ur_control.launch.py#L476) to optionally launch the `controller_stopper` node.

In our hardware setup we have multiple types of robots (URs, rails, lifts, AMRs, etc), and have implemented some custom software e-stops for halting everything in the system, then restarting controllers as needed. While we normally rely on the `controller_stopper`, we've found that it steps on the toes of our custom e-stopper. It would be handy to optionally not include the node in a way that lets us continue to use the driver's launch files as is.

I don't imagine this change will be something that most UR users will need. That said, it may be a nice to have if anyone runs into a similar situation as we are.

Testable with variations of:

```
ros2 launch ur_robot_driver ur5e.launch.py robot_ip:=0.0.0.0 use_mock_hardware:=false use_controller_stopper:=false
```