### PR TITLE
Fix passthrough controller to not read non-existing state_interfaces

### DIFF
--- a/ur_controllers/src/passthrough_trajectory_controller.cpp
+++ b/ur_controllers/src/passthrough_trajectory_controller.cpp
@@ -597,7 +597,7 @@ bool PassthroughTrajectoryController::check_goal_tolerance()
       return false;
     }
 
-    if (!active_joint_traj_.points.back().velocities.empty()) {
+    if (!active_joint_traj_.points.back().velocities.empty() && !joint_velocity_state_interface_.empty()) {
       const auto joint_vel = joint_velocity_state_interface_[i].get().get_optional();
       if (!joint_vel.has_value()) {
         return false;
@@ -607,7 +607,7 @@ bool PassthroughTrajectoryController::check_goal_tolerance()
         return false;
       }
     }
-    if (!active_joint_traj_.points.back().accelerations.empty()) {
+    if (!active_joint_traj_.points.back().accelerations.empty() && !joint_acceleration_state_interface_.empty()) {
       const auto joint_acc = joint_acceleration_state_interface_[i].get().get_optional();
       if (!joint_acc.has_value()) {
         return false;


### PR DESCRIPTION
When specifying higher-order splines while no velocity or acceleration state interfaces are configured for the robot, the controller attempted to read from the non-existing interfaces. This PR adds a check whether those interfaces are actually configured before attempting to read from them.