### PR TITLE
Set minimal velocity tolerance in passthrough trajectory test

### DIFF
--- a/ur_robot_driver/test/robot_driver.py
+++ b/ur_robot_driver/test/robot_driver.py
@@ -369,7 +369,7 @@ class RobotDriverTest(unittest.TestCase):
             Duration(sec=12, nanosec=0),
         ]
         goal_tolerance = [
-            JointTolerance(position=0.01, name=tf_prefix + ROBOT_JOINTS[i])
+            JointTolerance(position=0.01, velocity=5e-5, name=tf_prefix + ROBOT_JOINTS[i])
             for i in range(len(ROBOT_JOINTS))
         ]
         goal_time_tolerance = Duration(sec=1, nanosec=0)


### PR DESCRIPTION
When running a quintic spline with the passthrough trajectory test there can be a minimal velocity deviation at the end of the trajectory due to how the robot interpolates motions. With a velocity tolerance of 0.0 there is a chance that we hit this tolerance.