### PR TITLE
update control_toolbox branch

### DIFF
--- a/Universal_Robots_ROS2_Driver.humble.repos
+++ b/Universal_Robots_ROS2_Driver.humble.repos
@@ -30,7 +30,7 @@ repositories:
   control_toolbox:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
-    version: ros2-master
+    version: humble
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
control_toolbox has branched out for Humble. This updates the repos file accordingly.

See https://github.com/ros-controls/control_toolbox/pull/265