### PR TITLE
Increase default dashboard client timeout to 2 seconds

### DIFF
--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -51,7 +51,7 @@ namespace ur_robot_driver
 DashboardClientROS::DashboardClientROS(const rclcpp::Node::SharedPtr& node, const std::string& robot_ip)
   : node_(node), primary_client_(robot_ip, notifier_)
 {
-  node_->declare_parameter<double>("receive_timeout", 1);
+  node_->declare_parameter<double>("receive_timeout", 2);
 
   primary_client_.start(10, std::chrono::seconds(10));
   auto robot_version = primary_client_.getRobotVersion();


### PR DESCRIPTION
The default timeout of 1 second can collide with certain actions. For example, the power_off command on PolyScope 5 takes 1 sec almost exactly until it sends the answer. With that, the timeout was right on the edge and led to a flaky integration test. Defaulting to 2 seconds should prevent those tests from failing randomly.

I'll add this commit to #1561 and #1562 once approved.