### PR TITLE
Disable enforcing command limits

### DIFF
--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -42,6 +42,14 @@ controller_manager:
     tool_contact_controller:
       type: ur_controllers/ToolContactController
 
+    # The way this is currently implemented upstream doesn't really work for us. When using
+    # position control, the robot will have a tracking error. However, limits will be enforced
+    # from the currently reported position, effectively limiting the possible step size using the
+    # joints' velocity limits. Until this is resolved, we will keep command limits non-enforced.
+    # Note: On Jazzy this is the default behavior, anyway. For Rolling / Kilted this defaults to
+    # true.
+    enforce_command_limits: false
+
 speed_scaling_state_broadcaster:
   ros__parameters:
     state_publish_rate: 100.0


### PR DESCRIPTION
This feature has recently been added in ros2_control and enabled in Rolling / Kilted by default. However, this causes command clampings due to the tracking error that comes from the controller cascade using servoj on the robot.

This may be changed in the future once there is another implementation available taking tracking errors into account.