### PR TITLE
Install the urdf directory of ur_robot_driver

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -173,7 +173,7 @@ install(PROGRAMS scripts/start_ursim.sh
   DESTINATION lib/${PROJECT_NAME}
 )
 
-install(DIRECTORY config launch
+install(DIRECTORY config launch urdf
   DESTINATION share/${PROJECT_NAME}
 )
 


### PR DESCRIPTION
The directory is also installed on the main branch, and I did not see a reason why it should not be installed on Humble

The urdf file was added [here](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/commit/92b1bea47a939a266378f3095c1a87a6176f8537#diff-93110686145e59c58f86e3a61c7e8fdb0c9c66b8e6160918d72d09119498e0f9), but the CMakeLists.txt was not updated