### PR TITLE
Add deprecation warning for scaled JTC

### DIFF
--- a/ur_controllers/doc/index.rst
+++ b/ur_controllers/doc/index.rst
@@ -50,6 +50,11 @@ down by the controller).
 ur_controlers/ScaledJointTrajectoryController
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. note::
+   The upstream joint_trajectory_controller has been updated to support the scaling feature
+   explained below. Hence, we have decided to deprecate the scaled joint trajectory controller.
+   It will get removed in ROS Lyrical Luth.
+
 These controllers work similar to the well-known
 `joint_trajectory_controller <https://control.ros.org/master/doc/ros2_controllers/joint_trajectory_controller/doc/userdoc.html>`_.
 

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -52,6 +52,10 @@ controller_interface::CallbackReturn ScaledJointTrajectoryController::on_init()
     get_node()->set_parameter(
         rclcpp::Parameter("speed_scaling.state_interface", scaled_params_.speed_scaling_interface_name));
   }
+
+  RCLCPP_WARN(get_node()->get_logger(), "DEPRECATION WARNING: Using the scaled joint trajectory controller is "
+                                        "considered deprecated. It will get removed with ROS Lyrical Luth. Please "
+                                        "use the joint_trajectory_controller that supports the same features.");
   return JointTrajectoryController::on_init();
 }
 


### PR DESCRIPTION
It will be removed in Lyrical, so it makes sense to add a deprecation warning already.