### PR TITLE
Update upstream workspace to branched out jazzy versions

### DIFF
--- a/Universal_Robots_ROS2_Driver.jazzy.repos
+++ b/Universal_Robots_ROS2_Driver.jazzy.repos
@@ -22,26 +22,26 @@ repositories:
   kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
-    version: master
+    version: jazzy
   control_msgs:
     type: git
     url: https://github.com/ros-controls/control_msgs.git
-    version: master
+    version: jazzy
   control_toolbox:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
-    version: ros2-master
+    version: jazzy
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git
     version: jazzy
   moveit2:
     type: git
-    url: https://github.com/ros-planning/moveit2.git
+    url: https://github.com/moveit/moveit2.git
     version: main
   moveit_msgs:
     type: git
-    url: https://github.com/ros-planning/moveit_msgs.git
+    url: https://github.com/moveit/moveit_msgs.git
     version: ros2
   srdfdom:
     type: git

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -37,11 +37,11 @@ repositories:
     version: master
   moveit2:
     type: git
-    url: https://github.com/ros-planning/moveit2.git
+    url: https://github.com/moveit/moveit2.git
     version: main
   moveit_msgs:
     type: git
-    url: https://github.com/ros-planning/moveit_msgs.git
+    url: https://github.com/moveit/moveit_msgs.git
     version: ros2
   srdfdom:
     type: git


### PR DESCRIPTION
ros2_controls branched out a couple of packages for Jazzy. This doesn't necessarily mean that we have to branch out, too, but we should adapt in the upstream workspaces for the semi-binary builds. This way we will see when they diverge in an API-incompatible manor.