### PR TITLE
Use the Python mirror for clang-format in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,15 +86,10 @@ repos:
         files: \.(h\+\+|h|hh|hxx|hpp|cuh|c|cc|cpp|cu|c\+\+|cxx|tpp|txx)$
         args: ["--linelength=120"]
 
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: 'v20.1.5'
     hooks:
       - id: clang-format
-        name: clang-format
-        description: Format files with ClangFormat.
-        entry: clang-format-14
-        language: system
-        files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
-        args: ['-fallback-style=none', '-i']
 
   # Cmake hooks
   - repo: local


### PR DESCRIPTION
This will not require users to have a specific clang-format version installed. Also, this will be updated automatically, so we are not stuck with an old clang-format version. If formatting changes come in from a newer clang-format version, we can adapt our config whenever that happens.