### PR TITLE
ur_calibration: Fix compilation with BUILD_SHARED_LIBS:BOOL=ON on Windows

### DIFF
--- a/ur_calibration/CMakeLists.txt
+++ b/ur_calibration/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 project(ur_calibration)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(-Wall -Wextra -Wpedantic -Wno-unused-parameter)
 endif()
 
-add_compile_options(-Wno-unused-parameter)
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   message("${PROJECT_NAME}: You did not request a specific build type: selecting 'RelWithDebInfo'.")


### PR DESCRIPTION
The package compiles a library, but does not expose any symbol on Windows, so if the CMake project is compiled with `-DBUILD_SHARED_LIBS:BOOL=ON` on Windows, no library is actually generated.

On Linux and macOS, everything compiles fine with  `-DBUILD_SHARED_LIBS:BOOL=ON` as by default all the symbols are visible. We can achieve exactly the same behavior in Windows by setting to `ON` the [`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`](https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html) CMake variable, so this PR sets the `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` variable to `ON`, to ensure that the compilation with `-DBUILD_SHARED_LIBS:BOOL=ON` works fine on Windows.

Furthermore, the `-Wno-unused-parameter` is a GCC/Clang specific compilations option, so I moved it in the existing `if` for adding GCC/Clang specific compilations options.