### PR TITLE
Make ur_controllers compileable on humble

### DIFF
--- a/ur_controllers/src/passthrough_trajectory_controller.cpp
+++ b/ur_controllers/src/passthrough_trajectory_controller.cpp
@@ -331,6 +331,7 @@ controller_interface::return_type PassthroughTrajectoryController::update(const 
 #if RCLCPP_VERSION_MAJOR >= 17
       active_trajectory_elapsed_time_ += period * scaling_factor_;
 #else
+      // This is kept for Humble compatibility
       active_trajectory_elapsed_time_ = active_trajectory_elapsed_time_ + period * scaling_factor_;
 #endif
       // RCLCPP_INFO(get_node()->get_logger(), "Elapsed trajectory time: %f. Scaling factor: %f, period: %f",

--- a/ur_controllers/src/passthrough_trajectory_controller.cpp
+++ b/ur_controllers/src/passthrough_trajectory_controller.cpp
@@ -44,6 +44,7 @@
 
 #include <controller_interface/controller_interface.hpp>
 #include <rclcpp/logging.hpp>
+#include <rclcpp/version.h>
 #include <builtin_interfaces/msg/duration.hpp>
 #include <lifecycle_msgs/msg/state.hpp>
 
@@ -327,8 +328,11 @@ controller_interface::return_type PassthroughTrajectoryController::update(const 
         scaling_factor_ = scaling_state_interface_->get().get_value();
       }
 
+#if RCLCPP_VERSION_MAJOR >= 17
       active_trajectory_elapsed_time_ += period * scaling_factor_;
-
+#else
+      active_trajectory_elapsed_time_ = active_trajectory_elapsed_time_ + period * scaling_factor_;
+#endif
       // RCLCPP_INFO(get_node()->get_logger(), "Elapsed trajectory time: %f. Scaling factor: %f, period: %f",
       // active_trajectory_elapsed_time_.seconds(), scaling_factor_, period.seconds());
 


### PR DESCRIPTION
The rolling version of ros2_control is kept compatible for compiling on humble distro. Obviously, I need to compile the rolling UR driver on humble too:
There exists no `+=` overload for `rclcpp::Duration` class on humble, which was introduced later https://github.com/ros2/rclcpp/pull/1988

We can use the rclcpp/version.h, or we could also just use the manual assignment.