### PR TITLE
Call correctChain in Calibration constructor in calibration.cpp

### DIFF
--- a/ur_calibration/src/calibration.cpp
+++ b/ur_calibration/src/calibration.cpp
@@ -50,6 +50,7 @@ namespace ur_calibration
 Calibration::Calibration(const DHRobot& robot_parameters) : robot_parameters_(robot_parameters)
 {
   buildChain();
+  correctChain();
 }
 
 Calibration::~Calibration()


### PR DESCRIPTION
Calling correctChain() in the constructor doesn't add much overhead, but improves usability.

E.g. the chain is already correct when calling "calcForwardKinematics".