### PR TITLE
Add missing update_rate config files for UR7e and UR12e

### DIFF
--- a/ur_robot_driver/config/ur12e_update_rate.yaml
+++ b/ur_robot_driver/config/ur12e_update_rate.yaml
@@ -1,0 +1,3 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 500  # Hz

--- a/ur_robot_driver/config/ur7e_update_rate.yaml
+++ b/ur_robot_driver/config/ur7e_update_rate.yaml
@@ -1,0 +1,3 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 500  # Hz


### PR DESCRIPTION
As mentioned in #1542 the update rates for UR7e and UR12e are missing. This fixes that.