### PR TITLE
Temporarily deactivate one testcase in controller_switch_test

### DIFF
--- a/ur_robot_driver/test/integration_test_controller_switch.py
+++ b/ur_robot_driver/test/integration_test_controller_switch.py
@@ -203,14 +203,16 @@ class ControllerSwitchTest(unittest.TestCase):
                 ],
             ).ok
         )
-        self.assertFalse(
-            self._controller_manager_interface.switch_controller(
-                strictness=SwitchController.Request.STRICT,
-                activate_controllers=[
-                    "forward_position_controller",
-                ],
-            ).ok
-        )
+        # This got removed on 2025-10-29 due to a change in ros2_control
+        # See https://github.com/ros-controls/ros2_control/issues/2758 for details
+        # self.assertFalse(
+        # self._controller_manager_interface.switch_controller(
+        # strictness=SwitchController.Request.STRICT,
+        # activate_controllers=[
+        # "forward_position_controller",
+        # ],
+        # ).ok
+        # )
         self.assertFalse(
             self._controller_manager_interface.switch_controller(
                 strictness=SwitchController.Request.STRICT,


### PR DESCRIPTION
This test currently fails due to an upstream change. This should get addressed somehow, but for now this test case is disabled in order to not block other work.

See https://github.com/ros-controls/ros2_control/issues/2758 for details about the issue. I don't know how that will be resolved and how long that will take. Since this is currently blocking the merge of #1546 and #1341 I would like to disable this check for now. 

If this PR gets approved, I will create an issue that we should re-activate this.