### PR TITLE
Add control_toolbox to semi-binary repos files

### DIFF
--- a/Universal_Robots_ROS2_Driver.jazzy.repos
+++ b/Universal_Robots_ROS2_Driver.jazzy.repos
@@ -27,6 +27,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
     version: master
+  control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: ros2-master
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -27,6 +27,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
     version: master
+  control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: ros2-master
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Currently, the semi-binary jobs are failing because ros2_controllers need a new class from control_toolbox.