### PR TITLE
Add scaling parameters to upstream JTC

### DIFF
--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -97,12 +97,17 @@ joint_trajectory_controller:
     constraints:
       stopped_velocity_tolerance: 0.2
       goal_time: 0.0
-      $(var tf_prefix)shoulder_pan_joint: { trajectory: 0.2, goal: 0.1 }
-      $(var tf_prefix)shoulder_lift_joint: { trajectory: 0.2, goal: 0.1 }
-      $(var tf_prefix)elbow_joint: { trajectory: 0.2, goal: 0.1 }
-      $(var tf_prefix)wrist_1_joint: { trajectory: 0.2, goal: 0.1 }
-      $(var tf_prefix)wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
-      $(var tf_prefix)wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
+      $(var tf_prefix)shoulder_pan_joint: {trajectory: 0.2, goal: 0.1}
+      $(var tf_prefix)shoulder_lift_joint: {trajectory: 0.2, goal: 0.1}
+      $(var tf_prefix)elbow_joint: {trajectory: 0.2, goal: 0.1}
+      $(var tf_prefix)wrist_1_joint: {trajectory: 0.2, goal: 0.1}
+      $(var tf_prefix)wrist_2_joint: {trajectory: 0.2, goal: 0.1}
+      $(var tf_prefix)wrist_3_joint: {trajectory: 0.2, goal: 0.1}
+    speed_scaling:
+      state_interface: $(var tf_prefix)speed_scaling/speed_scaling_factor
+      # Setting the command interface currently would clash with the io_and_status_controller
+      # This will probably be changed in the future.
+      # command_interface: $(var tf_prefix)speed_scaling/target_speed_fraction_cmd
 
 
 scaled_joint_trajectory_controller:


### PR DESCRIPTION
Since the upstream JTC supports scaling by know, we can start adding the state interface to the controller.