### PR TITLE
Ignore deprecation warning for set_gains for now

### DIFF
--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -354,7 +354,10 @@ void ScaledJointTrajectoryController::update_pids()
     const auto& gains = params_.gains.joints_map.at(params_.joints.at(map_cmd_to_joints_[i]));
     if (pids_[i]) {
       // update PIDs with gains from ROS parameters
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       pids_[i]->set_gains(gains.p, gains.i, gains.d, gains.i_clamp, -gains.i_clamp);
+#pragma GCC diagnostic pop
     } else {
       // Init PIDs with gains from ROS parameters
       pids_[i] = std::make_shared<control_toolbox::Pid>(gains.p, gains.i, gains.d, gains.i_clamp, -gains.i_clamp);


### PR DESCRIPTION
The upstream API isn't finalized, yet. For now, let's ignore the deprecation warning in order to not fail our builds.

As discussed in https://github.com/ros-controls/control_toolbox/issues/392 the API change isn't final, yet.