### PR TITLE
Use i_clamp_max/min in UR controllers

### DIFF
--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -358,8 +358,8 @@ void ScaledJointTrajectoryController::update_pids()
     const auto& gains = params_.gains.joints_map.at(params_.joints.at(map_cmd_to_joints_[i]));
     control_toolbox::AntiWindupStrategy antiwindup_strat;
     antiwindup_strat.set_type(gains.antiwindup_strategy);
-    antiwindup_strat.i_max = gains.i_clamp;
-    antiwindup_strat.i_min = -gains.i_clamp;
+    antiwindup_strat.i_max = gains.i_clamp_max;
+    antiwindup_strat.i_min = gains.i_clamp_min;
     antiwindup_strat.error_deadband = gains.error_deadband;
     antiwindup_strat.tracking_time_constant = gains.tracking_time_constant;
     if (pids_[i]) {


### PR DESCRIPTION
### **Overview**

This PR aligns `ur_controllers` with the current `joint_trajectory_controller`
parameter schema on Rolling by switching the anti-windup clamping from the
symmetric `gains.i_clamp` to the explicit `gains.i_clamp_max` / `gains.i_clamp_min`.
This matches how JTC exposes per-joint PID limits and the newer anti-windup
options, while keeping behavior identical when max = +M and min = −M.

### **What was added/changed in this PR**

* Replace `gains.i_clamp` with `gains.i_clamp_max` / `gains.i_clamp_min`
  in the anti-windup mapping.
* Enable asymmetric integral limits when configured by users.
* Bring `ur_controllers` in line with JTC’s Rolling parameter names and
  anti-windup configuration.

### **About tests**

The packages compile correctly and have passed the colcon tests.

### **Related PR's**

- https://github.com/ros-controls/control_toolbox/pull/436
- https://github.com/ros-controls/ros2_controllers/pull/1845

### **Final notes**

I'm very open to any recommendations to improve this code.
