### PR TITLE
Add sim_time to servo launch file

### DIFF
--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -159,6 +159,9 @@ def generate_launch_description():
         parameters=[
             moveit_config.to_dict(),
             servo_params,
+            {
+                "use_sim_time": use_sim_time,
+            },
         ],
         output="screen",
     )


### PR DESCRIPTION
Minor: propagate the sim time to the servo launch as well.

See also [this PR](https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/pull/128) which  needs this to run.