### PR TITLE
Replace dashboard client on PolyScope X warning

### DIFF
--- a/ur_robot_driver/src/dashboard_client_node.cpp
+++ b/ur_robot_driver/src/dashboard_client_node.cpp
@@ -58,11 +58,9 @@ int main(int argc, char** argv)
   try {
     client = std::make_shared<ur_robot_driver::DashboardClientROS>(node, robot_ip);
   } catch (const urcl::UrException& e) {
-    RCLCPP_WARN(rclcpp::get_logger("Dashboard_Client"),
-                "%s This warning is expected on a PolyScopeX robot. If you don't want to see this warning, "
-                "please don't start the dashboard client. Exiting dashboard client now.",
-                e.what());
-    return 0;
+    RCLCPP_ERROR(rclcpp::get_logger("Dashboard_Client"),
+                 "Error raised during Dashboard Client startup: %s. Exiting dashboard client now.", e.what());
+    return 1;
   }
 
   rclcpp::spin(node);


### PR DESCRIPTION
Since connections to PolyScope X robots are now handled differently, the warning isn't true any longer. If an error is raised during initialization, that most likely is a problem and we should stop the client in that case. Returning 1 instead of 0 makes it transparent to the outside world, that there has been an unexpected exit.