### PR TITLE
Allow using the actual torques as joint efforts

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -349,6 +349,10 @@ if(BUILD_TESTING)
       TIMEOUT
         800
     )
+    add_launch_test(test/integration_test_joint_efforts.py
+      TIMEOUT
+        800
+    )
     add_launch_test(test/integration_test_hand_back_control.py
       TIMEOUT
         800

--- a/ur_robot_driver/doc/hardware_interface.rst
+++ b/ur_robot_driver/doc/hardware_interface.rst
@@ -29,13 +29,8 @@ The UR hardware interface supports the following control modes:
 - **Effort state interfaces**: Joint efforts are reported as torques by default
   (``actual_current_as_torque``, requires PolyScope >= 5.23.0 / 10.11.0). Set
   ``use_currents_as_efforts`` to ``true`` to report motor currents instead.
+  See :doc:`../hardware_interface_parameters` for more information.
 
-  .. note::
-
-     The torques reported are gravity-compensated, meaning a torque of 0.0 corresponds to a joint that is
-     not moving and does not experience an external load. This will only be true for a correctly setup
-     payload on the robot. Please see :ref:`the GPIO controller <io_and_status_controller>` for more
-     information on how to set up the payload dynamically.
 - **Force control**: The robot's end-effector is controlled by specifying target forces
   in Cartesian space.
 - **Freedrive mode**: The robot can be moved freely by the user without any active control.

--- a/ur_robot_driver/doc/hardware_interface.rst
+++ b/ur_robot_driver/doc/hardware_interface.rst
@@ -26,6 +26,9 @@ The UR hardware interface supports the following control modes:
 - **Velocity control**: The robot's joints are controlled by specifying target velocities.
 - **Effort control**: The robot's joints are controlled by specifying target efforts (torques).
   (Only available when running PolyScope >= 5.23.0 / 10.10.0)
+- **Effort state interfaces**: Joint efforts are reported as torques by default
+  (``actual_current_as_torque``, requires PolyScope >= 5.23.0 / 10.11.0). Set
+  ``use_currents_as_efforts`` to ``true`` to report motor currents instead.
 - **Force control**: The robot's end-effector is controlled by specifying target forces
   in Cartesian space.
 - **Freedrive mode**: The robot can be moved freely by the user without any active control.

--- a/ur_robot_driver/doc/hardware_interface.rst
+++ b/ur_robot_driver/doc/hardware_interface.rst
@@ -29,6 +29,13 @@ The UR hardware interface supports the following control modes:
 - **Effort state interfaces**: Joint efforts are reported as torques by default
   (``actual_current_as_torque``, requires PolyScope >= 5.23.0 / 10.11.0). Set
   ``use_currents_as_efforts`` to ``true`` to report motor currents instead.
+  
+  .. note::
+  
+     The torques reported are gravity-compensated, meaning a torque of 0.0 corresponds to a joint that is 
+     not moving and does not experience an external load. This will only be true for a correctly setup
+     payload on the robot. Please see :ref:`the GPIO controller <io_and_status_controller>` for more
+     information on how to set up the payload dynamically.
 - **Force control**: The robot's end-effector is controlled by specifying target forces
   in Cartesian space.
 - **Freedrive mode**: The robot can be moved freely by the user without any active control.

--- a/ur_robot_driver/doc/hardware_interface.rst
+++ b/ur_robot_driver/doc/hardware_interface.rst
@@ -29,10 +29,10 @@ The UR hardware interface supports the following control modes:
 - **Effort state interfaces**: Joint efforts are reported as torques by default
   (``actual_current_as_torque``, requires PolyScope >= 5.23.0 / 10.11.0). Set
   ``use_currents_as_efforts`` to ``true`` to report motor currents instead.
-  
+
   .. note::
-  
-     The torques reported are gravity-compensated, meaning a torque of 0.0 corresponds to a joint that is 
+
+     The torques reported are gravity-compensated, meaning a torque of 0.0 corresponds to a joint that is
      not moving and does not experience an external load. This will only be true for a correctly setup
      payload on the robot. Please see :ref:`the GPIO controller <io_and_status_controller>` for more
      information on how to set up the payload dynamically.

--- a/ur_robot_driver/doc/hardware_interface.rst
+++ b/ur_robot_driver/doc/hardware_interface.rst
@@ -25,11 +25,11 @@ The UR hardware interface supports the following control modes:
 - **Position control**: The robot's joints are controlled by specifying target positions.
 - **Velocity control**: The robot's joints are controlled by specifying target velocities.
 - **Effort control**: The robot's joints are controlled by specifying target efforts (torques).
-  (Only available when running PolyScope >= 5.23.0 / 10.10.0)
+  (Only available when running PolyScope >= 5.23.0 / 10.11.0)
 - **Effort state interfaces**: Joint efforts are reported as torques by default
   (``actual_current_as_torque``, requires PolyScope >= 5.23.0 / 10.11.0). Set
   ``use_currents_as_efforts`` to ``true`` to report motor currents instead.
-  See :doc:`../hardware_interface_parameters` for more information.
+  See :ref:`hardware_interface_parameters` for more information.
 
 - **Force control**: The robot's end-effector is controlled by specifying target forces
   in Cartesian space.

--- a/ur_robot_driver/doc/hardware_interface.rst
+++ b/ur_robot_driver/doc/hardware_interface.rst
@@ -25,7 +25,7 @@ The UR hardware interface supports the following control modes:
 - **Position control**: The robot's joints are controlled by specifying target positions.
 - **Velocity control**: The robot's joints are controlled by specifying target velocities.
 - **Effort control**: The robot's joints are controlled by specifying target efforts (torques).
-  (Only available when running PolyScope >= 5.23.0 / 10.11.0)
+  (Only available when running PolyScope >= 5.23.0 / 10.10.0)
 - **Effort state interfaces**: Joint efforts are reported as torques by default
   (``actual_current_as_torque``, requires PolyScope >= 5.23.0 / 10.11.0). Set
   ``use_currents_as_efforts`` to ``true`` to report motor currents instead.

--- a/ur_robot_driver/doc/hardware_interface_parameters.rst
+++ b/ur_robot_driver/doc/hardware_interface_parameters.rst
@@ -128,7 +128,8 @@ Selects which RTDE values are exported on the joint effort state interfaces.
 * When set to ``true``, the driver keeps the previous behavior and reports motor currents from
   ``actual_current`` as efforts.
 * When set to ``false`` on robot software versions < 5.23.0 / 10.11.0, the driver will
-  automatically fall back to using ``actual_current`` as efforts and print a warning message.
+  fail to initialize, printing an error about the missing variable ``actual_current_as_torque`` on
+  the robot.
 
 This parameter can also be set through the ``use_currents_as_efforts`` launch argument of
 ``ur_control.launch.py`` / ``ur_rsp.launch.py``.

--- a/ur_robot_driver/doc/hardware_interface_parameters.rst
+++ b/ur_robot_driver/doc/hardware_interface_parameters.rst
@@ -127,7 +127,7 @@ Selects which RTDE values are exported on the joint effort state interfaces.
   versions, configuring the hardware interface will fail.
 * When set to ``true``, the driver keeps the previous behavior and reports motor currents from
   ``actual_current`` as efforts.
-* When set to ``true`` on robot software versions < 5.23.0 / 10.11.0, the driver will report
+* When set to ``false`` on robot software versions < 5.23.0 / 10.11.0, the driver will report
   automatically fall back to using ``actual_current`` as efforts and print a warning message.
 
 This parameter can also be set through the ``use_currents_as_efforts`` launch argument of

--- a/ur_robot_driver/doc/hardware_interface_parameters.rst
+++ b/ur_robot_driver/doc/hardware_interface_parameters.rst
@@ -127,7 +127,7 @@ Selects which RTDE values are exported on the joint effort state interfaces.
   versions, configuring the hardware interface will fail.
 * When set to ``true``, the driver keeps the previous behavior and reports motor currents from
   ``actual_current`` as efforts.
-* When set to ``false`` on robot software versions < 5.23.0 / 10.11.0, the driver will report
+* When set to ``false`` on robot software versions < 5.23.0 / 10.11.0, the driver will
   automatically fall back to using ``actual_current`` as efforts and print a warning message.
 
 This parameter can also be set through the ``use_currents_as_efforts`` launch argument of

--- a/ur_robot_driver/doc/hardware_interface_parameters.rst
+++ b/ur_robot_driver/doc/hardware_interface_parameters.rst
@@ -117,6 +117,22 @@ Tool voltage that will be set as soon as the UR-Program on the robot is started.
 
 This can also be configured using the robot teach pendant. Remember to save the installation on the robot to keep the setting after reboot.
 
+use_currents_as_efforts (default: "false")
+------------------------------------------
+
+Selects which RTDE values are exported on the joint effort state interfaces.
+
+* When set to ``false`` (default), the driver reports the joint torques from the RTDE field
+  ``actual_current_as_torque``. This requires PolyScope >= 5.23.0 / 10.11.0. On older software
+  versions, configuring the hardware interface will fail.
+* When set to ``true``, the driver keeps the previous behavior and reports motor currents from
+  ``actual_current`` as efforts.
+* When set to ``true`` on robot software versions < 5.23.0 / 10.11.0, the driver will report
+  automatically fall back to using ``actual_current`` as efforts and print a warning message.
+
+This parameter can also be set through the ``use_currents_as_efforts`` launch argument of
+``ur_control.launch.py`` / ``ur_rsp.launch.py``.
+
 use_tool_communication (Required)
 ---------------------------------
 

--- a/ur_robot_driver/doc/hardware_interface_parameters.rst
+++ b/ur_robot_driver/doc/hardware_interface_parameters.rst
@@ -1,5 +1,7 @@
 :github_url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/blob/main/ur_robot_driver/doc/hardware_interface_parameters.rst
 
+.. _hardware_interface_parameters:
+
 UR Hardware interface parameters
 ================================
 

--- a/ur_robot_driver/doc/migration/makoa.rst
+++ b/ur_robot_driver/doc/migration/makoa.rst
@@ -3,6 +3,28 @@
 ur_robot_driver
 ^^^^^^^^^^^^^^^
 
+Joint effort state interfaces report torques by default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The joint effort state interfaces (and therefore the ``effort`` field of
+``sensor_msgs/JointState``) now report joint torques from RTDE
+(``actual_current_as_torque``) by default instead of motor currents.
+
+This requires PolyScope >= 5.23.0 / 10.11.0. On older software versions the driver will fall back to
+reporting currents instead of torques.
+
+To keep reporting motor currents as efforts, set ``use_currents_as_efforts`` to ``true``:
+
+.. code::
+
+   ros2 launch ur_robot_driver ur_control.launch.py \
+     robot_ip:=192.168.56.101 \
+     ur_type:=ur5e \
+     use_currents_as_efforts:=true
+
+See :doc:`../hardware_interface_parameters` for details.
+
+
 Interface change of set_payload service
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/ur_robot_driver/doc/migration/makoa.rst
+++ b/ur_robot_driver/doc/migration/makoa.rst
@@ -10,10 +10,10 @@ The joint effort state interfaces (and therefore the ``effort`` field of
 ``sensor_msgs/JointState``) now report joint torques from RTDE
 (``actual_current_as_torque``) by default instead of motor currents.
 
-This requires PolyScope >= 5.23.0 / 10.11.0. On older software versions the driver will fall back to
-reporting currents instead of torques.
+This requires PolyScope >= 5.23.0 / 10.11.0. On older software versions the driver will fail to
+init and print an error about the missing variable ``actual_current_as_torque`` on the robot.
 
-To keep reporting motor currents as efforts, set ``use_currents_as_efforts`` to ``true``:
+To keep reporting motor currents as efforts (e.g. on a CB3 robot), set ``use_currents_as_efforts`` to ``true``:
 
 .. code::
 

--- a/ur_robot_driver/doc/migration/makoa.rst
+++ b/ur_robot_driver/doc/migration/makoa.rst
@@ -22,7 +22,7 @@ To keep reporting motor currents as efforts (e.g. on a CB3 robot), set ``use_cur
      ur_type:=ur5e \
      use_currents_as_efforts:=true
 
-See :doc:`../hardware_interface_parameters` for details.
+See :ref:`hardware_interface_parameters` for details.
 
 Blocking read enabled by default in launch files
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/ur_robot_driver/doc/usage/force_torque_control.rst
+++ b/ur_robot_driver/doc/usage/force_torque_control.rst
@@ -56,8 +56,11 @@ with one value per joint.
 
 .. note::
 
-   The ``effort`` field in ``sensor_msgs/JointState`` (published by the ``joint_state_broadcaster``)
-   contains motor currents, not physical joint torques.
+   For robot softwware versions prior to PolyScope 5.23.0 / 10.11.0 the joint_states' ``effort``
+   field contains the motor currents instead of the actual joint torques.
+   On newer robot software versions, the driver reports the actual joint torques by default. To
+   revert to the previous behavior, set the hardware parameter ``use_currents_as_efforts`` to
+   ``true``. See :doc:`../hardware_interface_parameters` for details.
 
 Friction Compensation
 ^^^^^^^^^^^^^^^^^^^^^

--- a/ur_robot_driver/doc/usage/force_torque_control.rst
+++ b/ur_robot_driver/doc/usage/force_torque_control.rst
@@ -56,11 +56,13 @@ with one value per joint.
 
 .. note::
 
-   For robot softwware versions prior to PolyScope 5.23.0 / 10.11.0 the joint_states' ``effort``
-   field contains the motor currents instead of the actual joint torques.
-   On newer robot software versions, the driver reports the actual joint torques by default. To
-   revert to the previous behavior, set the hardware parameter ``use_currents_as_efforts`` to
-   ``true``. See :doc:`../hardware_interface_parameters` for details.
+   On older ROS distributions, the effort interfaces reported motor currents instead of actual
+   torques. This is no longer the case, and the driver now reports actual joint torques by
+   default, which requires PolyScope >= 5.23.0 / 10.11.0. If you are using an older robot
+   software version, the driver will fail to start and print an error about the missing RTDE
+   variable ``actual_current_as_torque``. To revert to the previous behavior, set the hardware
+   parameter ``use_currents_as_efforts`` to ``true``. See
+   :ref:`hardware_interface_parameters` for details.
 
 Friction Compensation
 ^^^^^^^^^^^^^^^^^^^^^

--- a/ur_robot_driver/doc/usage/startup.rst
+++ b/ur_robot_driver/doc/usage/startup.rst
@@ -34,6 +34,9 @@ Other important arguments are:
 * ``use_mock_hardware`` (default: *false* ) - Use simple hardware emulator from ros2_control. Useful for testing launch files, descriptions, etc.
 * ``headless_mode`` (default: *false*) - Start driver in :ref:`headless_mode`.
 * ``launch_rviz`` (default: *true*) - Start RViz together with the driver.
+* ``use_currents_as_efforts`` (default: *false*) - Report motor currents as joint efforts.
+  When ``false``, joint torques from the robot are used instead (requires PolyScope >= 5.23.0 /
+  10.11.0). See :doc:`../hardware_interface_parameters`.
 * ``initial_joint_controller`` (default: *joint_trajectory_controller*) - Use this if you
   want to start the robot with another controller.
 

--- a/ur_robot_driver/doc/usage/startup.rst
+++ b/ur_robot_driver/doc/usage/startup.rst
@@ -34,9 +34,9 @@ Other important arguments are:
 * ``use_mock_hardware`` (default: *false* ) - Use simple hardware emulator from ros2_control. Useful for testing launch files, descriptions, etc.
 * ``headless_mode`` (default: *false*) - Start driver in :ref:`headless_mode`.
 * ``launch_rviz`` (default: *true*) - Start RViz together with the driver.
-* ``use_currents_as_efforts`` (default: *false*) - Report motor currents as joint efforts.
-  When ``false``, joint torques from the robot are used instead (requires PolyScope >= 5.23.0 /
-  10.11.0). See :doc:`../hardware_interface_parameters`.
+* ``use_currents_as_efforts`` (default: *false*) - Report motor currents as joint efforts
+  when ``true``. The default (``false``) reports joint torques instead (requires PolyScope
+  >= 5.23.0 / 10.11.0). See :doc:`../hardware_interface_parameters`.
 * ``initial_joint_controller`` (default: *joint_trajectory_controller*) - Use this if you
   want to start the robot with another controller.
 * ``blocking_read`` (default: *true*) - Make the robot's communication drive the ROS control loop's

--- a/ur_robot_driver/doc/usage/startup.rst
+++ b/ur_robot_driver/doc/usage/startup.rst
@@ -36,7 +36,7 @@ Other important arguments are:
 * ``launch_rviz`` (default: *true*) - Start RViz together with the driver.
 * ``use_currents_as_efforts`` (default: *false*) - Report motor currents as joint efforts
   when ``true``. The default (``false``) reports joint torques instead (requires PolyScope
-  >= 5.23.0 / 10.11.0). See :doc:`../hardware_interface_parameters`.
+  >= 5.23.0 / 10.11.0). See :ref:`hardware_interface_parameters`.
 * ``initial_joint_controller`` (default: *joint_trajectory_controller*) - Use this if you
   want to start the robot with another controller.
 * ``blocking_read`` (default: *true*) - Make the robot's communication drive the ROS control loop's

--- a/ur_robot_driver/doc/usage/utility_controllers.rst
+++ b/ur_robot_driver/doc/usage/utility_controllers.rst
@@ -19,12 +19,16 @@ joint_state_broadcaster
 
 Type: `joint_state_broadcaster/JointStateBroadcaster <https://control.ros.org/rolling/doc/ros2_controllers/joint_state_broadcaster/doc/userdoc.html>`_
 
-Publishes all joints' positions, velocities, and motor currents as ``sensor_msgs/JointState`` on the ``joint_states`` topic. This broadcaster is read-only and can run alongside any other controller.
+Publishes all joints' positions, velocities, and efforts as ``sensor_msgs/JointState`` on the
+``joint_states`` topic. This broadcaster is read-only and can run alongside any other controller.
 
 .. note::
 
-   The effort field contains the currents reported by the joints and not the actual efforts in a
-   physical sense.
+   For robot softwware versions prior to PolyScope 5.23.0 / 10.11.0 the joint_states' ``effort``
+   field contains the motor currents instead of the actual joint torques.
+   On newer robot software versions, the driver reports the actual joint torques by default. To
+   revert to the previous behavior, set the hardware parameter ``use_currents_as_efforts`` to
+   ``true``. See :doc:`../hardware_interface_parameters` for details.
 
 speed_scaling_state_broadcaster
 -------------------------------

--- a/ur_robot_driver/doc/usage/utility_controllers.rst
+++ b/ur_robot_driver/doc/usage/utility_controllers.rst
@@ -24,11 +24,13 @@ Publishes all joints' positions, velocities, and efforts as ``sensor_msgs/JointS
 
 .. note::
 
-   For robot softwware versions prior to PolyScope 5.23.0 / 10.11.0 the joint_states' ``effort``
-   field contains the motor currents instead of the actual joint torques.
-   On newer robot software versions, the driver reports the actual joint torques by default. To
-   revert to the previous behavior, set the hardware parameter ``use_currents_as_efforts`` to
-   ``true``. See :doc:`../hardware_interface_parameters` for details.
+   On older ROS distributions, the effort interfaces reported motor currents instead of actual
+   torques. This is no longer the case, and the driver now reports actual joint torques by
+   default, which requires PolyScope >= 5.23.0 / 10.11.0. If you are using an older robot
+   software version, the driver will fail to start and print an error about the missing RTDE
+   variable ``actual_current_as_torque``. To revert to the previous behavior, set the hardware
+   parameter ``use_currents_as_efforts`` to ``true``. See
+   :ref:`hardware_interface_parameters` for details.
 
 speed_scaling_state_broadcaster
 -------------------------------

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -403,6 +403,8 @@ protected:
 
   std::unique_ptr<urcl::rtde_interface::DataPackage> data_package_buffer_;
   std::function<bool()> get_data_package;
+
+  bool use_currents_as_efforts_ = false;
 };
 }  // namespace ur_robot_driver
 

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -518,6 +518,16 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
+            "use_currents_as_efforts",
+            default_value="false",
+            description=(
+                "Report motor currents as efforts. When set to false, the torques as reported "
+                "from the robot are used. Note that this requires software 5.23.0 / 10.11.0."
+            ),
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
             name="update_rate_config_file",
             default_value=[
                 PathJoinSubstitution(

--- a/ur_robot_driver/launch/ur_rsp.launch.py
+++ b/ur_robot_driver/launch/ur_rsp.launch.py
@@ -74,6 +74,7 @@ def generate_launch_description():
     reverse_port = LaunchConfiguration("reverse_port")
     script_sender_port = LaunchConfiguration("script_sender_port")
     trajectory_port = LaunchConfiguration("trajectory_port")
+    use_currents_as_efforts = LaunchConfiguration("use_currents_as_efforts")
 
     script_filename = PathJoinSubstitution(
         [
@@ -191,6 +192,8 @@ def generate_launch_description():
             "trajectory_port:=",
             trajectory_port,
             " ",
+            "use_currents_as_efforts:=",
+            use_currents_as_efforts,
         ]
     )
     robot_description = {
@@ -455,6 +458,13 @@ def generate_launch_description():
             "trajectory_port",
             default_value="50003",
             description="Port that will be opened for trajectory control.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_currents_as_efforts",
+            default_value="true",
+            description="Report motor currents as efforts. When set to false, the torques as reported from the robot are used. Note that this requires software 5.23.0 / 10.11.0.",
         )
     )
 

--- a/ur_robot_driver/launch/ur_rsp.launch.py
+++ b/ur_robot_driver/launch/ur_rsp.launch.py
@@ -463,7 +463,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "use_currents_as_efforts",
-            default_value="true",
+            default_value="false",
             description="Report motor currents as efforts. When set to false, the torques as reported from the robot are used. Note that this requires software 5.23.0 / 10.11.0.",
         )
     )

--- a/ur_robot_driver/resources/rtde_output_recipe.txt
+++ b/ur_robot_driver/resources/rtde_output_recipe.txt
@@ -26,6 +26,7 @@ safety_mode
 robot_status_bits
 safety_status_bits
 actual_current
+actual_current_as_torque
 tcp_offset
 payload
 payload_cog

--- a/ur_robot_driver/resources/rtde_output_recipe.txt
+++ b/ur_robot_driver/resources/rtde_output_recipe.txt
@@ -26,7 +26,6 @@ safety_mode
 robot_status_bits
 safety_status_bits
 actual_current
-actual_current_as_torque
 tcp_offset
 payload
 payload_cog

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -701,6 +701,11 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
   // The driver will offer an interface to receive the program's URScript on this port.
   const int script_sender_port = stoi(info_.hardware_parameters["script_sender_port"]);
 
+  // Newer software version (5.23.0 / 10.11.0) support reporting the actual joint torques. On older
+  // versions fall back to the currents, instead.
+  use_currents_as_efforts_ = ((info_.hardware_parameters["use_currents_as_efforts"] == "true") ||
+                              (info_.hardware_parameters["use_currents_as_efforts"] == "True"));
+
   // The ip address of the host the driver runs on
   std::string reverse_ip = info_.hardware_parameters["reverse_ip"];
   if (reverse_ip == "0.0.0.0") {
@@ -883,6 +888,17 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
   RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"), "Initializing InstructionExecutor");
   instruction_executor_ = std::make_shared<urcl::InstructionExecutor>(ur_driver_);
 
+  if (!use_currents_as_efforts_) {
+    if ((version_info_.major == 5 && version_info_.minor < 23) ||
+        (version_info_.major == 10 && version_info_.minor < 11) || version_info_.major < 5) {
+      RCLCPP_ERROR(get_logger(),
+                   "Driver configured to use actual torques as efforts, which is not supported by this software "
+                   "version %s. Please use version 5.23.0 / 10.11.0 or newer for this feature.",
+                   version_info_.toString().c_str());
+      return hardware_interface::CallbackReturn::ERROR;
+    }
+  }
+
   async_thread_ = std::make_shared<std::thread>(&URPositionHardwareInterface::asyncThread, this);
 
   // Start async thread for sending motion primitives
@@ -996,7 +1012,11 @@ hardware_interface::return_type URPositionHardwareInterface::read(const rclcpp::
     packet_read_ = true;
     readData(data_package_buffer_, "actual_q", urcl_joint_positions_);
     readData(data_package_buffer_, "actual_qd", urcl_joint_velocities_);
-    readData(data_package_buffer_, "actual_current", urcl_joint_efforts_);
+    if (use_currents_as_efforts_) {
+      readData(data_package_buffer_, "actual_current", urcl_joint_efforts_);
+    } else {
+      readData(data_package_buffer_, "actual_current_as_torque", urcl_joint_efforts_);
+    }
     readData(data_package_buffer_, "target_speed_fraction", target_speed_fraction_);
     readData(data_package_buffer_, "speed_scaling", speed_scaling_);
     readData(data_package_buffer_, "runtime_state", runtime_state_);

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -701,8 +701,6 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
   // The driver will offer an interface to receive the program's URScript on this port.
   const int script_sender_port = stoi(info_.hardware_parameters["script_sender_port"]);
 
-  // Newer software version (5.23.0 / 10.11.0) support reporting the actual joint torques. On older
-  // versions fall back to the currents, instead.
   use_currents_as_efforts_ = ((info_.hardware_parameters["use_currents_as_efforts"] == "true") ||
                               (info_.hardware_parameters["use_currents_as_efforts"] == "True"));
 
@@ -802,11 +800,20 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
   }
 
   RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"), "Initializing driver...");
+  std::string ur_type = info_.hardware_parameters["ur_type"];
+  auto expected_type = robotTypeFromString(ur_type);
   try {
     auto input_recipe = urcl::rtde_interface::RTDEClient::readRecipe(input_recipe_filename);
     auto output_recipe = urcl::rtde_interface::RTDEClient::readRecipe(output_recipe_filename);
 
     if (!use_currents_as_efforts_) {
+      if (expected_type.robot_series == urcl::RobotSeries::CB3) {
+        RCLCPP_WARN_STREAM(rclcpp::get_logger("URPositionHardwareInterface"), "Using actual joint torques as efforts "
+                                                                              "requested on a CB3 robot. This is not "
+                                                                              "supported and will fail to initialize. "
+                                                                              "Please set the parameter "
+                                                                              "'use_currents_as_efforts' to true.");
+      }
       if (std::find(output_recipe.begin(), output_recipe.end(), "actual_current_as_torque") == output_recipe.end()) {
         output_recipe.push_back("actual_current_as_torque");
       }
@@ -839,6 +846,20 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
     RCLCPP_FATAL_STREAM(rclcpp::get_logger("URPositionHardwareInterface"), "See parameter use_tool_communication");
 
     return hardware_interface::CallbackReturn::ERROR;
+  } catch (urcl::RTDEInvalidKeyException& e) {
+    RCLCPP_FATAL_STREAM(rclcpp::get_logger("URPositionHardwareInterface"), e.what());
+    if (std::find(e.invalid_keys.begin(), e.invalid_keys.end(), "actual_current_as_torque") != e.invalid_keys.end()) {
+      RCLCPP_FATAL_STREAM(rclcpp::get_logger("URPositionHardwareInterface"), "The robot declined the RTDE key "
+                                                                             "'actual_current_as_torque'. This is "
+                                                                             "required for "
+                                                                             "using actual joint torques as efforts. "
+                                                                             "Please use a newer version of the UR "
+                                                                             "robot software "
+                                                                             "(5.23.0 / 10.11.0 or newer) or set the "
+                                                                             "parameter 'use_currents_as_efforts' to "
+                                                                             "true.");
+    }
+    return hardware_interface::CallbackReturn::ERROR;
   } catch (urcl::UrException& e) {
     RCLCPP_FATAL_STREAM(rclcpp::get_logger("URPositionHardwareInterface"), e.what());
     return hardware_interface::CallbackReturn::ERROR;
@@ -853,8 +874,6 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
   get_robot_software_version_build_ = version_info_.build;
   get_robot_software_version_bugfix_ = version_info_.bugfix;
 
-  std::string ur_type = info_.hardware_parameters["ur_type"];
-  auto expected_type = robotTypeFromString(ur_type);
   auto robot_type = ur_driver_->getPrimaryClient()->getRobotType();
   auto robot_series = ur_driver_->getPrimaryClient()->getRobotSeries();
 

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -803,12 +803,21 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
 
   RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"), "Initializing driver...");
   try {
+    auto input_recipe = urcl::rtde_interface::RTDEClient::readRecipe(input_recipe_filename);
+    auto output_recipe = urcl::rtde_interface::RTDEClient::readRecipe(output_recipe_filename);
+
+    if (!use_currents_as_efforts_) {
+      if (std::find(output_recipe.begin(), output_recipe.end(), "actual_current_as_torque") == output_recipe.end()) {
+        output_recipe.push_back("actual_current_as_torque");
+      }
+    }
+
     rtde_comm_has_been_started_ = false;
     urcl::UrDriverConfiguration driver_config;
     driver_config.robot_ip = robot_ip;
     driver_config.script_file = script_filename;
-    driver_config.output_recipe_file = output_recipe_filename;
-    driver_config.input_recipe_file = input_recipe_filename;
+    driver_config.output_recipe = output_recipe;
+    driver_config.input_recipe = input_recipe;
     driver_config.headless_mode = headless_mode;
     driver_config.reverse_port = static_cast<uint32_t>(reverse_port);
     driver_config.script_sender_port = static_cast<uint32_t>(script_sender_port);
@@ -823,7 +832,7 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
         std::bind(&URPositionHardwareInterface::handleRobotProgramState, this, std::placeholders::_1);
     ur_driver_ = std::make_shared<urcl::UrDriver>(driver_config);
     if (ur_driver_->getControlFrequency() != info_.rw_rate) {
-      ur_driver_->resetRTDEClient(output_recipe_filename, input_recipe_filename, info_.rw_rate);
+      ur_driver_->resetRTDEClient(output_recipe, input_recipe, info_.rw_rate);
     }
     data_package_buffer_ = std::make_unique<rtde::DataPackage>(ur_driver_->getRTDEOutputRecipe());
   } catch (urcl::ToolCommNotAvailable& e) {

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -876,6 +876,8 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
                    "Driver configured to use actual torques as efforts, which is not supported by this software "
                    "version %s. Please use version 5.23.0 / 10.11.0 or newer for this feature.",
                    version_info_.toString().c_str());
+      instruction_executor_.reset();
+      ur_driver_.reset();
       return hardware_interface::CallbackReturn::ERROR;
     }
   }

--- a/ur_robot_driver/test/integration_test_joint_efforts.py
+++ b/ur_robot_driver/test/integration_test_joint_efforts.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python
+# Copyright 2026, Universal Robots A/S
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Integration tests for joint effort reporting.
+
+Verifies that the driver can publish joint efforts from either RTDE field:
+* ``actual_current_as_torque`` (default, ``use_currents_as_efforts:=false``)
+* ``actual_current`` (legacy, ``use_currents_as_efforts:=true``)
+
+Requires a UR5e URSim image with PolyScope >= 5.23.0 / 10.11.0 for the default torque mode.
+"""
+
+import math
+import os
+import sys
+import time
+import unittest
+
+import launch_testing
+import pytest
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+sys.path.append(os.path.dirname(__file__))
+from test_common import (  # noqa: E402
+    ConfigurationInterface,
+    DashboardInterface,
+    IoStatusInterface,
+    generate_driver_test_description,
+)
+
+# Approximate effort magnitude thresholds used to distinguish torques (Nm) from
+# currents (A) at the default URSim pose. These are not exact and are only
+# valid for a UR5e.
+MIN_TORQUE_EFFORT_NM = 20.0
+MIN_CURRENT_EFFORT_A = 2.0
+UR_TYPE = "ur5e"
+
+
+@pytest.mark.launch_test
+@launch_testing.parametrize(
+    "use_currents_as_efforts",
+    # None: omit the launch argument and assert the default is torque mode.
+    [(None), ("false"), ("true")],
+)
+def generate_test_description(use_currents_as_efforts):
+    return generate_driver_test_description(
+        ur_type=UR_TYPE,
+        use_currents_as_efforts=use_currents_as_efforts,
+    )
+
+
+class JointEffortsTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node("joint_efforts_test")
+        time.sleep(1)
+        cls.init_robot(cls)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    def init_robot(self):
+        self._dashboard_interface = DashboardInterface(self.node)
+        self._io_status_controller_interface = IoStatusInterface(self.node)
+        self._configuration_controller_interface = ConfigurationInterface(self.node)
+
+    def setUp(self):
+        self._dashboard_interface.start_robot()
+        time.sleep(1)
+        self.assertTrue(self._io_status_controller_interface.resend_robot_program().success)
+
+    def _wait_for_joint_state(self, timeout_sec=10.0):
+        last_msg = None
+
+        def cb(msg):
+            nonlocal last_msg
+            last_msg = msg
+
+        sub = self.node.create_subscription(JointState, "/joint_states", cb, 10)
+        deadline = time.monotonic() + timeout_sec
+        while last_msg is None and time.monotonic() < deadline:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+        self.node.destroy_subscription(sub)
+        self.assertIsNotNone(last_msg, "Timed out waiting for /joint_states")
+        return last_msg
+
+    def test_joint_efforts_are_published(self, use_currents_as_efforts):
+        """Driver comes up and publishes finite joint efforts for the selected RTDE source."""
+        # Default (argument omitted) and explicit false both select torque reporting.
+        expect_torques = use_currents_as_efforts in (None, "false")
+
+        if expect_torques:
+            version = self._configuration_controller_interface.get_robot_software_version()
+            # Mirror the version gate in URPositionHardwareInterface::on_configure
+            unsupported = (
+                (version.major == 5 and version.minor < 23)
+                or (version.major == 10 and version.minor < 11)
+                or version.major < 5
+            )
+            self.assertFalse(
+                unsupported,
+                f"URSim software {version.major}.{version.minor} does not support "
+                "actual_current_as_torque; need >= 5.23.0 / 10.11.0 for the default effort mode.",
+            )
+
+        joint_state = self._wait_for_joint_state()
+
+        self.assertEqual(len(joint_state.name), 6)
+        self.assertEqual(
+            len(joint_state.effort),
+            6,
+            "JointState.effort must contain one value per joint",
+        )
+        for name, effort in zip(joint_state.name, joint_state.effort):
+            self.assertTrue(
+                math.isfinite(effort),
+                f"Effort for joint '{name}' is not finite: {effort}",
+            )
+
+        # At the default URSim pose, gravity-related joint torques (Nm) are much
+        # larger than idle motor currents (A). Use that to verify the correct RTDE
+        # source is selected.
+        max_abs_effort = max(abs(e) for e in joint_state.effort)
+        if expect_torques:
+            self.assertGreater(
+                max_abs_effort,
+                MIN_TORQUE_EFFORT_NM,
+                "Expected gravity-related joint torques > "
+                f"{MIN_TORQUE_EFFORT_NM} Nm with use_currents_as_efforts="
+                f"{use_currents_as_efforts!r}, but max |effort| was {max_abs_effort}. "
+                "Check that actual_current_as_torque is read (default).",
+            )
+        else:
+            self.assertGreater(
+                max_abs_effort,
+                MIN_CURRENT_EFFORT_A,
+                "Expected motor currents > "
+                f"{MIN_CURRENT_EFFORT_A} A with use_currents_as_efforts:=true, "
+                f"but max |effort| was {max_abs_effort}. "
+                "Check that actual_current is read.",
+            )
+            self.assertLess(
+                max_abs_effort,
+                MIN_TORQUE_EFFORT_NM,
+                "Expected motor currents (A) to stay below typical gravity torque "
+                f"magnitudes (Nm), but max |effort| was {max_abs_effort}.",
+            )

--- a/ur_robot_driver/test/integration_test_robot_models.py
+++ b/ur_robot_driver/test/integration_test_robot_models.py
@@ -82,11 +82,22 @@ ROBOT_MODEL_CASES = [
     ("ur5e", "ur20"),
 ]
 
+# CB3 robots (PolyScope 3.x / URSim CB3) do not provide the ``actual_current_as_torque``
+# RTDE field, so the default torque-based effort reporting would make the hardware
+# interface fail during ``on_configure``. For these models we fall back to reporting
+# motor currents as efforts. e-Series / UR-Series models keep the default torque mode.
+CB3_MODELS = {"ur3", "ur5", "ur10"}
+
 
 @pytest.mark.launch_test
 @launch_testing.parametrize("ursim_type, driver_type", ROBOT_MODEL_CASES)
 def generate_test_description(ursim_type, driver_type):
-    return generate_driver_test_description_for_model(ur_type=driver_type, ursim_type=ursim_type)
+    use_currents_as_efforts = "true" if driver_type in CB3_MODELS else None
+    return generate_driver_test_description_for_model(
+        ur_type=driver_type,
+        ursim_type=ursim_type,
+        use_currents_as_efforts=use_currents_as_efforts,
+    )
 
 
 class RobotModelStartupTest(unittest.TestCase):

--- a/ur_robot_driver/test/test_common.py
+++ b/ur_robot_driver/test/test_common.py
@@ -647,6 +647,7 @@ def generate_driver_test_description(
     ur_type="ur5e",
     ursim_program_folder=None,
     urcap_folder=None,
+    use_currents_as_efforts=None,
 ):
     launch_arguments = {
         "robot_ip": "192.168.56.101",
@@ -658,6 +659,8 @@ def generate_driver_test_description(
         "launch_dashboard_client": "true",
         "start_joint_controller": "false",
     }
+    if use_currents_as_efforts is not None:
+        launch_arguments["use_currents_as_efforts"] = use_currents_as_efforts
     if tf_prefix:
         launch_arguments["tf_prefix"] = tf_prefix
 

--- a/ur_robot_driver/test/test_common.py
+++ b/ur_robot_driver/test/test_common.py
@@ -705,6 +705,7 @@ def generate_driver_test_description_for_model(
     controller_spawner_timeout=TIMEOUT_WAIT_SERVICE_INITIAL,
     ursim_version="latest",
     ursim_type=None,
+    use_currents_as_efforts=None,
 ):
     """
     Generate a launch description that brings up URSim and the driver for an explicit ``ur_type``.
@@ -732,6 +733,8 @@ def generate_driver_test_description_for_model(
         "launch_dashboard_client": "true",
         "start_joint_controller": "false",
     }
+    if use_currents_as_efforts is not None:
+        launch_arguments["use_currents_as_efforts"] = use_currents_as_efforts
     if tf_prefix:
         launch_arguments["tf_prefix"] = tf_prefix
 

--- a/ur_robot_driver/urdf/ur.ros2_control.xacro
+++ b/ur_robot_driver/urdf/ur.ros2_control.xacro
@@ -29,6 +29,7 @@
     robot_receive_timeout:=0.04
     rw_rate:=0
     verify_robot_model:=true
+    use_currents_as_efforts:=true
     ">
     <!-- rw_rate of 0 uses the rate of the controller_manager -->
 
@@ -77,6 +78,7 @@
           <param name="tool_tcp_port">${tool_tcp_port}</param>
           <param name="robot_receive_timeout">${robot_receive_timeout}</param>
           <param name="verify_robot_model">${verify_robot_model}</param>
+          <param name="use_currents_as_efforts">${use_currents_as_efforts}</param>
         </xacro:unless>
       </hardware>
 

--- a/ur_robot_driver/urdf/ur.ros2_control.xacro
+++ b/ur_robot_driver/urdf/ur.ros2_control.xacro
@@ -29,7 +29,7 @@
     robot_receive_timeout:=0.04
     rw_rate:=0
     verify_robot_model:=true
-    use_currents_as_efforts:=true
+    use_currents_as_efforts:=false
     ">
     <!-- rw_rate of 0 uses the rate of the controller_manager -->
 

--- a/ur_robot_driver/urdf/ur.urdf.xacro
+++ b/ur_robot_driver/urdf/ur.urdf.xacro
@@ -34,6 +34,8 @@
   <xacro:arg name="script_sender_port" default="50002"/>
   <xacro:arg name="trajectory_port" default="50003"/>
   <xacro:arg name="verify_robot_model" default="true" />
+  <xacro:arg name="use_currents_as_efforts" default="true"/>
+
   <!--   tool communication related parameters-->
   <xacro:arg name="use_tool_communication" default="false" />
   <xacro:arg name="tool_voltage" default="0" />
@@ -104,6 +106,7 @@
     trajectory_port="$(arg trajectory_port)"
     ur_type="$(arg ur_type)"
     verify_robot_model="$(arg verify_robot_model)"
+    use_currents_as_efforts="$(arg use_currents_as_efforts)"
   />
 
 </robot>

--- a/ur_robot_driver/urdf/ur.urdf.xacro
+++ b/ur_robot_driver/urdf/ur.urdf.xacro
@@ -34,7 +34,7 @@
   <xacro:arg name="script_sender_port" default="50002"/>
   <xacro:arg name="trajectory_port" default="50003"/>
   <xacro:arg name="verify_robot_model" default="true" />
-  <xacro:arg name="use_currents_as_efforts" default="true"/>
+  <xacro:arg name="use_currents_as_efforts" default="false"/>
 
   <!--   tool communication related parameters-->
   <xacro:arg name="use_tool_communication" default="false" />


### PR DESCRIPTION
Add the option to use the joint_torques reported through RTDE as joint efforts as discussed in #1468.

This will not run on robots with software version < 5.23.0 / 10.11.0, hence the draft. The RTDE output for actual joints doesn't exist before. We would need to find a solution for that. Possible solutions are:
- Keep a separate output recipe and leave passing a compatible recipe file when this option is enabled to the user (I don't quite like that)
- read the recipe file in the driver, append the torque field if requested and save it as a temporary file that gets passed to the driver object
- Extend the driver config to accept a string vector, as well. Then, we can easily append the field in the hardware interface

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Default joint effort semantics change and driver init fails on PolyScope older than 5.23.0 / 10.11.0 unless `use_currents_as_efforts:=true`; downstream nodes that assumed motor currents in `JointState.effort` may misinterpret data.
> 
> **Overview**
> **Joint effort state now defaults to physical torques** instead of motor currents on `/joint_states` and ros2_control effort interfaces. Unless `use_currents_as_efforts` is `true`, the driver reads RTDE `actual_current_as_torque` (PolyScope ≥ 5.23.0 / 10.11.0).
> 
> The hardware interface loads RTDE recipes as vectors, **appends** `actual_current_as_torque` when torque mode is selected, and passes those recipes into `UrDriver` (replacing recipe file paths in driver config). Configure-time checks enforce minimum software versions, warn on CB3, and surface clear errors if the robot rejects the RTDE key. The `read()` loop selects `actual_current` vs `actual_current_as_torque` based on the flag.
> 
> **Configuration surface:** new `use_currents_as_efforts` hardware parameter (default `false`), xacro/URDF wiring, and launch arguments on `ur_control.launch.py` / `ur_rsp.launch.py`. Docs and Makoa migration notes describe the behavior change and how to keep legacy currents.
> 
> **Testing:** new parametrized integration test `integration_test_joint_efforts.py` (registered in CMake) validates both effort sources via magnitude heuristics on URSim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2a53a7dcdcc6b0dea2b8cbee21920090cb906e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->