### PR TITLE
[Driver Tests] Unlock protective stop during test case setup

### DIFF
--- a/ur_robot_driver/test/test_common.py
+++ b/ur_robot_driver/test/test_common.py
@@ -248,7 +248,7 @@ class DashboardInterface(
 
         robot_mode = self.get_robot_mode()
         start_time = time.time()
-        while time.time() - start_time < 10:
+        while time.time() - start_time < TIMEOUT_WAIT_SERVICE:
             self._check_call(robot_mode)
             if robot_mode.robot_mode.mode == RobotMode.RUNNING:
                 self._check_call(self.stop())


### PR DESCRIPTION
If the last test case left the robot in a protective stop for some reason, starting the next test case properly will fail. Therefore, unlock any protective stop during test case setup.

This should fix most of the flaky integration tests that we are currently facing.