### PR TITLE
Use a secondary program to confirm urscript_interface initialization

### DIFF
--- a/ur_robot_driver/src/urscript_interface.cpp
+++ b/ur_robot_driver/src/urscript_interface.cpp
@@ -71,7 +71,8 @@ public:
         this->get_parameter("robot_ip").as_string(), urcl::primary_interface::UR_SECONDARY_PORT);
     m_secondary_stream->connect();
 
-    auto program_with_newline = std::string("textmsg(\"urscript_interface connected\")\n");
+    auto program_with_newline = std::string("sec urscript_interface_initialization:\ntextmsg(\"urscript_interface "
+                                            "connected\")\nend\n");
     size_t len = program_with_newline.size();
     const auto* data = reinterpret_cast<const uint8_t*>(program_with_newline.c_str());
     size_t written;


### PR DESCRIPTION
When sending a script not being wrapped in a secondary program, that can interrupt the main program, which isn't necessarily what we want at this point.

I stumbled upon this while testing https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/446. If we stop the driver with a looping program running on the robot, restarting the driver will stop the robot program due to the urscript_interface sending a primary program.