### PR TITLE
improve docs around usage of extracted calibration info

### DIFF
--- a/ur_robot_driver/doc/installation/robot_setup.rst
+++ b/ur_robot_driver/doc/installation/robot_setup.rst
@@ -87,8 +87,11 @@ For this, there exists a helper script:
    $ ros2 launch ur_calibration calibration_correction.launch.py \
    robot_ip:=<robot_ip> target_filename:="${HOME}/my_robot_calibration.yaml"
 
+.. note::
+   The robot must be powered on (can be idle) before executing this script.
+
+
 For the parameter ``robot_ip`` insert the IP address on which the ROS pc can reach the robot. As
-``target_filename`` provide an absolute path where the result will be saved to. The robot must be
-powered on (can be idle) before executing this script.
+``target_filename`` provide an absolute path where the result will be saved to.
 
 See :ref:`ur_robot_driver_startup` for instructions on using the extracted calibration information.

--- a/ur_robot_driver/doc/installation/robot_setup.rst
+++ b/ur_robot_driver/doc/installation/robot_setup.rst
@@ -69,10 +69,10 @@ Prepare the ROS PC
 For using the driver make sure it is installed (either by the debian package or built from source
 inside a colcon workspace).
 
+.. _calibration_extraction:
+
 Extract calibration information
 -------------------------------
-
-.. _calibration_extraction:
 
 Each UR robot is calibrated inside the factory giving exact forward and inverse kinematics. To also
 make use of this in ROS, you first have to extract the calibration information from the robot.
@@ -88,4 +88,7 @@ For this, there exists a helper script:
    robot_ip:=<robot_ip> target_filename:="${HOME}/my_robot_calibration.yaml"
 
 For the parameter ``robot_ip`` insert the IP address on which the ROS pc can reach the robot. As
-``target_filename`` provide an absolute path where the result will be saved to.
+``target_filename`` provide an absolute path where the result will be saved to. The robot must be
+powered on (can be idle) before executing this script.
+
+See :ref:`ur_robot_driver_startup` for instructions on using the extracted calibration information.

--- a/ur_robot_driver/doc/usage/startup.rst
+++ b/ur_robot_driver/doc/usage/startup.rst
@@ -28,6 +28,7 @@ Allowed ``ur_type`` strings: ``ur3``, ``ur3e``, ``ur5``, ``ur5e``, ``ur10``, ``u
 Other important arguments are:
 
 
+* ``kinematics_params_file`` (default: *None*) - Path to the calibration file extracted from the robot, as described in :ref:`calibration_extraction`.
 * ``use_mock_hardware`` (default: *false* ) - Use simple hardware emulator from ros2_control. Useful for testing launch files, descriptions, etc.
 * ``headless_mode`` (default: *false*) - Start driver in :ref:`headless_mode`.
 * ``launch_rviz`` (default: *true*) - Start RViz together with the driver.
@@ -71,6 +72,23 @@ Depending on the :ref:`robot control mode<operation_modes>` do the following:
   already.
 
 .. _continuation_after_interruptions:
+
+Verify calibration info is being used correctly
+-----------------------------------------------
+
+.. _verify_calibration:
+
+If you passed a path to extracted calibration via the *kinematics_params_file*
+parameter, verify that the checksum of the loaded calibration matches that of your extracted
+calibration. Search for the term *checksum* in the console output after launching the driver,
+and you should see:
+
+.. code-block:: console
+
+  $ [INFO] [1694437690.406932381] [URPositionHardwareInterface]: Calibration checksum: 'calib_xxxxxxxxxxxxxxxxxxx'
+
+Verify that the printed checksum matches that on the final line of your extracted calibration file.
+
 
 Continuation after interruptions
 --------------------------------

--- a/ur_robot_driver/doc/usage/startup.rst
+++ b/ur_robot_driver/doc/usage/startup.rst
@@ -78,21 +78,23 @@ Verify calibration info is being used correctly
 
 .. _verify_calibration:
 
-If you passed a path to extracted calibration via the *kinematics_params_file*
+If you passed a path to an extracted calibration via the *kinematics_params_file*
 parameter, ensure that the loaded calibration matches that of the robot by inspecting the console
-output after launching ur_robot_driver. If the calibration does not match, you will see an error:
+output after launching the ``ur_robot_driver``. If the calibration does not match, you will see an error:
 
-.. code-block:: none
-
-  [ERROR] [1694437624.484381456] [URPositionHardwareInterface]: The calibration parameters of the connected robot don't match the ones from the given kinematics config file.
-
-Alternatively, search for the term *checksum* in the console output after launching the driver, and
-you should see:
-
-.. code-block:: none
+.. code-block::
 
   [INFO] [1694437690.406932381] [URPositionHardwareInterface]: Calibration checksum: 'calib_xxxxxxxxxxxxxxxxxxx'
+  [ERROR] [1694437690.516957265] [URPositionHardwareInterface]: The calibration parameters of the connected robot don't match the ones from the given kinematics config file.
 
+With the correct calibration you should see:
+
+.. code-block::
+
+  [INFO] [1694437690.406932381] [URPositionHardwareInterface]: Calibration checksum: 'calib_xxxxxxxxxxxxxxxxxxx'
+  [INFO] [1694437690.516957265] [URPositionHardwareInterface]: Calibration checked successfully.
+
+Alternatively, search for the term *checksum* in the console output after launching the driver.
 Verify that the printed checksum matches that on the final line of your extracted calibration file.
 
 

--- a/ur_robot_driver/doc/usage/startup.rst
+++ b/ur_robot_driver/doc/usage/startup.rst
@@ -79,13 +79,19 @@ Verify calibration info is being used correctly
 .. _verify_calibration:
 
 If you passed a path to extracted calibration via the *kinematics_params_file*
-parameter, verify that the checksum of the loaded calibration matches that of your extracted
-calibration. Search for the term *checksum* in the console output after launching the driver,
-and you should see:
+parameter, ensure that the loaded calibration matches that of the robot by inspecting the console
+output after launching ur_robot_driver. If the calibration does not match, you will see an error:
 
-.. code-block:: console
+.. code-block:: none
 
-  $ [INFO] [1694437690.406932381] [URPositionHardwareInterface]: Calibration checksum: 'calib_xxxxxxxxxxxxxxxxxxx'
+  [ERROR] [1694437624.484381456] [URPositionHardwareInterface]: The calibration parameters of the connected robot don't match the ones from the given kinematics config file.
+
+Alternatively, search for the term *checksum* in the console output after launching the driver, and
+you should see:
+
+.. code-block:: none
+
+  [INFO] [1694437690.406932381] [URPositionHardwareInterface]: Calibration checksum: 'calib_xxxxxxxxxxxxxxxxxxx'
 
 Verify that the printed checksum matches that on the final line of your extracted calibration file.
 


### PR DESCRIPTION
Added to / modified documentation to make it more clear how to utilize extracted calibration information, and how to verify that the information is being utilized. Also clarified that the robot must be on to extract calibration info.

I added a description of the parameter-passing method, but not the "create your own description package and use that" method. That seemed a little too in-depth and unnecessary for the getting started documentation, when the parameter method will work for most cases. But if I'm missing something, maybe we want to describe the second method as well.

Related issues: #799 