### PR TITLE
Ensure calibration library in ur_calibration is always built as static to fix build with BUILD_SHARED_LIBS=ON

### DIFF
--- a/ur_calibration/CMakeLists.txt
+++ b/ur_calibration/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(ur_client_library REQUIRED)
 ## Build ##
 ###########
 
-add_library(calibration
+add_library(calibration STATIC
   src/calibration.cpp
   src/calibration_consumer.cpp
 )


### PR DESCRIPTION
CMake permits to set the `BUILD_SHARED_LIBS=ON` variable to specify if `add_library` calls without specifying explicitly `STATIC` or `SHARED` build a shared library. 

However, in the case of the `calibration` library, the library itself is not meant to be installed, so even if `BUILD_SHARED_LIBS=ON`, the `calibration` library should be built as STATIC, otherwise at runtime the `calibration_correction` can fail with error:

~~~
calibration_correction: error while loading shared libraries: libcalibration.so: cannot open shared object file: No such file or directory
~~~

See https://github.com/RoboStack/ros-jazzy/issues/158 for more details.

This PR fixes this by forcing the `calibration` library to be built as `STATIC`, even if the `BUILD_SHARED_LIBS` variable is set to `ON`.