### PR TITLE
Add a release config file for GitHub release note auto-generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+---
+changelog:
+  exclude:
+    labels:
+      - release
+  categories:
+    - title: Bugfixes
+      labels:
+        - bugfix
+    - title: New features
+      labels:
+        - enhancement
+    - title: Documentation
+      labels:
+        - documentation
+    - title: CI/ Repo / Packages
+      labels:
+        - CI
+        - package
+        - dependencies
+    - title: Other
+      labels:
+        - "*"


### PR DESCRIPTION
Github allows customizing the auto-generated changelogs. This is a first attempt to configure that.