### PR TITLE
Cleanup workflows

### DIFF
--- a/.github/workflows/humble-binary-main.yml
+++ b/.github/workflows/humble-binary-main.yml
@@ -6,7 +6,7 @@ on:
     - cron: '03 5 * * *'
 
 jobs:
-  binary:
+  humble_binary_main:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: humble

--- a/.github/workflows/humble-binary-main.yml
+++ b/.github/workflows/humble-binary-main.yml
@@ -1,12 +1,9 @@
 name: Humble Binary Build Main
 on:
   workflow_dispatch:
-    branches:
-      - humble
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 5 * * *'
-
 
 jobs:
   binary:

--- a/.github/workflows/humble-binary-testing.yml
+++ b/.github/workflows/humble-binary-testing.yml
@@ -7,7 +7,7 @@ on:
 
 
 jobs:
-  binary:
+  humble_binary_testing:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: humble

--- a/.github/workflows/humble-binary-testing.yml
+++ b/.github/workflows/humble-binary-testing.yml
@@ -1,8 +1,6 @@
 name: Humble Binary Build Testing
 on:
   workflow_dispatch:
-    branches:
-      - humble
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 5 * * *'

--- a/.github/workflows/humble-semi-binary-main.yml
+++ b/.github/workflows/humble-semi-binary-main.yml
@@ -1,8 +1,6 @@
 name: Humble Semi Binary Build Main
 on:
   workflow_dispatch:
-    branches:
-      - humble
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 5 * * *'

--- a/.github/workflows/humble-semi-binary-main.yml
+++ b/.github/workflows/humble-semi-binary-main.yml
@@ -7,7 +7,7 @@ on:
 
 
 jobs:
-  binary:
+  humble_semi_main:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: humble

--- a/.github/workflows/humble-semi-binary-testing.yml
+++ b/.github/workflows/humble-semi-binary-testing.yml
@@ -1,8 +1,6 @@
 name: Humble Semi Binary Build Testing
 on:
   workflow_dispatch:
-    branches:
-      - humble
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '03 5 * * *'

--- a/.github/workflows/humble-semi-binary-testing.yml
+++ b/.github/workflows/humble-semi-binary-testing.yml
@@ -7,7 +7,7 @@ on:
 
 
 jobs:
-  binary:
+  humble_semi_testing:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: humble

--- a/.github/workflows/iron-binary-main.yml
+++ b/.github/workflows/iron-binary-main.yml
@@ -1,8 +1,6 @@
 name: Iron Binary Build Main
 on:
   workflow_dispatch:
-    branches:
-      - iron
   pull_request:
     branches:
       - iron

--- a/.github/workflows/iron-binary-main.yml
+++ b/.github/workflows/iron-binary-main.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 5 * * *'
 
 jobs:
-  binary:
+  iron_binary_main:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: iron

--- a/.github/workflows/iron-binary-testing.yml
+++ b/.github/workflows/iron-binary-testing.yml
@@ -1,8 +1,6 @@
 name: Iron Binary Build Testing
 on:
   workflow_dispatch:
-    branches:
-      - iron
   pull_request:
     branches:
       - iron

--- a/.github/workflows/iron-binary-testing.yml
+++ b/.github/workflows/iron-binary-testing.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 5 * * *'
 
 jobs:
-  binary:
+  iron_binary_testing:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: iron

--- a/.github/workflows/iron-semi-binary-main.yml
+++ b/.github/workflows/iron-semi-binary-main.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 5 * * *'
 
 jobs:
-  binary:
+  iron_semi_main:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: iron

--- a/.github/workflows/iron-semi-binary-main.yml
+++ b/.github/workflows/iron-semi-binary-main.yml
@@ -1,8 +1,6 @@
 name: Iron Semi Binary Build Main
 on:
   workflow_dispatch:
-    branches:
-      - iron
   pull_request:
     branches:
       - iron

--- a/.github/workflows/iron-semi-binary-testing.yml
+++ b/.github/workflows/iron-semi-binary-testing.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 5 * * *'
 
 jobs:
-  binary:
+  iron_semi_testing:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: iron

--- a/.github/workflows/iron-semi-binary-testing.yml
+++ b/.github/workflows/iron-semi-binary-testing.yml
@@ -1,8 +1,6 @@
 name: Iron Semi Binary Build Testing
 on:
   workflow_dispatch:
-    branches:
-      - iron
   pull_request:
     branches:
       - iron

--- a/.github/workflows/jazzy-binary-main.yml
+++ b/.github/workflows/jazzy-binary-main.yml
@@ -1,8 +1,6 @@
 name: Jazzy Binary Build Main
 on:
   workflow_dispatch:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/jazzy-binary-main.yml
+++ b/.github/workflows/jazzy-binary-main.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 4 * * *'
 
 jobs:
-  binary:
+  jazzy_binary_main:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: jazzy

--- a/.github/workflows/jazzy-binary-testing.yml
+++ b/.github/workflows/jazzy-binary-testing.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 4 * * *'
 
 jobs:
-  binary:
+  jazzy_binary_testing:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: jazzy

--- a/.github/workflows/jazzy-binary-testing.yml
+++ b/.github/workflows/jazzy-binary-testing.yml
@@ -1,8 +1,6 @@
 name: Jazzy Binary Build Testing
 on:
   workflow_dispatch:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/jazzy-semi-binary-main.yml
+++ b/.github/workflows/jazzy-semi-binary-main.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 4 * * *'
 
 jobs:
-  binary:
+  jazzy_semi_main:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: jazzy

--- a/.github/workflows/jazzy-semi-binary-main.yml
+++ b/.github/workflows/jazzy-semi-binary-main.yml
@@ -1,8 +1,6 @@
 name: Jazzy Semi Binary Build Main
 on:
   workflow_dispatch:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/jazzy-semi-binary-testing.yml
+++ b/.github/workflows/jazzy-semi-binary-testing.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 4 * * *'
 
 jobs:
-  binary:
+  jazzy_semi_testing:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: jazzy

--- a/.github/workflows/jazzy-semi-binary-testing.yml
+++ b/.github/workflows/jazzy-semi-binary-testing.yml
@@ -1,8 +1,6 @@
 name: Jazzy Semi Binary Build Testing
 on:
   workflow_dispatch:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           ref: ${{ inputs.ref_for_scheduled_build }}
       - run: docker network create --subnet=192.168.56.0/24 ursim_net
+        if: ${{ !env.ACT }}
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}

--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -31,15 +31,15 @@ on:
 
 jobs:
   reusable_ici:
-    name: ${{ inputs.ros_distro }} ${{ inputs.ros_repo }} ${{ inputs.os_code_name }}
+    name: ${{ inputs.ros_distro }} ${{ inputs.ros_repo }}
     runs-on: ubuntu-latest
     env:
       DOCKER_RUN_OPTS: '-v /var/run/docker.sock:/var/run/docker.sock --network ursim_net'
     steps:
-      - name: Checkout ${{ inputs.ref }} when build is not scheduled
+      - name: Checkout ${{ github.ref_name }} since build is not scheduled
         if: ${{ github.event_name != 'schedule' }}
         uses: actions/checkout@v4
-      - name: Checkout ${{ inputs.ref }} on scheduled build
+      - name: Checkout ${{ inputs.ref_for_scheduled_build }} on scheduled build
         if: ${{ github.event_name == 'schedule' }}
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -28,6 +28,11 @@ on:
         default: ''
         required: false
         type: string
+      ccache_dir:
+        description: 'CCache dir that should be used. Relative to github.workspace'
+        default: '.ccache'
+        required: false
+        type: string
 
 jobs:
   reusable_ici:
@@ -35,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_RUN_OPTS: '-v /var/run/docker.sock:/var/run/docker.sock --network ursim_net'
+      CCACHE_DIR: ${{ github.workspace }}/${{ inputs.ccache_dir }}
+      CACHE_PREFIX: ${{ inputs.ros_distro }}-${{ inputs.upstream_workspace }}-${{ inputs.ros_repo }}-${{ github.job }}
     steps:
       - name: Checkout ${{ github.ref_name }} since build is not scheduled
         if: ${{ github.event_name != 'schedule' }}
@@ -46,6 +53,14 @@ jobs:
           ref: ${{ inputs.ref_for_scheduled_build }}
       - run: docker network create --subnet=192.168.56.0/24 ursim_net
         if: ${{ !env.ACT }}
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
+            ccache-${{ env.CACHE_PREFIX }}
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}

--- a/.github/workflows/rolling-binary-main.yml
+++ b/.github/workflows/rolling-binary-main.yml
@@ -1,8 +1,6 @@
 name: Rolling Binary Build Main
 on:
   workflow_dispatch:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/rolling-binary-main.yml
+++ b/.github/workflows/rolling-binary-main.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 4 * * *'
 
 jobs:
-  binary:
+  rolling_binary_main:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: rolling

--- a/.github/workflows/rolling-binary-testing.yml
+++ b/.github/workflows/rolling-binary-testing.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 4 * * *'
 
 jobs:
-  binary:
+  rolling_binary_testing:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: rolling

--- a/.github/workflows/rolling-binary-testing.yml
+++ b/.github/workflows/rolling-binary-testing.yml
@@ -1,8 +1,6 @@
 name: Rolling Binary Build Testing
 on:
   workflow_dispatch:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/rolling-semi-binary-main.yml
+++ b/.github/workflows/rolling-semi-binary-main.yml
@@ -1,8 +1,6 @@
 name: Rolling Semi Binary Build Main
 on:
   workflow_dispatch:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/.github/workflows/rolling-semi-binary-main.yml
+++ b/.github/workflows/rolling-semi-binary-main.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 4 * * *'
 
 jobs:
-  binary:
+  rolling_semi_main:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: rolling

--- a/.github/workflows/rolling-semi-binary-testing.yml
+++ b/.github/workflows/rolling-semi-binary-testing.yml
@@ -12,7 +12,7 @@ on:
     - cron: '13 4 * * *'
 
 jobs:
-  binary:
+  rolling_semi_testing:
     uses: ./.github/workflows/reusable_ici.yml
     with:
       ros_distro: rolling

--- a/.github/workflows/rolling-semi-binary-testing.yml
+++ b/.github/workflows/rolling-semi-binary-testing.yml
@@ -1,8 +1,6 @@
 name: Rolling Semi Binary Build Testing
 on:
   workflow_dispatch:
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/Universal_Robots_ROS2_Driver.jazzy.repos
+++ b/Universal_Robots_ROS2_Driver.jazzy.repos
@@ -27,3 +27,7 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
     version: master
+  realtime_tools:
+    type: git
+    url: https://github.com/ros-controls/realtime_tools.git
+    version: master

--- a/Universal_Robots_ROS2_Driver.jazzy.repos
+++ b/Universal_Robots_ROS2_Driver.jazzy.repos
@@ -31,3 +31,15 @@ repositories:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git
     version: master
+  moveit2:
+    type: git
+    url: https://github.com/ros-planning/moveit2.git
+    version: main
+  moveit_msgs:
+    type: git
+    url: https://github.com/ros-planning/moveit_msgs.git
+    version: ros2
+  srdfdom:
+    type: git
+    url: https://github.com/moveit/srdfdom.git
+    version: ros2

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -27,3 +27,7 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
     version: master
+  realtime_tools:
+    type: git
+    url: https://github.com/ros-controls/realtime_tools.git
+    version: master

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -31,3 +31,15 @@ repositories:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git
     version: master
+  moveit2:
+    type: git
+    url: https://github.com/ros-planning/moveit2.git
+    version: main
+  moveit_msgs:
+    type: git
+    url: https://github.com/ros-planning/moveit_msgs.git
+    version: ros2
+  srdfdom:
+    type: git
+    url: https://github.com/moveit/srdfdom.git
+    version: ros2


### PR DESCRIPTION
The recent upstream changes in ros2_control revealed some tech debt on our workflows. This PR updates them regarding

- Proper naming of jobs for clearer identification
- Correct naming of steps in reusable ici
- Adding missing upstream packages from ros2_control in upstream workspaces
- Fix workflow syntax in some places
- Add ccache
- Add MoveIt to upstream workspace -- this avoids installing ros2_control from binary packages.