### PR TITLE
ur_controllers: Fix compilation on Windows

### DIFF
--- a/ur_controllers/CMakeLists.txt
+++ b/ur_controllers/CMakeLists.txt
@@ -4,6 +4,7 @@ project(ur_controllers)
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra)
 endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 find_package(ament_cmake REQUIRED)
 find_package(angles REQUIRED)
@@ -133,7 +134,9 @@ target_link_libraries(${PROJECT_NAME}
   tf2_ros::tf2_ros
 )
 
-target_compile_options(${PROJECT_NAME} PRIVATE -Wpedantic -Werror)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(${PROJECT_NAME} PRIVATE -Wpedantic -Werror)
+endif()
 
 # prevent pluginlib from using boost
 target_compile_definitions(${PROJECT_NAME} PUBLIC "PLUGINLIB__DISABLE_BOOST_FUNCTIONS")


### PR DESCRIPTION
The package compiles a library, but does not expose any symbol on Windows, so if the CMake project is compiled on  on Windows, no library is actually generated.

On Linux and macOS, everything compiles by default all the symbols are visible. We can achieve exactly the same behavior in Windows by setting to `ON` the [`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`](https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html) CMake variable, so this PR sets the `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` variable to `ON`, to ensure that the compilation works fine on Windows.

Furthermore, the `-Wpedantic -Werror` are GCC/Clang specific compilations options, so I moved it in an `if` for adding GCC/Clang specific compilations options.