### PR TITLE
Changes for branching out for kilted

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -20,3 +20,14 @@ pull_request_rules:
           - jazzy
         labels:
           - jazzy
+
+  - name: Backport to kilted branch
+    conditions:
+      - base=main
+      - label=backport-kilted
+    actions:
+      backport:
+        branches:
+          - kilted
+        labels:
+          - kilted

--- a/.github/workflows/kilted-binary-main.yml
+++ b/.github/workflows/kilted-binary-main.yml
@@ -1,12 +1,6 @@
 name: Kilted Binary Build Main
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '13 4 * * *'
@@ -17,4 +11,4 @@ jobs:
     with:
       ros_distro: kilted
       ros_repo: main
-      ref_for_scheduled_build: main
+      ref_for_scheduled_build: kilted

--- a/.github/workflows/kilted-binary-testing.yml
+++ b/.github/workflows/kilted-binary-testing.yml
@@ -1,12 +1,6 @@
 name: Kilted Binary Build Testing
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '13 4 * * *'
@@ -17,4 +11,4 @@ jobs:
     with:
       ros_distro: kilted
       ros_repo: testing
-      ref_for_scheduled_build: main
+      ref_for_scheduled_build: kilted

--- a/.github/workflows/kilted-semi-binary-main.yml
+++ b/.github/workflows/kilted-semi-binary-main.yml
@@ -1,12 +1,6 @@
 name: Kilted Semi Binary Build Main
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '13 4 * * *'
@@ -18,4 +12,4 @@ jobs:
       ros_distro: kilted
       ros_repo: main
       upstream_workspace: Universal_Robots_ROS2_Driver.kilted.repos
-      ref_for_scheduled_build: main
+      ref_for_scheduled_build: kilted

--- a/.github/workflows/kilted-semi-binary-testing.yml
+++ b/.github/workflows/kilted-semi-binary-testing.yml
@@ -1,12 +1,6 @@
 name: Kilted Semi Binary Build Testing
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '13 4 * * *'
@@ -18,4 +12,4 @@ jobs:
       ros_distro: kilted
       ros_repo: testing
       upstream_workspace: Universal_Robots_ROS2_Driver.kilted.repos
-      ref_for_scheduled_build: main
+      ref_for_scheduled_build: kilted

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
         <th>Branch</th>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/humble">humble</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/jazzy">jazzy</a></td>
-        <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
+        <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">kilted</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
       </tr>
       <tr>

--- a/Universal_Robots_ROS2_Driver.kilted.repos
+++ b/Universal_Robots_ROS2_Driver.kilted.repos
@@ -14,11 +14,11 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
-    version: master
+    version: kilted
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers
-    version: master
+    version: kilted
   kinematics_interface:
     type: git
     url: https://github.com/ros-controls/kinematics_interface.git
@@ -34,7 +34,7 @@ repositories:
   realtime_tools:
     type: git
     url: https://github.com/ros-controls/realtime_tools.git
-    version: master
+    version: kilted
   moveit2:
     type: git
     url: https://github.com/moveit/moveit2.git

--- a/ci_status.md
+++ b/ci_status.md
@@ -47,16 +47,16 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
       </a> <br />
     </td>
     <td> <!-- kilted -->
-      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-binary-main.yml?query=branch%3Amain+">
-         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-binary-main.yml/badge.svg?branch=main"
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-binary-main.yml?query=event%3Aschedule+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-binary-main.yml/badge.svg?event=schedule"
               alt="Kilted Binary Main"/>
       </a> <br />
-      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-binary-testing.yml?query=branch%3Amain+">
-         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-binary-testing.yml/badge.svg?branch=main"
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-binary-testing.yml?query=event%3Aschedule+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-binary-testing.yml/badge.svg?event=schedule"
               alt="Kilted Binary Testing"/>
       </a> <br />
-      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-semi-binary-main.yml?query=branch%3Amain+">
-         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-semi-binary-main.yml/badge.svg?branch=main"
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-semi-binary-main.yml?query=event%3Aschedule+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/kilted-semi-binary-main.yml/badge.svg?event=schedule"
               alt="Kilted Semi-Binary Main"/>
       </a> <br />
     </td>


### PR DESCRIPTION
Creating a branch for kilted requires some information getting updated:

- Update branch in README.md
- Update badge and pipeline links in ci_status.md
- Update workflows to only run on scheduled builds and with sources from the kilted branch

I've also updated the kilted upstream workspace along the way.