### PR TITLE
[CI Doc build] Pin sphinx to version <9

### DIFF
--- a/.github/workflows/sphinx_build.yml
+++ b/.github/workflows/sphinx_build.yml
@@ -27,7 +27,7 @@ jobs:
           pip install -r doc_requirements.txt
       - name: Build documentation
         run: |
-          sphinx-build -W -b html ur_calibration/doc _doc_build && \
-          sphinx-build -W -b html ur_controllers/doc _doc_build && \
-          sphinx-build -W -b html ur_moveit_config/doc _doc_build && \
-          sphinx-build -W -b html ur_robot_driver/doc _doc_build
+          sphinx-build -W -b html ur_calibration/doc _doc_build_calibration && \
+          sphinx-build -W -b html ur_controllers/doc _doc_build_controllers && \
+          sphinx-build -W -b html ur_moveit_config/doc _doc_build_moveit_config && \
+          sphinx-build -W -b html ur_robot_driver/doc _doc_build_robot_driver

--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx<9
 sphinx-copybutton
 sphinx-tabs
 sphinx_rtd_theme


### PR DESCRIPTION
Using sphinx >=9 leads to issues with the sphinx-tabs extension (see https://github.com/executablebooks/sphinx-tabs/issues/206)

Until this is fixed upstream, sphinx will be pinned to version <9.

This should fix our doc builds.