### PR TITLE
Initialize force mode interfaces to NaN on init

### DIFF
--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -182,6 +182,13 @@ URPositionHardwareInterface::on_init(const hardware_interface::HardwareComponent
   motion_primitives_forward_controller_running_ = false;
   hw_moprim_states_.fill(std::numeric_limits<double>::quiet_NaN());
   hw_moprim_commands_.fill(std::numeric_limits<double>::quiet_NaN());
+  for (size_t i = 0; i < 6; i++) {
+    force_mode_task_frame_[i] = NO_NEW_CMD_;
+    force_mode_selection_vector_[i] = static_cast<uint32_t>(NO_NEW_CMD_);
+    force_mode_wrench_[i] = NO_NEW_CMD_;
+    force_mode_limits_[i] = NO_NEW_CMD_;
+  }
+  force_mode_type_ = static_cast<unsigned int>(NO_NEW_CMD_);
 
   for (const hardware_interface::ComponentInfo& joint : info_.joints) {
     auto has_cmd_interface = [](const hardware_interface::ComponentInfo& joint, const std::string& interface_name) {
@@ -778,13 +785,6 @@ URPositionHardwareInterface::on_activate(const rclcpp_lifecycle::State& previous
 {
   RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"), "Activating HW interface");
 
-  for (size_t i = 0; i < 6; i++) {
-    force_mode_task_frame_[i] = NO_NEW_CMD_;
-    force_mode_selection_vector_[i] = static_cast<uint32_t>(NO_NEW_CMD_);
-    force_mode_wrench_[i] = NO_NEW_CMD_;
-    force_mode_limits_[i] = NO_NEW_CMD_;
-  }
-  force_mode_type_ = static_cast<unsigned int>(NO_NEW_CMD_);
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 


### PR DESCRIPTION
Initializing them on activate would lead to an error.

When the program is running on the robot, the write method would invoke starting force mode with uninitialized (zero-initialized) values when the robot is in configured state.

Closing #1612 