### PR TITLE
Add control_toolbox to semi-binary repos file

### DIFF
--- a/Universal_Robots_ROS2_Driver.humble.repos
+++ b/Universal_Robots_ROS2_Driver.humble.repos
@@ -27,6 +27,10 @@ repositories:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
     version: humble
+  control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: ros2-master
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
Manual backport of #1208 