### PR TITLE
Update branch of control_toolbox in upstream ws

### DIFF
--- a/Universal_Robots_ROS2_Driver.kilted.repos
+++ b/Universal_Robots_ROS2_Driver.kilted.repos
@@ -30,7 +30,7 @@ repositories:
   control_toolbox:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
-    version: ros2-master
+    version: kilted
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git

--- a/Universal_Robots_ROS2_Driver.rolling.repos
+++ b/Universal_Robots_ROS2_Driver.rolling.repos
@@ -30,7 +30,7 @@ repositories:
   control_toolbox:
     type: git
     url: https://github.com/ros-controls/control_toolbox.git
-    version: ros2-master
+    version: master
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git


### PR DESCRIPTION
The default branch has been renamed and kilted got its own feature branch.