### PR TITLE
ur_moveit_config: Assure the description is loaded as string

### DIFF
--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -125,7 +125,7 @@ def launch_setup(context, *args, **kwargs):
             " ",
         ]
     )
-    robot_description = {"robot_description": robot_description_content}
+    robot_description = {"robot_description": ParameterValue(robot_description_content, value_type=str)}
 
     # MoveIt Configuration
     robot_description_semantic_content = Command(


### PR DESCRIPTION
Otherwise the description might get loaded as yaml under certain situations.

As noted in https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1103#issuecomment-3053056137

@katallen405 would you like to test that?
