### PR TITLE
Update forward command controller types

### DIFF
--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -19,13 +19,13 @@ controller_manager:
       type: ur_controllers/ScaledJointTrajectoryController
 
     forward_velocity_controller:
-      type: velocity_controllers/JointGroupVelocityController
+      type: forward_command_controller/ForwardCommandController
 
     forward_effort_controller:
-      type: effort_controllers/JointGroupEffortController
+      type: forward_command_controller/ForwardCommandController
 
     forward_position_controller:
-      type: position_controllers/JointGroupPositionController
+      type: forward_command_controller/ForwardCommandController
 
     force_mode_controller:
       type: ur_controllers/ForceModeController
@@ -190,6 +190,7 @@ forward_position_controller:
       - $(var tf_prefix)wrist_1_joint
       - $(var tf_prefix)wrist_2_joint
       - $(var tf_prefix)wrist_3_joint
+    interface_name: position
 
 force_mode_controller:
   ros__parameters:


### PR DESCRIPTION
The specialized controllers have been deprecated upstream. Instead, users should use forward_command_controller/ForwardCommandController and specify the control domain through the "interface_name" parameter.

See https://github.com/ros-controls/ros2_controllers/pull/1913 for example.