### PR TITLE
Launch arguments support bool instead of string types only

### DIFF
--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -192,11 +192,11 @@ def launch_setup(context):
         "freedrive_mode_controller",
         "tool_contact_controller",
     ]
-    if activate_joint_controller.perform(context) == "true":
+    if activate_joint_controller.perform(context):
         controllers_active.append(initial_joint_controller.perform(context))
         controllers_inactive.remove(initial_joint_controller.perform(context))
 
-    if use_mock_hardware.perform(context) == "true":
+    if use_mock_hardware.perform(context):
         controllers_active.remove("tcp_pose_broadcaster")
 
     controller_spawners = [


### PR DESCRIPTION
The priorliy used string comparison would not work when passing proper bool types when including the launch file. This fix allows using both string and bool values.