### PR TITLE
Use modern CMake to link against yaml-cpp

### DIFF
--- a/ur_calibration/CMakeLists.txt
+++ b/ur_calibration/CMakeLists.txt
@@ -17,10 +17,9 @@ find_package(rclcpp REQUIRED)
 find_package(ur_robot_driver REQUIRED)
 
 find_package(Eigen3 REQUIRED)
+find_package(yaml_cpp_vendor REQUIRED)
 find_package(yaml-cpp REQUIRED)
 find_package(ur_client_library REQUIRED)
-
-set(YAML_CPP_INCLUDE_DIRS ${YAML_CPP_INCLUDE_DIR})
 
 ###########
 ## Build ##
@@ -34,10 +33,9 @@ target_include_directories(calibration
   PUBLIC
     include
     ${EIGEN3_INCLUDE_DIRS}
-    ${YAML_CPP_INCLUDE_DIRS}
 )
 target_link_libraries(calibration
-  ${YAML_CPP_LIBRARIES}
+  yaml-cpp::yaml-cpp
 )
 ament_target_dependencies(calibration
   rclcpp

--- a/ur_calibration/package.xml
+++ b/ur_calibration/package.xml
@@ -21,6 +21,7 @@
 
   <depend>eigen</depend>
   <depend>yaml-cpp</depend>
+  <depend>yaml_cpp_vendor</depend>
 
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
The way we link against yaml-cpp seems to be a leftover from times where it didn't support modern CMake.

Fixes #1294 