### PR TITLE
Add a PD control interface and a controller to that

### DIFF
--- a/ur_controllers/CMakeLists.txt
+++ b/ur_controllers/CMakeLists.txt
@@ -92,6 +92,11 @@ generate_parameter_library(
   src/ur_configuration_controller_parameters.yaml
 )
 
+generate_parameter_library(
+  pd_torque_controller_parameters
+  src/pd_torque_controller_parameters.yaml
+)
+
 add_library(${PROJECT_NAME} SHARED
   src/tool_contact_controller.cpp
   src/force_mode_controller.cpp
@@ -100,6 +105,7 @@ add_library(${PROJECT_NAME} SHARED
   src/freedrive_mode_controller.cpp
   src/gpio_controller.cpp
   src/passthrough_trajectory_controller.cpp
+  src/pd_torque_controller.cpp
   src/ur_configuration_controller.cpp)
 
 target_include_directories(${PROJECT_NAME} PRIVATE
@@ -114,6 +120,7 @@ target_link_libraries(${PROJECT_NAME}
   freedrive_mode_controller_parameters
   passthrough_trajectory_controller_parameters
   ur_configuration_controller_parameters
+  pd_torque_controller_parameters
   ${geometry_msgs_TARGETS}
   ${lifecycle_msgs_TARGETS}
   ${std_msgs_TARGETS}

--- a/ur_controllers/CMakeLists.txt
+++ b/ur_controllers/CMakeLists.txt
@@ -190,10 +190,20 @@ if(BUILD_TESTING)
     controller_manager::controller_manager
     ros2_control_test_assets::ros2_control_test_assets
   )
+
   ament_add_gmock(test_load_freedrive_mode_controller
     test/test_load_freedrive_mode_controller.cpp
   )
   target_link_libraries(test_load_freedrive_mode_controller
+    ${PROJECT_NAME}
+    controller_manager::controller_manager
+    ros2_control_test_assets::ros2_control_test_assets
+  )
+
+  ament_add_gmock(test_load_pd_torque_controller
+    test/test_load_pd_torque_controller.cpp
+  )
+  target_link_libraries(test_load_pd_torque_controller
     ${PROJECT_NAME}
     controller_manager::controller_manager
     ros2_control_test_assets::ros2_control_test_assets

--- a/ur_controllers/controller_plugins.xml
+++ b/ur_controllers/controller_plugins.xml
@@ -39,4 +39,9 @@
       Controller to use the tool contact functionality of the robot.
     </description>
   </class>
+  <class name="ur_controllers/PDTorqueController" type="ur_controllers::PDTorqueController" base_class_type="controller_interface::ControllerInterface">
+    <description>
+      Controller to leverage the on-control-box PD controller.
+    </description>
+  </class>
 </library>

--- a/ur_controllers/include/ur_controllers/pd_torque_controller.hpp
+++ b/ur_controllers/include/ur_controllers/pd_torque_controller.hpp
@@ -1,0 +1,85 @@
+// Copyright 2025, Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <memory>
+
+#include <controller_interface/controller_interface.hpp>
+#include <std_msgs/msg/float64_multi_array.hpp>
+#include "realtime_tools/realtime_thread_safe_box.hpp"
+
+#include "ur_controllers/pd_torque_controller_parameters.hpp"
+
+namespace ur_controllers
+{
+class PDTorqueController : public controller_interface::ControllerInterface
+{
+public:
+  using CmdType = std_msgs::msg::Float64MultiArray;
+
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  // Change the input for the update function
+  controller_interface::return_type update(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+
+  CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
+
+  CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
+
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
+
+  CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
+
+  CallbackReturn on_init() override;
+
+private:
+  enum class ControlType
+  {
+    NONE = 0,
+    JOINT_SPACE = 9,
+    TASK_SPACE = 10,
+  };
+
+  void command_callback(const CmdType::SharedPtr msg, const ControlType control_type);
+
+  std::shared_ptr<pd_torque_controller::ParamListener> param_listener_;
+  pd_torque_controller::Params params_;
+
+  rclcpp::Subscription<CmdType>::SharedPtr joints_command_sub_;
+  rclcpp::Subscription<CmdType>::SharedPtr task_space_command_sub_;
+
+  // the realtime container to exchange the reference from subscriber
+  realtime_tools::RealtimeThreadSafeBox<CmdType> rt_command_;
+  // save the last reference in case of unable to get value from box
+  CmdType joint_commands_;
+
+  std::atomic<ControlType> control_type_{ ControlType::NONE };
+};
+}  // namespace ur_controllers

--- a/ur_controllers/include/ur_controllers/ur_configuration_controller.hpp
+++ b/ur_controllers/include/ur_controllers/ur_configuration_controller.hpp
@@ -88,6 +88,7 @@ private:
   realtime_tools::RealtimeBox<std::shared_ptr<VersionInformation>> robot_software_version_{
     std::make_shared<VersionInformation>()
   };
+  std::atomic<bool> robot_software_version_set_{ false };
 
   rclcpp::Service<ur_msgs::srv::GetRobotSoftwareVersion>::SharedPtr get_robot_software_version_srv_;
 

--- a/ur_controllers/src/pd_torque_controller.cpp
+++ b/ur_controllers/src/pd_torque_controller.cpp
@@ -95,7 +95,7 @@ controller_interface::CallbackReturn PDTorqueController::on_configure(const rclc
 
   // Create subscribers
   joints_command_sub_ = get_node()->create_subscription<std_msgs::msg::Float64MultiArray>(
-      "~/joint_command", rclcpp::SystemDefaultsQoS(), [this](const std_msgs::msg::Float64MultiArray::SharedPtr msg) {
+      "~/joint_commands", rclcpp::SystemDefaultsQoS(), [this](const std_msgs::msg::Float64MultiArray::SharedPtr msg) {
         if (msg->data.size() != 6) {
           RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *(get_node()->get_clock()), 1000,
                                "The given command has %zu entries, while it should have 6 entries. Dropping command.",
@@ -130,9 +130,6 @@ controller_interface::CallbackReturn PDTorqueController::on_configure(const rclc
         task_space_command[3] = axis.x() * angle;  // rx
         task_space_command[4] = axis.y() * angle;  // ry
         task_space_command[5] = axis.z() * angle;  // rz
-        RCLCPP_INFO(get_node()->get_logger(), "Received task space command: [%f, %f, %f, %f, %f, %f] in frame %s",
-                    task_space_command[0], task_space_command[1], task_space_command[2], task_space_command[3],
-                    task_space_command[4], task_space_command[5], msg->header.frame_id.c_str());
         command_callback(task_space_command, ControlType::TASK_SPACE);
       });
 

--- a/ur_controllers/src/pd_torque_controller.cpp
+++ b/ur_controllers/src/pd_torque_controller.cpp
@@ -1,0 +1,176 @@
+// Copyright 2025, Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include "ur_controllers/pd_torque_controller.hpp"
+#include <cmath>
+#include <limits>
+#include <rclcpp/logging.hpp>
+#include <lifecycle_msgs/msg/state.hpp>
+#include <rclcpp/utilities.hpp>
+
+namespace ur_controllers
+{
+controller_interface::CallbackReturn PDTorqueController::on_init()
+{
+  try {
+    // Create the parameter listener and get the parameters
+    param_listener_ = std::make_shared<pd_torque_controller::ParamListener>(get_node());
+    params_ = param_listener_->get_params();
+  } catch (const std::exception& e) {
+    fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
+    return CallbackReturn::ERROR;
+  }
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::InterfaceConfiguration PDTorqueController::command_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration config;
+  config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+
+  const std::string tf_prefix = params_.tf_prefix;
+
+  // Get the command interfaces needed for freedrive mode from the hardware interface
+  for (size_t i = 0; i < 6; ++i) {
+    config.names.emplace_back(tf_prefix + "pd_control/pd_target_" + std::to_string(i));
+  }
+  config.names.emplace_back(tf_prefix + "pd_control/pd_control_type");
+
+  return config;
+}
+
+controller_interface::InterfaceConfiguration PDTorqueController::state_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration config;
+  config.type = controller_interface::interface_configuration_type::NONE;
+  return config;
+}
+
+controller_interface::CallbackReturn PDTorqueController::on_configure(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  const auto logger = get_node()->get_logger();
+
+  if (!param_listener_) {
+    RCLCPP_ERROR(get_node()->get_logger(), "Error encountered during configuration");
+    return controller_interface::CallbackReturn::ERROR;
+  }
+
+  // update the dynamic map parameters
+  param_listener_->refresh_dynamic_parameters();
+
+  // get parameters from the listener in case they were updated
+  params_ = param_listener_->get_params();
+
+  // Create subscribers
+  joints_command_sub_ = get_node()->create_subscription<CmdType>(
+      "~/joint_command", rclcpp::SystemDefaultsQoS(),
+      [this](const CmdType::SharedPtr msg) { command_callback(msg, ControlType::JOINT_SPACE); });
+  // ToDo: We should rather subscribe to a Pose or PoseStamped message here.
+  task_space_command_sub_ = get_node()->create_subscription<CmdType>(
+      "~/task_space_commands", rclcpp::SystemDefaultsQoS(),
+      [this](const CmdType::SharedPtr msg) { command_callback(msg, ControlType::TASK_SPACE); });
+
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn PDTorqueController::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  control_type_.store(ControlType::NONE);
+  joint_commands_.data.resize(6, std::numeric_limits<double>::quiet_NaN());  // Initialize joint commands to zero
+  rt_command_.try_set(joint_commands_);
+
+  RCLCPP_INFO(get_node()->get_logger(), "PDTorqueController activated.");
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn
+PDTorqueController::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  control_type_.store(ControlType::NONE);
+  RCLCPP_INFO(get_node()->get_logger(), "PDTorqueController deactivated.");
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn PDTorqueController::on_cleanup(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  RCLCPP_INFO(get_node()->get_logger(), "PDTorqueController cleaned up.");
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+void PDTorqueController::command_callback(const CmdType::SharedPtr msg, const ControlType control_type)
+{
+  if (!std::all_of(msg->data.cbegin(), msg->data.cend(), [](const auto& value) { return std::isfinite(value); })) {
+    RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *(get_node()->get_clock()), 1000,
+                         "One or more entries aren't finite. Dropping command.");
+    return;
+  }
+  if (get_node()->get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
+    if (msg->data.size() != 6) {
+      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *(get_node()->get_clock()), 1000,
+                           "The given command has %zu entries, while it should have 6 entries. Dropping command.",
+                           msg->data.size());
+      return;
+    }
+  }
+  rt_command_.set(*msg);
+  control_type_.store(control_type);
+}
+
+controller_interface::return_type PDTorqueController::update(const rclcpp::Time& /*time*/,
+                                                             const rclcpp::Duration& /*period*/)
+{
+  // Check if we have a command
+  auto command = rt_command_.try_get();
+  if (command.has_value()) {
+    joint_commands_ = command.value();
+  }
+
+  for (size_t i = 0; i < 6; ++i) {
+    if (std::isfinite(joint_commands_.data[i])) {
+      if (!command_interfaces_[i].set_value(joint_commands_.data[i])) {
+        RCLCPP_ERROR(get_node()->get_logger(), "Failed to set command interface %zu to value %f", i,
+                     joint_commands_.data[i]);
+        return controller_interface::return_type::ERROR;
+      }
+    }
+  }
+
+  if (!command_interfaces_[6].set_value(static_cast<double>(control_type_.load()))) {
+    RCLCPP_ERROR(get_node()->get_logger(), "Failed to set control type to value %d",
+                 static_cast<int>(control_type_.load()));
+    return controller_interface::return_type::ERROR;
+  }
+
+  return controller_interface::return_type::OK;
+}
+
+}  // namespace ur_controllers
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(ur_controllers::PDTorqueController, controller_interface::ControllerInterface)

--- a/ur_controllers/src/pd_torque_controller.cpp
+++ b/ur_controllers/src/pd_torque_controller.cpp
@@ -27,11 +27,14 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include "ur_controllers/pd_torque_controller.hpp"
+
 #include <cmath>
 #include <limits>
-#include <rclcpp/logging.hpp>
+
 #include <lifecycle_msgs/msg/state.hpp>
+#include <rclcpp/logging.hpp>
 #include <rclcpp/utilities.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace ur_controllers
 {
@@ -85,15 +88,53 @@ controller_interface::CallbackReturn PDTorqueController::on_configure(const rclc
 
   // get parameters from the listener in case they were updated
   params_ = param_listener_->get_params();
+  const std::string tf_prefix = params_.tf_prefix;
+
+  tf_buffer_ = std::make_unique<tf2_ros::Buffer>(get_node()->get_clock());
+  tf_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf_buffer_);
 
   // Create subscribers
-  joints_command_sub_ = get_node()->create_subscription<CmdType>(
-      "~/joint_command", rclcpp::SystemDefaultsQoS(),
-      [this](const CmdType::SharedPtr msg) { command_callback(msg, ControlType::JOINT_SPACE); });
-  // ToDo: We should rather subscribe to a Pose or PoseStamped message here.
-  task_space_command_sub_ = get_node()->create_subscription<CmdType>(
+  joints_command_sub_ = get_node()->create_subscription<std_msgs::msg::Float64MultiArray>(
+      "~/joint_command", rclcpp::SystemDefaultsQoS(), [this](const std_msgs::msg::Float64MultiArray::SharedPtr msg) {
+        if (msg->data.size() != 6) {
+          RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *(get_node()->get_clock()), 1000,
+                               "The given command has %zu entries, while it should have 6 entries. Dropping command.",
+                               msg->data.size());
+          return;
+        }
+        std::array<double, 6> joint_commands;
+        std::copy(msg->data.begin(), msg->data.end(), joint_commands.begin());
+        command_callback(joint_commands, ControlType::JOINT_SPACE);
+      });
+  task_space_command_sub_ = get_node()->create_subscription<geometry_msgs::msg::PoseStamped>(
       "~/task_space_commands", rclcpp::SystemDefaultsQoS(),
-      [this](const CmdType::SharedPtr msg) { command_callback(msg, ControlType::TASK_SPACE); });
+      [this, tf_prefix](const geometry_msgs::msg::PoseStamped::SharedPtr msg) {
+        std::array<double, 6> task_space_command;
+        auto target_transformed = *msg;
+        if (msg->header.frame_id != tf_prefix + "base") {
+          try {
+            target_transformed = tf_buffer_->transform(*msg, tf_prefix + "base");
+          } catch (const tf2::TransformException& ex) {
+            RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *(get_node()->get_clock()), 1000,
+                                 "Could not transform %s to robot base: %s. Dropping command.",
+                                 msg->header.frame_id.c_str(), ex.what());
+          }
+        }
+        task_space_command[0] = target_transformed.pose.position.x;
+        task_space_command[1] = target_transformed.pose.position.y;
+        task_space_command[2] = target_transformed.pose.position.z;
+        tf2::Quaternion quat_tf;
+        tf2::convert(target_transformed.pose.orientation, quat_tf);
+        const double angle = quat_tf.getAngle();
+        const auto axis = quat_tf.getAxis();
+        task_space_command[3] = axis.x() * angle;  // rx
+        task_space_command[4] = axis.y() * angle;  // ry
+        task_space_command[5] = axis.z() * angle;  // rz
+        RCLCPP_INFO(get_node()->get_logger(), "Received task space command: [%f, %f, %f, %f, %f, %f] in frame %s",
+                    task_space_command[0], task_space_command[1], task_space_command[2], task_space_command[3],
+                    task_space_command[4], task_space_command[5], msg->header.frame_id.c_str());
+        command_callback(task_space_command, ControlType::TASK_SPACE);
+      });
 
   return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
@@ -101,7 +142,7 @@ controller_interface::CallbackReturn PDTorqueController::on_configure(const rclc
 controller_interface::CallbackReturn PDTorqueController::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
 {
   control_type_.store(ControlType::NONE);
-  joint_commands_.data.resize(6, std::numeric_limits<double>::quiet_NaN());  // Initialize joint commands to zero
+  joint_commands_.fill(std::numeric_limits<double>::quiet_NaN());
   rt_command_.try_set(joint_commands_);
 
   RCLCPP_INFO(get_node()->get_logger(), "PDTorqueController activated.");
@@ -122,22 +163,14 @@ controller_interface::CallbackReturn PDTorqueController::on_cleanup(const rclcpp
   return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-void PDTorqueController::command_callback(const CmdType::SharedPtr msg, const ControlType control_type)
+void PDTorqueController::command_callback(const std::array<double, 6> command_vec, const ControlType control_type)
 {
-  if (!std::all_of(msg->data.cbegin(), msg->data.cend(), [](const auto& value) { return std::isfinite(value); })) {
+  if (!std::all_of(command_vec.cbegin(), command_vec.cend(), [](const auto& value) { return std::isfinite(value); })) {
     RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *(get_node()->get_clock()), 1000,
                          "One or more entries aren't finite. Dropping command.");
     return;
   }
-  if (get_node()->get_current_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_ACTIVE) {
-    if (msg->data.size() != 6) {
-      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *(get_node()->get_clock()), 1000,
-                           "The given command has %zu entries, while it should have 6 entries. Dropping command.",
-                           msg->data.size());
-      return;
-    }
-  }
-  rt_command_.set(*msg);
+  rt_command_.set(command_vec);
   control_type_.store(control_type);
 }
 
@@ -151,10 +184,10 @@ controller_interface::return_type PDTorqueController::update(const rclcpp::Time&
   }
 
   for (size_t i = 0; i < 6; ++i) {
-    if (std::isfinite(joint_commands_.data[i])) {
-      if (!command_interfaces_[i].set_value(joint_commands_.data[i])) {
+    if (std::isfinite(joint_commands_[i])) {
+      if (!command_interfaces_[i].set_value(joint_commands_[i])) {
         RCLCPP_ERROR(get_node()->get_logger(), "Failed to set command interface %zu to value %f", i,
-                     joint_commands_.data[i]);
+                     joint_commands_[i]);
         return controller_interface::return_type::ERROR;
       }
     }

--- a/ur_controllers/src/pd_torque_controller_parameters.yaml
+++ b/ur_controllers/src/pd_torque_controller_parameters.yaml
@@ -1,0 +1,7 @@
+---
+pd_torque_controller:
+  tf_prefix: {
+    type: string,
+    default_value: "",
+    description: "Urdf prefix of the corresponding arm"
+  }

--- a/ur_controllers/src/ur_configuration_controller.cpp
+++ b/ur_controllers/src/ur_configuration_controller.cpp
@@ -88,18 +88,21 @@ controller_interface::InterfaceConfiguration URConfigurationController::state_in
 controller_interface::return_type URConfigurationController::update(const rclcpp::Time& /* time */,
                                                                     const rclcpp::Duration& /* period */)
 {
+  if (!robot_software_version_set_) {
+    robot_software_version_set_ =
+        robot_software_version_.try_set([this](const std::shared_ptr<VersionInformation>& ptr) {
+          ptr->major = state_interfaces_[StateInterfaces::ROBOT_VERSION_MAJOR].get_optional().value_or(0.0);
+          ptr->minor = state_interfaces_[StateInterfaces::ROBOT_VERSION_MINOR].get_optional().value_or(0.0);
+          ptr->build = state_interfaces_[StateInterfaces::ROBOT_VERSION_BUILD].get_optional().value_or(0.0);
+          ptr->bugfix = state_interfaces_[StateInterfaces::ROBOT_VERSION_BUGFIX].get_optional().value_or(0.0);
+        });
+  }
   return controller_interface::return_type::OK;
 }
 
 controller_interface::CallbackReturn
 URConfigurationController::on_activate(const rclcpp_lifecycle::State& /* previous_state */)
 {
-  robot_software_version_.set([this](const std::shared_ptr<VersionInformation> ptr) {
-    ptr->major = state_interfaces_[StateInterfaces::ROBOT_VERSION_MAJOR].get_optional().value_or(0.0);
-    ptr->minor = state_interfaces_[StateInterfaces::ROBOT_VERSION_MINOR].get_optional().value_or(0.0);
-    ptr->build = state_interfaces_[StateInterfaces::ROBOT_VERSION_BUILD].get_optional().value_or(0.0);
-    ptr->bugfix = state_interfaces_[StateInterfaces::ROBOT_VERSION_BUGFIX].get_optional().value_or(0.0);
-  });
   return controller_interface::CallbackReturn::SUCCESS;
 }
 
@@ -113,6 +116,10 @@ bool URConfigurationController::getRobotSoftwareVersion(
     ur_msgs::srv::GetRobotSoftwareVersion::Request::SharedPtr /*req*/,
     ur_msgs::srv::GetRobotSoftwareVersion::Response::SharedPtr resp)
 {
+  if (!robot_software_version_set_) {
+    RCLCPP_WARN(get_node()->get_logger(), "Robot software version not set yet.");
+    return false;
+  }
   std::shared_ptr<VersionInformation> temp;
   return robot_software_version_.try_get([resp](const std::shared_ptr<VersionInformation> ptr) {
     resp->major = ptr->major;

--- a/ur_controllers/test/pd_torque_controller_params.yaml
+++ b/ur_controllers/test/pd_torque_controller_params.yaml
@@ -1,0 +1,4 @@
+---
+force_mode_controller:
+  ros__parameters:
+    tf_prefix: ""

--- a/ur_controllers/test/test_load_pd_torque_controller.cpp
+++ b/ur_controllers/test/test_load_pd_torque_controller.cpp
@@ -1,0 +1,60 @@
+// Copyright 2024, Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gmock/gmock.h>
+#include "controller_manager/controller_manager.hpp"
+#include "rclcpp/executor.hpp"
+#include "rclcpp/executors/single_threaded_executor.hpp"
+#include "rclcpp/utilities.hpp"
+#include "ros2_control_test_assets/descriptions.hpp"
+
+TEST(TestLoadPdTorqueController, load_controller)
+{
+  std::shared_ptr<rclcpp::Executor> executor = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+
+  controller_manager::ControllerManager cm{ executor, ros2_control_test_assets::minimal_robot_urdf, true,
+                                            "test_controller_manager" };
+
+  const std::string test_file_path = std::string{ TEST_FILES_DIRECTORY } + "/pd_torque_controller_params.yaml";
+  cm.set_parameter({ "test_pd_torque_controller.params_file", test_file_path });
+
+  cm.set_parameter({ "test_pd_torque_controller.type", "ur_controllers/PDTorqueController" });
+
+  ASSERT_NE(cm.load_controller("test_pd_torque_controller"), nullptr);
+}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleMock(&argc, argv);
+  rclcpp::init(argc, argv);
+
+  int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+
+  return result;
+}

--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -21,6 +21,9 @@ controller_manager:
     forward_velocity_controller:
       type: velocity_controllers/JointGroupVelocityController
 
+    forward_effort_controller:
+      type: effort_controllers/JointGroupEffortController
+
     forward_position_controller:
       type: position_controllers/JointGroupPositionController
 
@@ -158,6 +161,17 @@ forward_velocity_controller:
       - $(var tf_prefix)wrist_2_joint
       - $(var tf_prefix)wrist_3_joint
     interface_name: velocity
+
+forward_effort_controller:
+  ros__parameters:
+    joints:
+      - $(var tf_prefix)shoulder_pan_joint
+      - $(var tf_prefix)shoulder_lift_joint
+      - $(var tf_prefix)elbow_joint
+      - $(var tf_prefix)wrist_1_joint
+      - $(var tf_prefix)wrist_2_joint
+      - $(var tf_prefix)wrist_3_joint
+    interface_name: effort
 
 forward_position_controller:
   ros__parameters:

--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -45,6 +45,9 @@ controller_manager:
     tool_contact_controller:
       type: ur_controllers/ToolContactController
 
+    pd_torque_controller:
+      type: ur_controllers/PDTorqueController
+
     # The way this is currently implemented upstream doesn't really work for us. When using
     # position control, the robot will have a tracking error. However, limits will be enforced
     # from the currently reported position, effectively limiting the possible step size using the
@@ -199,5 +202,9 @@ tcp_pose_broadcaster:
       child_frame_id: $(var tf_prefix)tool0_controller
 
 tool_contact_controller:
+  ros__parameters:
+    tf_prefix: "$(var tf_prefix)"
+
+pd_torque_controller:
   ros__parameters:
     tf_prefix: "$(var tf_prefix)"

--- a/ur_robot_driver/doc/hardware_interface.rst
+++ b/ur_robot_driver/doc/hardware_interface.rst
@@ -1,0 +1,52 @@
+:github_url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/blob/main/ur_robot_driver/doc/hardware_interface.rst
+
+UR Hardware interface
+=====================
+
+The UR hardware interface is the core piece of the ROS driver. It is responsible for communicating
+with the robot controller, sending commands and receiving status updates.
+
+The hardware interface is implemented using the ``ros2_control`` framework, which allows for modular
+and flexible control of the robot.
+
+.. note::
+   The hardware interface itself doesn't define how the robot's motion can be controlled through
+   ROS. For that, a **controller** is needed. There are many controllers to choose from, such as
+   the ``JointTrajectoryController`` or the ``ForceModeController``. See `ros2_controllers
+   <https://control.ros.org/rolling/doc/ros2_controllers/doc/controllers_index.html#controllers-for-manipulators-and-other-robots>`_
+   for "standard" controllers and :ref:`ur_controllers` for more information on UR-specific
+   controllers
+
+Supported control modes
+-----------------------
+
+The UR hardware interface supports the following control modes:
+
+- **Position control**: The robot's joints are controlled by specifying target positions.
+- **Velocity control**: The robot's joints are controlled by specifying target velocities.
+- **Effort control**: The robot's joints are controlled by specifying target efforts (torques).
+  (Only available when running PolyScope >= 5.23.0 / 10.10.0)
+- **Force control**: The robot's end-effector is controlled by specifying target forces
+  in Cartesian space.
+- **Freedrive mode**: The robot can be moved freely by the user without any active control.
+- **Passthrough Trajectory control**: Complete trajectory points are forwarded to the robot for
+  interpolation and execution.
+- **Tool contact mode**: The robot stops when the tool comes into contact with an object, allowing for
+  safe interaction with the environment.
+- **Speed scaling**: Speed scaling on the robot can be read and written through the hardware
+  interface.
+- **GPIO**: Digital and analog I/O pins can be read and written through the hardware interface.
+- **Payload**: Payload configuration can be changed during runtime through the hardware interface.
+- **Force torque sensor**: Force torque sensor data can be read through the hardware interface.
+  Zeroing the sensor is also supported.
+
+Interacting with the hardware interface
+---------------------------------------
+
+As stated above, motion control is done through controllers. However, the ros2_control framework
+provides a set of services to interact with the hardware interface directly. These services can be
+comfortably used through the ``ros2 control`` `command line tool
+<https://control.ros.org/rolling/doc/ros2_control/ros2controlcli/doc/userdoc.html>`_.
+
+E.g. ``ros2 control list_hardware_components`` will list all hardware components, including the UR
+hardware interface with its interfaces as listed above.

--- a/ur_robot_driver/doc/index.rst
+++ b/ur_robot_driver/doc/index.rst
@@ -17,6 +17,7 @@ ur_robot_driver
    usage/toc
    operation_modes
    setup_tool_communication
+   hardware_interface
    hardware_interface_parameters
    dashboard_client
    robot_state_helper

--- a/ur_robot_driver/examples/pd_torque_controller.py
+++ b/ur_robot_driver/examples/pd_torque_controller.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# Copyright 2025, Universal Robots A/S
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import time
+
+import rclpy
+from rclpy.node import Node
+from rclpy.executors import ExternalShutdownException
+
+from scipy.spatial.transform import Rotation as R, Slerp
+
+from builtin_interfaces.msg import Duration
+from controller_manager_msgs.srv import SwitchController
+from geometry_msgs.msg import PoseStamped
+from std_msgs.msg import Float64MultiArray
+from std_srvs.srv import Trigger
+
+from examples import Robot
+
+
+class PDTorqueControllerExample(Node):
+    JOINT_START = [-1.6, -1.55, -1.7, -1.0, 2.05, 0.5]
+    JOINT_TARGET = [-0.6, -1.15, -1.0, 1.0, 0.05, -0.5]
+    TASK_START = PoseStamped()
+    TASK_END = PoseStamped()
+
+    INTERPOLATION_STEPS = 100
+    timer_period = 0.02  # 50 Hz
+
+    def __init__(self):
+        super().__init__("pd_torque_example")
+
+        self.robot = Robot(self)
+        self.joint_target_pub = self.create_publisher(
+            Float64MultiArray, "/pd_torque_controller/joint_commands", 1
+        )
+        self.task_space_target_pub = self.create_publisher(
+            PoseStamped, "/pd_torque_controller/task_space_commands", 1
+        )
+
+        self.TASK_START.header.frame_id = "base"
+        self.TASK_START.pose.position.x = -0.10223
+        self.TASK_START.pose.position.y = -0.50695
+        self.TASK_START.pose.position.z = 0.51035
+        self.TASK_START.pose.orientation.x = 0.194808
+        self.TASK_START.pose.orientation.y = 0.980198
+        self.TASK_START.pose.orientation.z = -0.162579
+        self.TASK_START.pose.orientation.w = 0.276547
+
+        self.TASK_END.header.frame_id = "base"
+        self.TASK_END.pose.position.x = 0.2
+        self.TASK_END.pose.position.y = -0.2
+        self.TASK_END.pose.position.z = 0.2
+        self.TASK_END.pose.position.z = 0.2
+        self.TASK_END.pose.orientation.x = 0.519404
+        self.TASK_END.pose.orientation.y = -0.479812
+        self.TASK_END.pose.orientation.z = 0.533193
+        self.TASK_END.pose.orientation.w = -0.464441
+
+        self._step = 0
+        self.timer = None
+
+        self.robot.init_robot()
+        self.startup()
+        time.sleep(0.5)
+        self.move_joint_based()
+        time.sleep(0.5)
+        self.move_to_starting_pose()
+        time.sleep(0.5)
+        self.move_task_space()
+
+    def move_to_starting_pose(self):
+        self.robot.call_service(
+            "/controller_manager/switch_controller",
+            SwitchController.Request(
+                deactivate_controllers=[
+                    "force_mode_controller",
+                    "forward_effort_controller",
+                    "forward_position_controller",
+                    "forward_velocity_controller",
+                    "freedrive_mode_controller",
+                    "joint_trajectory_controller",
+                    "pd_torque_controller",
+                    "scaled_joint_trajectory_controller",
+                    "tool_contact_controller",
+                ],
+                activate_controllers=[
+                    "passthrough_trajectory_controller",
+                ],
+                strictness=SwitchController.Request.BEST_EFFORT,
+            ),
+        )
+        # Move robot in to position
+        self.robot.send_trajectory(
+            waypts=[self.JOINT_START],
+            time_vec=[Duration(sec=1, nanosec=0)],
+            action_client=self.robot.passthrough_trajectory_action_client,
+        )
+
+    def move_joint_based(self):
+        # Switch to pd_torque_controller
+        self.robot.call_service(
+            "/controller_manager/switch_controller",
+            SwitchController.Request(
+                deactivate_controllers=[
+                    "force_mode_controller",
+                    "forward_effort_controller",
+                    "forward_position_controller",
+                    "forward_velocity_controller",
+                    "freedrive_mode_controller",
+                    "joint_trajectory_controller",
+                    "passthrough_trajectory_controller",
+                    "scaled_joint_trajectory_controller",
+                    "tool_contact_controller",
+                ],
+                activate_controllers=["pd_torque_controller"],
+                strictness=SwitchController.Request.BEST_EFFORT,
+            ),
+        )
+        self._step = 0
+        self.get_logger().info("Starting joint-based movement")
+        self.timer = self.create_timer(self.timer_period, self.on_timer_joint, autostart=True)
+
+    def move_task_space(self):
+        # Switch to pd_torque_controller
+        self.robot.call_service(
+            "/controller_manager/switch_controller",
+            SwitchController.Request(
+                deactivate_controllers=[
+                    "force_mode_controller",
+                    "forward_effort_controller",
+                    "forward_position_controller",
+                    "forward_velocity_controller",
+                    "freedrive_mode_controller",
+                    "joint_trajectory_controller",
+                    "passthrough_trajectory_controller",
+                    "scaled_joint_trajectory_controller",
+                    "tool_contact_controller",
+                ],
+                activate_controllers=["pd_torque_controller"],
+                strictness=SwitchController.Request.BEST_EFFORT,
+            ),
+        )
+        self._step = 0
+        self.get_logger().info("Starting task space movement")
+        self.timer = self.create_timer(self.timer_period, self.on_timer_task, autostart=True)
+
+    def startup(self):
+        # Press play on the robot
+        self.robot.call_service("/dashboard_client/play", Trigger.Request())
+
+        time.sleep(0.5)
+        # Start controllers
+        self.move_to_starting_pose()
+
+    def on_timer_joint(self):
+        # Publish joint commands
+        joint_commands = Float64MultiArray()
+        joint_commands.data = [
+            a + (b - a) * self._step / self.INTERPOLATION_STEPS
+            for a, b in zip(self.JOINT_START, self.JOINT_TARGET)
+        ]
+        self.joint_target_pub.publish(joint_commands)
+
+        self.get_logger().info(
+            f"Step {self._step}/{self.INTERPOLATION_STEPS}, "
+            f"Joint Commands: {joint_commands.data}"
+        )
+
+        if self._step >= self.INTERPOLATION_STEPS:
+            self.timer.cancel()
+        self._step += 1
+
+    def on_timer_task(self):
+        # Publish task space commands
+        task_space_command = PoseStamped()
+        task_space_command.header.frame_id = "base"
+        task_space_command.pose.position.x = (
+            self.TASK_START.pose.position.x
+            + (self.TASK_END.pose.position.x - self.TASK_START.pose.position.x)
+            * self._step
+            / self.INTERPOLATION_STEPS
+        )
+        task_space_command.pose.position.y = (
+            self.TASK_START.pose.position.y
+            + (self.TASK_END.pose.position.y - self.TASK_START.pose.position.y)
+            * self._step
+            / self.INTERPOLATION_STEPS
+        )
+        task_space_command.pose.position.z = (
+            self.TASK_START.pose.position.z
+            + (self.TASK_END.pose.position.z - self.TASK_START.pose.position.z)
+            * self._step
+            / self.INTERPOLATION_STEPS
+        )
+
+        # If someone knows whether this is possible with pure rclpy, please let me know.
+        key_times = [0, self.INTERPOLATION_STEPS]
+        rotations = R.from_quat(
+            [
+                [
+                    self.TASK_END.pose.orientation.x,
+                    self.TASK_END.pose.orientation.y,
+                    self.TASK_END.pose.orientation.z,
+                    self.TASK_END.pose.orientation.w,
+                ],
+                [
+                    self.TASK_START.pose.orientation.x,
+                    self.TASK_START.pose.orientation.y,
+                    self.TASK_START.pose.orientation.z,
+                    self.TASK_START.pose.orientation.w,
+                ],
+            ]
+        )
+        slerp = Slerp(key_times, rotations)
+        interp_rot = slerp(self._step)
+        interp_quat = interp_rot.as_quat()
+
+        task_space_command.pose.orientation.x = interp_quat[0]
+        task_space_command.pose.orientation.y = interp_quat[1]
+        task_space_command.pose.orientation.z = interp_quat[2]
+        task_space_command.pose.orientation.w = interp_quat[3]
+
+        self.task_space_target_pub.publish(task_space_command)
+
+        if self._step >= self.INTERPOLATION_STEPS:
+            self.timer.cancel()
+        self._step += 1
+
+
+if __name__ == "__main__":
+    rclpy.init()
+
+    node = PDTorqueControllerExample()
+
+    node.get_logger().info("PDTorqueControllerExample started.")
+    try:
+        rclpy.spin(node)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -82,6 +82,7 @@ enum StoppingInterface
   STOP_FORCE_MODE,
   STOP_FREEDRIVE,
   STOP_TOOL_CONTACT,
+  STOP_TORQUE,
 };
 
 // We define our own quaternion to use it as a buffer, since we need to pass pointers to the state
@@ -177,6 +178,7 @@ protected:
   urcl::vector6d_t urcl_position_commands_;
   urcl::vector6d_t urcl_position_commands_old_;
   urcl::vector6d_t urcl_velocity_commands_;
+  urcl::vector6d_t urcl_torque_commands_;
   urcl::vector6d_t urcl_joint_positions_;
   urcl::vector6d_t urcl_joint_velocities_;
   urcl::vector6d_t urcl_joint_efforts_;
@@ -305,6 +307,7 @@ protected:
   std::vector<std::vector<std::string>> start_modes_;
   bool position_controller_running_;
   bool velocity_controller_running_;
+  bool torque_controller_running_;
   bool force_mode_controller_running_ = false;
 
   std::unique_ptr<urcl::UrDriver> ur_driver_;

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -83,6 +83,7 @@ enum StoppingInterface
   STOP_FREEDRIVE,
   STOP_TOOL_CONTACT,
   STOP_TORQUE,
+  STOP_PD_CONTROL,
 };
 
 // We define our own quaternion to use it as a buffer, since we need to pass pointers to the state
@@ -179,6 +180,7 @@ protected:
   urcl::vector6d_t urcl_position_commands_old_;
   urcl::vector6d_t urcl_velocity_commands_;
   urcl::vector6d_t urcl_torque_commands_;
+  urcl::vector6d_t urcl_pd_targets_;
   urcl::vector6d_t urcl_joint_positions_;
   urcl::vector6d_t urcl_joint_velocities_;
   urcl::vector6d_t urcl_joint_efforts_;
@@ -288,6 +290,8 @@ protected:
   std::array<double, 4> robot_status_bits_copy_;
   std::array<double, 11> safety_status_bits_copy_;
 
+  double pd_control_type_;
+
   bool robot_program_running_;
   bool non_blocking_read_;
   double robot_program_running_copy_;
@@ -321,6 +325,7 @@ protected:
   const std::string FORCE_MODE_GPIO = "force_mode";
   const std::string FREEDRIVE_MODE_GPIO = "freedrive_mode";
   const std::string TOOL_CONTACT_GPIO = "tool_contact";
+  const std::string PD_CONTROL_GPIO = "pd_control";
 
   std::unordered_map<std::string, std::unordered_map<std::string, bool>> mode_compatibility_;
 };

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -192,6 +192,7 @@ def launch_setup(context):
         "passthrough_trajectory_controller",
         "freedrive_mode_controller",
         "tool_contact_controller",
+        "pd_torque_controller",
     ]
     if activate_joint_controller.perform(context) == "true":
         controllers_active.append(initial_joint_controller.perform(context))

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -187,6 +187,7 @@ def launch_setup(context):
         "joint_trajectory_controller",
         "forward_velocity_controller",
         "forward_position_controller",
+        "forward_effort_controller",
         "force_mode_controller",
         "passthrough_trajectory_controller",
         "freedrive_mode_controller",

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -1253,7 +1253,8 @@ hardware_interface::return_type URPositionHardwareInterface::prepare_command_mod
           StoppingInterface::STOP_PASSTHROUGH },
         { tf_prefix + FREEDRIVE_MODE_GPIO + "/async_success", FREEDRIVE_MODE_GPIO, StoppingInterface::STOP_FREEDRIVE },
         { tf_prefix + TOOL_CONTACT_GPIO + "/tool_contact_set_state", TOOL_CONTACT_GPIO,
-          StoppingInterface::STOP_TOOL_CONTACT }
+          StoppingInterface::STOP_TOOL_CONTACT },
+        { tf_prefix + PD_CONTROL_GPIO + "/pd_control_type", PD_CONTROL_GPIO, StoppingInterface::STOP_PD_CONTROL }
       };
       for (auto& item : stop_modes_to_check) {
         if (key == std::get<0>(item)) {

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -60,37 +60,50 @@ namespace ur_robot_driver
 URPositionHardwareInterface::URPositionHardwareInterface()
 {
   mode_compatibility_[hardware_interface::HW_IF_POSITION][hardware_interface::HW_IF_VELOCITY] = false;
+  mode_compatibility_[hardware_interface::HW_IF_POSITION][hardware_interface::HW_IF_EFFORT] = false;
   mode_compatibility_[hardware_interface::HW_IF_POSITION][FORCE_MODE_GPIO] = false;
   mode_compatibility_[hardware_interface::HW_IF_POSITION][PASSTHROUGH_GPIO] = false;
   mode_compatibility_[hardware_interface::HW_IF_POSITION][FREEDRIVE_MODE_GPIO] = false;
   mode_compatibility_[hardware_interface::HW_IF_POSITION][TOOL_CONTACT_GPIO] = true;
 
   mode_compatibility_[hardware_interface::HW_IF_VELOCITY][hardware_interface::HW_IF_POSITION] = false;
+  mode_compatibility_[hardware_interface::HW_IF_VELOCITY][hardware_interface::HW_IF_EFFORT] = false;
   mode_compatibility_[hardware_interface::HW_IF_VELOCITY][FORCE_MODE_GPIO] = false;
   mode_compatibility_[hardware_interface::HW_IF_VELOCITY][PASSTHROUGH_GPIO] = false;
   mode_compatibility_[hardware_interface::HW_IF_VELOCITY][FREEDRIVE_MODE_GPIO] = false;
   mode_compatibility_[hardware_interface::HW_IF_VELOCITY][TOOL_CONTACT_GPIO] = true;
 
+  mode_compatibility_[hardware_interface::HW_IF_EFFORT][hardware_interface::HW_IF_POSITION] = false;
+  mode_compatibility_[hardware_interface::HW_IF_EFFORT][hardware_interface::HW_IF_VELOCITY] = false;
+  mode_compatibility_[hardware_interface::HW_IF_EFFORT][FORCE_MODE_GPIO] = false;
+  mode_compatibility_[hardware_interface::HW_IF_EFFORT][PASSTHROUGH_GPIO] = false;
+  mode_compatibility_[hardware_interface::HW_IF_EFFORT][FREEDRIVE_MODE_GPIO] = false;
+  mode_compatibility_[hardware_interface::HW_IF_EFFORT][TOOL_CONTACT_GPIO] = true;
+
   mode_compatibility_[FORCE_MODE_GPIO][hardware_interface::HW_IF_POSITION] = false;
   mode_compatibility_[FORCE_MODE_GPIO][hardware_interface::HW_IF_VELOCITY] = false;
+  mode_compatibility_[FORCE_MODE_GPIO][hardware_interface::HW_IF_EFFORT] = false;
   mode_compatibility_[FORCE_MODE_GPIO][PASSTHROUGH_GPIO] = true;
   mode_compatibility_[FORCE_MODE_GPIO][FREEDRIVE_MODE_GPIO] = false;
   mode_compatibility_[FORCE_MODE_GPIO][TOOL_CONTACT_GPIO] = false;
 
   mode_compatibility_[PASSTHROUGH_GPIO][hardware_interface::HW_IF_POSITION] = false;
   mode_compatibility_[PASSTHROUGH_GPIO][hardware_interface::HW_IF_VELOCITY] = false;
+  mode_compatibility_[PASSTHROUGH_GPIO][hardware_interface::HW_IF_EFFORT] = false;
   mode_compatibility_[PASSTHROUGH_GPIO][FORCE_MODE_GPIO] = true;
   mode_compatibility_[PASSTHROUGH_GPIO][FREEDRIVE_MODE_GPIO] = false;
   mode_compatibility_[PASSTHROUGH_GPIO][TOOL_CONTACT_GPIO] = true;
 
   mode_compatibility_[FREEDRIVE_MODE_GPIO][hardware_interface::HW_IF_POSITION] = false;
   mode_compatibility_[FREEDRIVE_MODE_GPIO][hardware_interface::HW_IF_VELOCITY] = false;
+  mode_compatibility_[FREEDRIVE_MODE_GPIO][hardware_interface::HW_IF_EFFORT] = false;
   mode_compatibility_[FREEDRIVE_MODE_GPIO][FORCE_MODE_GPIO] = false;
   mode_compatibility_[FREEDRIVE_MODE_GPIO][PASSTHROUGH_GPIO] = false;
   mode_compatibility_[FREEDRIVE_MODE_GPIO][TOOL_CONTACT_GPIO] = false;
 
   mode_compatibility_[TOOL_CONTACT_GPIO][hardware_interface::HW_IF_POSITION] = true;
   mode_compatibility_[TOOL_CONTACT_GPIO][hardware_interface::HW_IF_VELOCITY] = true;
+  mode_compatibility_[TOOL_CONTACT_GPIO][hardware_interface::HW_IF_EFFORT] = true;
   mode_compatibility_[TOOL_CONTACT_GPIO][FORCE_MODE_GPIO] = false;
   mode_compatibility_[TOOL_CONTACT_GPIO][PASSTHROUGH_GPIO] = true;
   mode_compatibility_[TOOL_CONTACT_GPIO][FREEDRIVE_MODE_GPIO] = false;
@@ -120,6 +133,7 @@ URPositionHardwareInterface::on_init(const hardware_interface::HardwareInfo& sys
   urcl_velocity_commands_ = { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } };
   position_controller_running_ = false;
   velocity_controller_running_ = false;
+  torque_controller_running_ = false;
   freedrive_mode_controller_running_ = false;
   passthrough_trajectory_controller_running_ = false;
   tool_contact_controller_running_ = false;
@@ -143,9 +157,9 @@ URPositionHardwareInterface::on_init(const hardware_interface::HardwareInfo& sys
   trajectory_joint_accelerations_.reserve(32768);
 
   for (const hardware_interface::ComponentInfo& joint : info_.joints) {
-    if (joint.command_interfaces.size() != 2) {
+    if (joint.command_interfaces.size() != 3) {
       RCLCPP_FATAL(rclcpp::get_logger("URPositionHardwareInterface"),
-                   "Joint '%s' has %zu command interfaces found. 2 expected.", joint.name.c_str(),
+                   "Joint '%s' has %zu command interfaces found. 3 expected.", joint.name.c_str(),
                    joint.command_interfaces.size());
       return hardware_interface::CallbackReturn::ERROR;
     }
@@ -328,6 +342,9 @@ std::vector<hardware_interface::CommandInterface> URPositionHardwareInterface::e
 
     command_interfaces.emplace_back(hardware_interface::CommandInterface(
         info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &urcl_velocity_commands_[i]));
+
+    command_interfaces.emplace_back(hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_EFFORT, &urcl_torque_commands_[i]));
   }
   // Obtain the tf_prefix from the urdf so that we can have the general interface multiple times
   // NOTE using the tf_prefix at this point is some kind of workaround. One should actually go through the list of gpio
@@ -810,6 +827,7 @@ hardware_interface::return_type URPositionHardwareInterface::read(const rclcpp::
       // initialize commands
       urcl_position_commands_ = urcl_position_commands_old_ = urcl_joint_positions_;
       urcl_velocity_commands_ = { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } };
+      urcl_torque_commands_ = { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } };
       target_speed_fraction_cmd_ = NO_NEW_CMD_;
       resend_robot_program_cmd_ = NO_NEW_CMD_;
       zero_ftsensor_cmd_ = NO_NEW_CMD_;
@@ -844,7 +862,8 @@ hardware_interface::return_type URPositionHardwareInterface::write(const rclcpp:
 
     } else if (velocity_controller_running_) {
       ur_driver_->writeJointCommand(urcl_velocity_commands_, urcl::comm::ControlMode::MODE_SPEEDJ, receive_timeout_);
-
+    } else if (torque_controller_running_) {
+      ur_driver_->writeJointCommand(urcl_torque_commands_, urcl::comm::ControlMode::MODE_TORQUE, receive_timeout_);
     } else if (freedrive_mode_controller_running_ && freedrive_activated_) {
       ur_driver_->writeFreedriveControlMessage(urcl::control::FreedriveControlMessage::FREEDRIVE_NOOP);
 
@@ -1124,6 +1143,9 @@ hardware_interface::return_type URPositionHardwareInterface::prepare_command_mod
     if (velocity_controller_running_) {
       control_modes[i] = { hardware_interface::HW_IF_VELOCITY };
     }
+    if (torque_controller_running_) {
+      control_modes[i] = { hardware_interface::HW_IF_EFFORT };
+    }
     if (force_mode_controller_running_) {
       control_modes[i].push_back(FORCE_MODE_GPIO);
     }
@@ -1159,6 +1181,7 @@ hardware_interface::return_type URPositionHardwareInterface::prepare_command_mod
       const std::vector<std::pair<std::string, std::string>> start_modes_to_check{
         { info_.joints[i].name + "/" + hardware_interface::HW_IF_POSITION, hardware_interface::HW_IF_POSITION },
         { info_.joints[i].name + "/" + hardware_interface::HW_IF_VELOCITY, hardware_interface::HW_IF_VELOCITY },
+        { info_.joints[i].name + "/" + hardware_interface::HW_IF_EFFORT, hardware_interface::HW_IF_EFFORT },
         { tf_prefix + FORCE_MODE_GPIO + "/type", FORCE_MODE_GPIO },
         { tf_prefix + PASSTHROUGH_GPIO + "/setpoint_positions_" + std::to_string(i), PASSTHROUGH_GPIO },
         { tf_prefix + FREEDRIVE_MODE_GPIO + "/async_success", FREEDRIVE_MODE_GPIO },
@@ -1192,6 +1215,8 @@ hardware_interface::return_type URPositionHardwareInterface::prepare_command_mod
           StoppingInterface::STOP_POSITION },
         { info_.joints[i].name + "/" + hardware_interface::HW_IF_VELOCITY, hardware_interface::HW_IF_VELOCITY,
           StoppingInterface::STOP_VELOCITY },
+        { info_.joints[i].name + "/" + hardware_interface::HW_IF_EFFORT, hardware_interface::HW_IF_EFFORT,
+          StoppingInterface::STOP_TORQUE },
         { tf_prefix + FORCE_MODE_GPIO + "/disable_cmd", FORCE_MODE_GPIO, StoppingInterface::STOP_FORCE_MODE },
         { tf_prefix + PASSTHROUGH_GPIO + "/setpoint_positions_" + std::to_string(i), PASSTHROUGH_GPIO,
           StoppingInterface::STOP_PASSTHROUGH },
@@ -1237,6 +1262,11 @@ hardware_interface::return_type URPositionHardwareInterface::perform_command_mod
     velocity_controller_running_ = false;
     urcl_velocity_commands_ = { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } };
   }
+  if (stop_modes_[0].size() != 0 &&
+      std::find(stop_modes_[0].begin(), stop_modes_[0].end(), StoppingInterface::STOP_TORQUE) != stop_modes_[0].end()) {
+    torque_controller_running_ = false;
+    urcl_torque_commands_ = { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } };
+  }
   if (stop_modes_[0].size() != 0 && std::find(stop_modes_[0].begin(), stop_modes_[0].end(),
                                               StoppingInterface::STOP_FORCE_MODE) != stop_modes_[0].end()) {
     force_mode_controller_running_ = false;
@@ -1267,6 +1297,7 @@ hardware_interface::return_type URPositionHardwareInterface::perform_command_mod
   if (start_modes_.size() != 0 && std::find(start_modes_[0].begin(), start_modes_[0].end(),
                                             hardware_interface::HW_IF_POSITION) != start_modes_[0].end()) {
     velocity_controller_running_ = false;
+    torque_controller_running_ = false;
     passthrough_trajectory_controller_running_ = false;
     urcl_position_commands_ = urcl_position_commands_old_ = urcl_joint_positions_;
     position_controller_running_ = true;
@@ -1274,9 +1305,17 @@ hardware_interface::return_type URPositionHardwareInterface::perform_command_mod
   } else if (start_modes_[0].size() != 0 && std::find(start_modes_[0].begin(), start_modes_[0].end(),
                                                       hardware_interface::HW_IF_VELOCITY) != start_modes_[0].end()) {
     position_controller_running_ = false;
+    torque_controller_running_ = false;
     passthrough_trajectory_controller_running_ = false;
     urcl_velocity_commands_ = { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } };
     velocity_controller_running_ = true;
+  } else if (start_modes_[0].size() != 0 && std::find(start_modes_[0].begin(), start_modes_[0].end(),
+                                                      hardware_interface::HW_IF_EFFORT) != start_modes_[0].end()) {
+    position_controller_running_ = false;
+    velocity_controller_running_ = false;
+    torque_controller_running_ = true;
+    passthrough_trajectory_controller_running_ = false;
+    urcl_torque_commands_ = { { 0.0, 0.0, 0.0, 0.0, 0.0, 0.0 } };
   }
   if (start_modes_[0].size() != 0 &&
       std::find(start_modes_[0].begin(), start_modes_[0].end(), FORCE_MODE_GPIO) != start_modes_[0].end()) {
@@ -1286,6 +1325,7 @@ hardware_interface::return_type URPositionHardwareInterface::perform_command_mod
       std::find(start_modes_[0].begin(), start_modes_[0].end(), PASSTHROUGH_GPIO) != start_modes_[0].end()) {
     velocity_controller_running_ = false;
     position_controller_running_ = false;
+    torque_controller_running_ = false;
     passthrough_trajectory_controller_running_ = true;
     passthrough_trajectory_abort_ = 0.0;
   }
@@ -1293,6 +1333,7 @@ hardware_interface::return_type URPositionHardwareInterface::perform_command_mod
       std::find(start_modes_[0].begin(), start_modes_[0].end(), FREEDRIVE_MODE_GPIO) != start_modes_[0].end()) {
     velocity_controller_running_ = false;
     position_controller_running_ = false;
+    torque_controller_running_ = false;
     freedrive_mode_controller_running_ = true;
     freedrive_activated_ = false;
   }

--- a/ur_robot_driver/test/integration_test_controller_switch.py
+++ b/ur_robot_driver/test/integration_test_controller_switch.py
@@ -97,6 +97,7 @@ class RobotDriverTest(unittest.TestCase):
                     "passthrough_trajectory_controller",
                     "force_mode_controller",
                     "freedrive_mode_controller",
+                    "pd_torque_controller",
                 ],
             ).ok
         )
@@ -134,6 +135,7 @@ class RobotDriverTest(unittest.TestCase):
                     "force_mode_controller",
                     "passthrough_trajectory_controller",
                     "freedrive_mode_controller",
+                    "pd_torque_controller",
                 ],
             ).ok
         )
@@ -208,6 +210,7 @@ class RobotDriverTest(unittest.TestCase):
                     "force_mode_controller",
                     "freedrive_mode_controller",
                     "passthrough_trajectory_controller",
+                    "pd_torque_controller",
                 ],
             ).ok
         )
@@ -269,7 +272,9 @@ class RobotDriverTest(unittest.TestCase):
             ).ok
         )
 
-    def test_activating_controller_with_running_passthrough_trajectory_controller_fails(self):
+    def test_activating_controller_with_running_passthrough_trajectory_controller_fails(
+        self,
+    ):
         # Having a position-based controller active, no other controller should be able to
         # activate.
         self.assertTrue(
@@ -425,6 +430,7 @@ class RobotDriverTest(unittest.TestCase):
                     "forward_position_controller",
                     "forward_velocity_controller",
                     "passthrough_trajectory_controller",
+                    "pd_torque_controller",
                     "force_mode_controller",
                     "tool_contact_controller",
                 ],
@@ -499,6 +505,57 @@ class RobotDriverTest(unittest.TestCase):
                 activate_controllers=[
                     "tool_contact_controller",
                     "freedrive_mode_controller",
+                ],
+            ).ok
+        )
+
+    def test_pf_torque_controller_compatibility(self):
+        # Deactivate all writing controllers
+        self.assertTrue(
+            self._controller_manager_interface.switch_controller(
+                strictness=SwitchController.Request.BEST_EFFORT,
+                deactivate_controllers=[
+                    "scaled_joint_trajectory_controller",
+                    "joint_trajectory_controller",
+                    "forward_position_controller",
+                    "forward_velocity_controller",
+                    "passthrough_trajectory_controller",
+                    "force_mode_controller",
+                    "tool_contact_controller",
+                ],
+            ).ok
+        )
+
+        self.assertTrue(
+            self._controller_manager_interface.switch_controller(
+                strictness=SwitchController.Request.STRICT,
+                activate_controllers=[
+                    "pd_torque_controller",
+                ],
+            ).ok
+        )
+
+        # Try starting another position controller verifying that resources are cleared properly
+        self.assertTrue(
+            self._controller_manager_interface.switch_controller(
+                strictness=SwitchController.Request.STRICT,
+                activate_controllers=[
+                    "scaled_joint_trajectory_controller",
+                ],
+                deactivate_controllers=[
+                    "pd_torque_controller",
+                ],
+            ).ok
+        )
+
+        self.assertTrue(
+            self._controller_manager_interface.switch_controller(
+                strictness=SwitchController.Request.STRICT,
+                deactivate_controllers=[
+                    "scaled_joint_trajectory_controller",
+                ],
+                activate_controllers=[
+                    "pd_torque_controller",
                 ],
             ).ok
         )

--- a/ur_robot_driver/test/integration_test_controller_switch.py
+++ b/ur_robot_driver/test/integration_test_controller_switch.py
@@ -231,6 +231,14 @@ class RobotDriverTest(unittest.TestCase):
             self._controller_manager_interface.switch_controller(
                 strictness=SwitchController.Request.STRICT,
                 activate_controllers=[
+                    "forward_effort_controller",
+                ],
+            ).ok
+        )
+        self.assertFalse(
+            self._controller_manager_interface.switch_controller(
+                strictness=SwitchController.Request.STRICT,
+                activate_controllers=[
                     "freedrive_mode_controller",
                 ],
             ).ok

--- a/ur_robot_driver/urdf/ur.ros2_control.xacro
+++ b/ur_robot_driver/urdf/ur.ros2_control.xacro
@@ -305,6 +305,12 @@
         <state_interface name="get_version_build"/>
         <state_interface name="get_version_bugfix"/>
       </gpio>
+
+      <gpio name="${tf_prefix}pd_control">
+        <command_interface name="pd_control_active">
+         <param name="data_type">bool</param>
+        </command_interface>
+      </gpio>
     </ros2_control>
   </xacro:macro>
 </robot>

--- a/ur_robot_driver/urdf/ur.ros2_control.xacro
+++ b/ur_robot_driver/urdf/ur.ros2_control.xacro
@@ -307,9 +307,15 @@
       </gpio>
 
       <gpio name="${tf_prefix}pd_control">
-        <command_interface name="pd_control_active">
-         <param name="data_type">bool</param>
+        <command_interface name="pd_control_type">
+          <param name="initial_value">-1.0</param>
         </command_interface>
+        <command_interface name="pd_target_0"/>
+        <command_interface name="pd_target_1"/>
+        <command_interface name="pd_target_2"/>
+        <command_interface name="pd_target_3"/>
+        <command_interface name="pd_target_4"/>
+        <command_interface name="pd_target_5"/>
       </gpio>
     </ros2_control>
   </xacro:macro>


### PR DESCRIPTION
This adds the PD control mode from the client_library to ROS. In PD control mode the user can specify a target position (either in joint or in task space) and the robot will use a torque-control loop internally to reach that position.

This PR contains an example controller using a topic input for streaming targets to the robot. Topic communication might introduce a certain lack of determinism which is why it is probably best to write a controller fitting a custom use case from input to control target.

## ToDo's:
 - [x] Implementation
 - [ ] Test on a real robot
 - [x] Write tests (torque control doesn't work with URSim -- we cannot test much)
 - [ ] Write documentation