### PR TITLE
Update Humble upstream workspace

### DIFF
--- a/Universal_Robots_ROS2_Driver-not-released.humble.repos
+++ b/Universal_Robots_ROS2_Driver-not-released.humble.repos
@@ -3,8 +3,4 @@
 # requires a newer version than the one currently released to the target distributions.
 # Once Upstream packages are released and synced to the target distributions in the required
 # version, the entry in this file shall be removed again.
-repositories:
-  Universal_Robots_ROS2_Description:
-    type: git
-    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
-    version: humble
+repositories: []

--- a/Universal_Robots_ROS2_Driver.humble.repos
+++ b/Universal_Robots_ROS2_Driver.humble.repos
@@ -27,3 +27,7 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
     version: humble
+  realtime_tools:
+    type: git
+    url: https://github.com/ros-controls/realtime_tools.git
+    version: master

--- a/Universal_Robots_ROS2_Driver.humble.repos
+++ b/Universal_Robots_ROS2_Driver.humble.repos
@@ -22,7 +22,7 @@ repositories:
   kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
-    version: master
+    version: humble
   control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git


### PR DESCRIPTION
Update the upstream workspace regarding

- Add realtime_tools from ros-controls
- Update branch of kinematics_interface to humble as the master version got API incompatible
- Make upstream ws for binary build empty