### PR TITLE
ensure latched qos in gpio_controller is reliable

### DIFF
--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -286,6 +286,7 @@ ur_controllers::GPIOController::on_activate(const rclcpp_lifecycle::State& /*pre
   try {
     auto qos_latched = rclcpp::SystemDefaultsQoS();
     qos_latched.transient_local();
+    qos_latched.reliable();
     // register publisher
     io_pub_ = get_node()->create_publisher<ur_msgs::msg::IOStates>("~/io_states", rclcpp::SystemDefaultsQoS());
 


### PR DESCRIPTION
in case a user overrides the system default qos settings, the latched topics of gpio controller (robot_mode, safety_mode, etc) will be incompatible with a latched topic subscriber (transient local and reliable). this change ensures that gpio controller's latched topics are reliable.