### PR TITLE
ur_robot_driver: Fix compilation on Windows

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -9,9 +9,12 @@ option(
   OFF
 )
 
-add_compile_options(-Wall)
-add_compile_options(-Wextra)
-add_compile_options(-Wno-unused-parameter)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall)
+  add_compile_options(-Wextra)
+  add_compile_options(-Wno-unused-parameter)
+endif()
+set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   message("${PROJECT_NAME}: You did not request a specific build type: selecting 'RelWithDebInfo'.")

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -299,7 +299,7 @@ protected:
   double pausing_ramp_up_increment_;
 
   // resources switching aux vars
-  std::vector<std::vector<uint>> stop_modes_;
+  std::vector<std::vector<uint32_t>> stop_modes_;
   std::vector<std::vector<std::string>> start_modes_;
   bool position_controller_running_;
   bool velocity_controller_running_;

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -181,7 +181,7 @@ std::vector<hardware_interface::StateInterface> URPositionHardwareInterface::exp
       const std::vector<std::string> fts_names = {
         "force.x", "force.y", "force.z", "torque.x", "torque.y", "torque.z"
       };
-      for (uint j = 0; j < 6; ++j) {
+      for (uint32_t j = 0; j < 6; ++j) {
         state_interfaces.emplace_back(
             hardware_interface::StateInterface(sensor.name, fts_names[j], &urcl_ft_sensor_measurements_[j]));
       }
@@ -1073,7 +1073,7 @@ hardware_interface::return_type URPositionHardwareInterface::prepare_command_mod
   hardware_interface::return_type ret_val = hardware_interface::return_type::OK;
 
   start_modes_ = std::vector<std::vector<std::string>>(info_.joints.size());
-  stop_modes_ = std::vector<std::vector<uint>>(info_.joints.size());
+  stop_modes_ = std::vector<std::vector<uint32_t>>(info_.joints.size());
   std::vector<std::vector<std::string>> control_modes(info_.joints.size());
   const std::string tf_prefix = info_.hardware_parameters.at("tf_prefix");
 

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -366,7 +366,7 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
           result_->message = "Play program service not available on this robot.";
         } else {
           // The dashboard denies playing immediately after switching the mode to RUNNING
-          sleep(1);
+          std::this_thread::sleep_for(std::chrono::milliseconds(1000));
           result_->success = safeDashboardTrigger(this->play_program_srv_);
         }
       }


### PR DESCRIPTION
The package compiles a library, but does not expose any symbol on Windows, so if the CMake project is compiled on  on Windows, no library is actually generated.

On Linux and macOS, everything compiles by default all the symbols are visible. We can achieve exactly the same behavior in Windows by setting to `ON` the [`CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS`](https://cmake.org/cmake/help/v3.4/variable/CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS.html) CMake variable, so this PR sets the `CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS` variable to `ON`, to ensure that the compilation works fine on Windows.

Furthermore, the following fixes were also added:
* `-Wall -Wextra` are GCC/Clang specific compilations options, so I moved it in an `if` for adding GCC/Clang specific compilations options.
* `uint` does not exists in Windows, so we use `uint32_t` instead
* The `sleep` function is not defined on Windows, so we use `std::this_thread::sleep_for` instead