### PR TITLE
Remove deprecated code from sjtc

### DIFF
--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -133,7 +133,7 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
     // if sampling the first time, set the point before you sample
     if (!current_trajectory_->is_sampled_already()) {
       first_sample = true;
-      if (params_.interpolate_from_desired_state || params_.open_loop_control) {
+      if (params_.interpolate_from_desired_state) {
         if (std::abs(last_commanded_time_.seconds()) < std::numeric_limits<float>::epsilon()) {
           last_commanded_time_ = time;
         }


### PR DESCRIPTION
The open_loop parameter has been removed upstream (see https://github.com/ros-controls/ros2_controllers/pull/1598), so we'll have to remove it from here, as well.