### PR TITLE
Fix: Ignore first trajectory point in passthrough traj controller if time is 0

### DIFF
--- a/ur_moveit_config/config/moveit_controllers.yaml
+++ b/ur_moveit_config/config/moveit_controllers.yaml
@@ -10,9 +10,11 @@ trajectory_execution:
 moveit_simple_controller_manager:
   controller_names:
     - scaled_joint_trajectory_controller
+    - passthrough_trajectory_controller
     - joint_trajectory_controller
 
-  scaled_joint_trajectory_controller:
+  #scaled_joint_trajectory_controller:
+  passthrough_trajectory_controller:
     action_ns: follow_joint_trajectory
     type: FollowJointTrajectory
     default: true

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -337,7 +337,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "initial_joint_controller",
-            default_value="scaled_joint_trajectory_controller",
+            default_value="passthrough_trajectory_controller",
             choices=[
                 "scaled_joint_trajectory_controller",
                 "joint_trajectory_controller",


### PR DESCRIPTION
Currently, when the first trajectory point has a time of 0, this raises an error on the robot, as the spline segment would have the length 0.

Some planners do add such a point with the current joint positions at the beginning. An easy fix to handle this is to ignore the first point in that case.

Note: Currently, this contains a commit to configure moveit and the driver to use the passthrough controller by default to easily test this. This will be reverted before this is marked as ready.