### PR TITLE
Fix crashes on shutting down

### DIFF
--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -124,6 +124,7 @@ public:
   hardware_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) final;
   hardware_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) final;
   hardware_interface::CallbackReturn on_cleanup(const rclcpp_lifecycle::State& previous_state) final;
+  hardware_interface::CallbackReturn on_shutdown(const rclcpp_lifecycle::State& previous_state) final;
 
   hardware_interface::return_type read(const rclcpp::Time& time, const rclcpp::Duration& period) final;
   hardware_interface::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) final;
@@ -153,6 +154,9 @@ protected:
   template <typename T, size_t N>
   void readBitsetData(const std::unique_ptr<urcl::rtde_interface::DataPackage>& data_pkg, const std::string& var_name,
                       std::bitset<N>& data);
+
+  // stop function used by on_shutdown and on_cleanup
+  hardware_interface::CallbackReturn stop();
 
   void initAsyncIO();
   void checkAsyncIO();

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -58,9 +58,6 @@ namespace ur_robot_driver
 
 URPositionHardwareInterface::~URPositionHardwareInterface()
 {
-  // If the controller manager is shutdown via Ctrl + C the on_deactivate methods won't be called.
-  // We therefore need to make sure to actually deactivate the communication
-  on_cleanup(rclcpp_lifecycle::State());
 }
 
 hardware_interface::CallbackReturn
@@ -592,6 +589,19 @@ URPositionHardwareInterface::on_activate(const rclcpp_lifecycle::State& previous
 
 hardware_interface::CallbackReturn
 URPositionHardwareInterface::on_cleanup(const rclcpp_lifecycle::State& previous_state)
+{
+  RCLCPP_DEBUG(rclcpp::get_logger("URPositionHardwareInterface"), "on_cleanup");
+  return stop();
+}
+
+hardware_interface::CallbackReturn
+URPositionHardwareInterface::on_shutdown(const rclcpp_lifecycle::State& previous_state)
+{
+  RCLCPP_DEBUG(rclcpp::get_logger("URPositionHardwareInterface"), "on_shutdown");
+  return stop();
+}
+
+hardware_interface::CallbackReturn URPositionHardwareInterface::stop()
 {
   RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"), "Stopping ...please wait...");
 


### PR DESCRIPTION
We did not have the on_shutdown method implemented which gets called by the resource manager when shutting down. This could potentially result in crashes or pipeline overflows when shutting down the control node.

There was an intermediate fix calling on_cleanup in the destructor, which isn't correct either. That got deleted.