### PR TITLE
Add ros2run as a test_depend

### DIFF
--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -74,6 +74,7 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>ros2run</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
Since we use a "ros2 run" command line command to run the example in the tests, we need to add ros2run as a test dependency as well, to make sure that it is present in the testing container.

Before, it was installed as a transitive dependency, but we start seeing test errors on the testing repo because of this.