### PR TITLE
Migrate hardware_interface's on_init method

### DIFF
--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -118,7 +118,7 @@ public:
   URPositionHardwareInterface();
   virtual ~URPositionHardwareInterface();
 
-  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareInfo& system_info) final;
+  hardware_interface::CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams& params) final;
 
   std::vector<hardware_interface::StateInterface> export_state_interfaces() final;
 

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -101,13 +101,13 @@ URPositionHardwareInterface::~URPositionHardwareInterface()
 }
 
 hardware_interface::CallbackReturn
-URPositionHardwareInterface::on_init(const hardware_interface::HardwareInfo& system_info)
+URPositionHardwareInterface::on_init(const hardware_interface::HardwareComponentInterfaceParams& params)
 {
-  if (hardware_interface::SystemInterface::on_init(system_info) != hardware_interface::CallbackReturn::SUCCESS) {
+  if (hardware_interface::SystemInterface::on_init(params) != hardware_interface::CallbackReturn::SUCCESS) {
     return hardware_interface::CallbackReturn::ERROR;
   }
 
-  info_ = system_info;
+  info_ = params.hardware_info;
 
   // initialize
   urcl_joint_positions_ = { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } };


### PR DESCRIPTION
The preferred signature of hardware_interface::on_init has been changed upstream. This change avoids a deprecation warning on that.