### PR TITLE
RTDE Package to create ROS2 topics for the RTDE Field Names selected.

### DIFF
--- a/ur_rtde_client/CMakeLists.txt
+++ b/ur_rtde_client/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.16)
+project(ur_rtde_client)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(example_interfaces REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(ur_client_library REQUIRED)
+find_package(yaml-cpp REQUIRED)
+find_package(ament_index_cpp REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(tf2_ros REQUIRED)
+find_package(tf2_geometry_msgs REQUIRED)
+find_package(ur_dashboard_msgs REQUIRED)
+
+add_library(${PROJECT_NAME}_lib
+  src/publisher.cpp
+  src/rtde_manager.cpp
+  src/converter.cpp
+)
+target_include_directories(${PROJECT_NAME}_lib PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>)
+target_link_libraries(${PROJECT_NAME}_lib PUBLIC
+  rclcpp::rclcpp
+  tf2::tf2
+  tf2_ros::tf2_ros
+  tf2_geometry_msgs::tf2_geometry_msgs
+  ${example_interfaces_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${builtin_interfaces_TARGETS}
+  ${ur_dashboard_msgs_TARGETS}
+  sensor_msgs::sensor_msgs_library
+  ur_client_library::urcl
+  yaml-cpp
+)
+
+add_executable(rtde_client_node
+  src/rtde_client_node.cpp
+)
+target_link_libraries(rtde_client_node PUBLIC
+  ${PROJECT_NAME}_lib
+  ament_index_cpp::ament_index_cpp
+  rclcpp::rclcpp
+)
+
+install(TARGETS ${PROJECT_NAME}_lib rtde_client_node
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
+)
+install(DIRECTORY include/
+  DESTINATION include
+)
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+install(DIRECTORY config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/ur_rtde_client/LICENSE
+++ b/ur_rtde_client/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2026, Sergi Romero
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/ur_rtde_client/README.md
+++ b/ur_rtde_client/README.md
@@ -1,0 +1,3 @@
+# ur_rtde_client
+
+A ROS 2 package providing a real-time RTDE client for Universal Robots manipulators. It reads robot state fields (e.g. robot mode, safety status, timestamps) via UR’s RTDE protocol and publishes them as ROS 2 topics.

--- a/ur_rtde_client/config/rtde_map.yaml
+++ b/ur_rtde_client/config/rtde_map.yaml
@@ -1,0 +1,194 @@
+rtde_variables:
+  DOUBLE_to_Float64:
+    rtde_type: "DOUBLE"
+    output_type: "example_interfaces/Float64"
+    variables:
+      - "speed_scaling"
+      - "target_speed_fraction"
+      - "actual_momentum"
+      - "actual_main_voltage"
+      - "actual_robot_voltage"
+      - "actual_robot_current"
+      - "standard_analog_input0"
+      - "standard_analog_input1"
+      - "standard_analog_output0"
+      - "standard_analog_output1"
+      - "io_current"
+      - "input_double_register_<0-47>"
+      - "output_double_register_<0-47>"
+      - "actual_robot_energy_consumed"
+      - "actual_robot_braking_energy_dissipated"
+      - "euromap67_24V_voltage"
+      - "euromap67_24V_current"
+      - "tool_analog_input0"
+      - "tool_analog_input1"
+      - "tool_output_current"
+      - "tcp_force_scalar"
+      - "joint_position_deviation_ratio"
+      - "collision_detection_ratio"
+      - "payload"
+
+  INT32_to_INT32:
+    rtde_type: "INT32"
+    output_type: "example_interfaces/Int32"
+    variables:
+      - "input_int_register_<0-47>"
+      - "output_int_register_<0-47>"
+      - "encoder0_raw"
+      - "encoder1_raw"
+      - "tool_output_voltage"
+      - "time_scale_source"
+
+  BOOL_to_BOOL:
+    rtde_type: "BOOL"
+    output_type: "example_interfaces/Bool"
+    variables:
+      - "input_bit_register_<64-127>"
+      - "output_bit_register_<64-127>"
+
+  VECTOR6INT_to_Int32MultiArray:
+    rtde_type: "VECTOR6INT"
+    output_type: "example_interfaces/Int32MultiArray"
+    variables:
+      - "joint_mode"
+
+  VECTOR3D_to_GeometryMsgVector3:
+    rtde_type: "VECTOR3D"
+    output_type: "geometry_msgs/Vector3Stamped"
+    variables:
+      - "target_gravity"
+
+  VECTOR6D_to_GeometryMsgTwist:
+    rtde_type: "VECTOR6D"
+    output_type: "geometry_msgs/TwistStamped"
+    variables:
+      - "actual_TCP_speed"
+      - "target_TCP_speed"
+
+  VECTOR6D_to_GeometryMsgWrench:
+    rtde_type: "VECTOR6D"
+    output_type: "geometry_msgs/WrenchStamped"
+    variables:
+      - "actual_TCP_force"
+      - "ft_raw_wrench"
+      - "wrench_calc_from_currents"
+
+  VECTOR6D_to_GeometryMsgAccel:
+    rtde_type: "VECTOR6D"
+    output_type: "geometry_msgs/AccelStamped"
+    variables:
+      - "actual_TCP_acceleration"
+      - "target_TCP_acceleration"
+      - "actual_tool_accelerometer"
+
+  VECTOR6D_to_GeometryMsgPose:
+    rtde_type: "VECTOR6D"
+    output_type: "geometry_msgs/PoseStamped"
+    variables:
+      - "actual_TCP_pose"
+      - "target_TCP_pose"
+      - "tcp_offset"
+
+  VECTOR3D_to_GeometryMsgTwist:
+    rtde_type: "VECTOR3D"
+    output_type: "geometry_msgs/TwistStamped"
+    variables:
+      - "elbow_velocity"
+
+  VECTOR3D_to_GeometryMsgPoint:
+    rtde_type: "VECTOR3D"
+    output_type: "geometry_msgs/PointStamped"
+    variables:
+      - "elbow_position"
+      - "payload_cog"
+
+  VECTOR6D_to_GeometryMsgInertia:
+    rtde_type: "VECTOR6D"
+    output_type: "geometry_msgs/InertiaStamped"
+    variables:
+      - "payload_inertia"
+
+  DOUBLE_to_Temperature:
+    rtde_type: "DOUBLE"
+    output_type: "sensor_msgs/Temperature"
+    variables:
+      - "tool_temperature"
+
+  VECTOR6D_to_Float64MultiArray:
+    rtde_type: "VECTOR6D"
+    output_type: "example_interfaces/Float64MultiArray"
+    variables:
+      - "target_q"
+      - "target_qd"
+      - "target_qdd"
+      - "target_current"
+      - "target_moment"
+      - "actual_q"
+      - "actual_qd"
+      - "actual_current"
+      - "actual_current_window"
+      - "actual_current_as_torque"
+      - "joint_control_output"
+      - "joint_temperatures"
+      - "actual_joint_voltage"
+      - "target_base_acceleration"
+
+  DOUBLE_to_BuiltinInterfaces:
+    rtde_type: "DOUBLE"
+    output_type: "builtin_interfaces/Time"
+    variables:
+      - "timestamp"
+      - "actual_execution_time"
+      - "target_execution_time"
+
+  UINT64_to_ByteMultiArray:
+    rtde_type: "UINT64"
+    output_type: "example_interfaces/ByteMultiArray"
+    variables:
+      - "actual_digital_input_bits"
+      - "actual_configurable_digital_input_bits"
+      - "actual_digital_output_bits"
+      - "actual_configurable_digital_output_bits"
+
+  UINT32_to_ByteMultiArray:
+    rtde_type: "UINT32"
+    output_type: "example_interfaces/ByteMultiArray"
+    variables:
+      - "robot_status_bits"
+      - "safety_status_bits"
+      - "analog_io_types"
+      - "input_bit_registers0_to_31"
+      - "input_bit_registers32_to_63"
+      - "output_bit_registers0_to_31"
+      - "output_bit_registers32_to_63"
+      - "euromap67_input_bits"
+      - "euromap67_output_bits"
+      - "tool_analog_input_types"
+
+  UINT32_to_UINT32:
+    rtde_type: "UINT32"
+    output_type: "example_interfaces/UInt32"
+    variables:
+      - "runtime_state"
+      - "tool_mode"
+      - "script_control_line"
+
+  UINT8_to_UINT8:
+    rtde_type: "UINT8"
+    output_type: "example_interfaces/UInt8"
+    variables:
+      - "tool_output_mode"
+      - "tool_digital_output0_mode"
+      - "tool_digital_output1_mode"
+
+  INT32_to_ROBOT_MODE:
+    rtde_type: "INT32"
+    output_type: "ur_dashboard_msgs/RobotMode"
+    variables:
+      - "robot_mode"
+
+  INT32_to_SAFETY_MODE:
+    rtde_type: "INT32"
+    output_type: "ur_dashboard_msgs/SafetyMode"
+    variables:
+      - "safety_mode"

--- a/ur_rtde_client/include/ur_rtde_client/converter.hpp
+++ b/ur_rtde_client/include/ur_rtde_client/converter.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <cmath>
+#include <rclcpp/rclcpp.hpp>
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <geometry_msgs/msg/wrench_stamped.hpp>
+#include <geometry_msgs/msg/accel_stamped.hpp>
+#include <geometry_msgs/msg/vector3_stamped.hpp>
+#include <geometry_msgs/msg/point_stamped.hpp>
+#include <geometry_msgs/msg/inertia_stamped.hpp>
+#include <example_interfaces/msg/u_int8.hpp>
+#include <example_interfaces/msg/u_int32.hpp>
+#include <example_interfaces/msg/u_int64.hpp>
+#include <example_interfaces/msg/int32.hpp>
+#include <example_interfaces/msg/byte_multi_array.hpp>
+#include <example_interfaces/msg/float64.hpp>
+#include <example_interfaces/msg/bool.hpp>
+#include <example_interfaces/msg/float64_multi_array.hpp>
+#include <example_interfaces/msg/int32_multi_array.hpp>
+#include <sensor_msgs/msg/temperature.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <builtin_interfaces/msg/time.hpp>
+#include "ur_client_library/rtde/rtde_client.h"
+#include <ur_dashboard_msgs/msg/robot_mode.hpp>
+#include <ur_dashboard_msgs/msg/safety_mode.hpp>
+
+namespace ur_rtde_client
+{
+    /**
+     * @brief Utility class to convert raw RTDE-like data into ROS 2 messages.
+     */
+    class Converter
+    {
+    public:
+        static std::unique_ptr<geometry_msgs::msg::TwistStamped>
+        vector6dToTwistStamped(const std::vector<double> &data);
+
+        static std::unique_ptr<example_interfaces::msg::UInt32>
+        uint32ToMsg(uint32_t value);
+
+        static std::unique_ptr<example_interfaces::msg::Float64>
+        doubleToMsg(double value);
+
+        static std::unique_ptr<example_interfaces::msg::Float64MultiArray>
+        vector6dToFloat64MultiArray(const std::vector<double> &data);
+
+        static std::unique_ptr<geometry_msgs::msg::WrenchStamped>
+        vector6dToWrenchStamped(const std::vector<double> &data);
+
+        static std::unique_ptr<geometry_msgs::msg::PoseStamped>
+        vector6dToPoseStamped(const std::vector<double> &data);
+
+        static std::unique_ptr<geometry_msgs::msg::AccelStamped>
+        vector6dToAccelStamped(const std::vector<double> &data);
+
+        static std::unique_ptr<example_interfaces::msg::Int32>
+        int32ToMsg(int32_t value);
+
+        static std::unique_ptr<geometry_msgs::msg::Vector3Stamped>
+        vector3dToVector3Stamped(const std::vector<double> &data);
+
+        static std::unique_ptr<geometry_msgs::msg::PointStamped>
+        vector3dToPointStamped(const std::vector<double> &data);
+
+        static std::unique_ptr<builtin_interfaces::msg::Time>
+        doubleToTimeMsg(double value);
+
+        static std::unique_ptr<example_interfaces::msg::ByteMultiArray>
+        uint32ToByteMultiArray(uint32_t value);
+
+        static std::unique_ptr<example_interfaces::msg::ByteMultiArray>
+        uint64ToByteMultiArray(uint64_t value);
+
+        static std::unique_ptr<ur_dashboard_msgs::msg::RobotMode>
+        int32ToURRobotModeMsg(int32_t value);
+
+        static std::unique_ptr<ur_dashboard_msgs::msg::SafetyMode>
+        int32ToURSafetyModeMsg(int32_t value);
+
+        static std::unique_ptr<geometry_msgs::msg::InertiaStamped>
+        vector6dToInertiaStamped(const std::vector<double> &data);
+
+        static std::unique_ptr<sensor_msgs::msg::Temperature>
+        doubleToTemperatureMsg(double value);
+
+        static std::unique_ptr<example_interfaces::msg::UInt8>
+        uint8Tomsg(uint8_t value);
+
+        static std::unique_ptr<example_interfaces::msg::Int32MultiArray>
+        vector6intToMsg(const std::vector<int32_t> &data);
+
+        static std::unique_ptr<example_interfaces::msg::Bool>
+        boolToMsg(bool value);
+    };
+
+} // namespace ur_rtde_client

--- a/ur_rtde_client/include/ur_rtde_client/converter.hpp
+++ b/ur_rtde_client/include/ur_rtde_client/converter.hpp
@@ -1,3 +1,31 @@
+// Copyright 2026, Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #pragma once
 
 #include <string>
@@ -30,71 +58,52 @@
 
 namespace ur_rtde_client
 {
-    /**
-     * @brief Utility class to convert raw RTDE-like data into ROS 2 messages.
-     */
-    class Converter
-    {
-    public:
-        static std::unique_ptr<geometry_msgs::msg::TwistStamped>
-        vector6dToTwistStamped(const std::vector<double> &data);
+/**
+ * @brief Utility class to convert raw RTDE-like data into ROS 2 messages.
+ */
+class Converter
+{
+public:
+  static std::unique_ptr<geometry_msgs::msg::TwistStamped> vector6dToTwistStamped(const std::vector<double>& data);
 
-        static std::unique_ptr<example_interfaces::msg::UInt32>
-        uint32ToMsg(uint32_t value);
+  static std::unique_ptr<example_interfaces::msg::UInt32> uint32ToMsg(uint32_t value);
 
-        static std::unique_ptr<example_interfaces::msg::Float64>
-        doubleToMsg(double value);
+  static std::unique_ptr<example_interfaces::msg::Float64> doubleToMsg(double value);
 
-        static std::unique_ptr<example_interfaces::msg::Float64MultiArray>
-        vector6dToFloat64MultiArray(const std::vector<double> &data);
+  static std::unique_ptr<example_interfaces::msg::Float64MultiArray>
+  vector6dToFloat64MultiArray(const std::vector<double>& data);
 
-        static std::unique_ptr<geometry_msgs::msg::WrenchStamped>
-        vector6dToWrenchStamped(const std::vector<double> &data);
+  static std::unique_ptr<geometry_msgs::msg::WrenchStamped> vector6dToWrenchStamped(const std::vector<double>& data);
 
-        static std::unique_ptr<geometry_msgs::msg::PoseStamped>
-        vector6dToPoseStamped(const std::vector<double> &data);
+  static std::unique_ptr<geometry_msgs::msg::PoseStamped> vector6dToPoseStamped(const std::vector<double>& data);
 
-        static std::unique_ptr<geometry_msgs::msg::AccelStamped>
-        vector6dToAccelStamped(const std::vector<double> &data);
+  static std::unique_ptr<geometry_msgs::msg::AccelStamped> vector6dToAccelStamped(const std::vector<double>& data);
 
-        static std::unique_ptr<example_interfaces::msg::Int32>
-        int32ToMsg(int32_t value);
+  static std::unique_ptr<example_interfaces::msg::Int32> int32ToMsg(int32_t value);
 
-        static std::unique_ptr<geometry_msgs::msg::Vector3Stamped>
-        vector3dToVector3Stamped(const std::vector<double> &data);
+  static std::unique_ptr<geometry_msgs::msg::Vector3Stamped> vector3dToVector3Stamped(const std::vector<double>& data);
 
-        static std::unique_ptr<geometry_msgs::msg::PointStamped>
-        vector3dToPointStamped(const std::vector<double> &data);
+  static std::unique_ptr<geometry_msgs::msg::PointStamped> vector3dToPointStamped(const std::vector<double>& data);
 
-        static std::unique_ptr<builtin_interfaces::msg::Time>
-        doubleToTimeMsg(double value);
+  static std::unique_ptr<builtin_interfaces::msg::Time> doubleToTimeMsg(double value);
 
-        static std::unique_ptr<example_interfaces::msg::ByteMultiArray>
-        uint32ToByteMultiArray(uint32_t value);
+  static std::unique_ptr<example_interfaces::msg::ByteMultiArray> uint32ToByteMultiArray(uint32_t value);
 
-        static std::unique_ptr<example_interfaces::msg::ByteMultiArray>
-        uint64ToByteMultiArray(uint64_t value);
+  static std::unique_ptr<example_interfaces::msg::ByteMultiArray> uint64ToByteMultiArray(uint64_t value);
 
-        static std::unique_ptr<ur_dashboard_msgs::msg::RobotMode>
-        int32ToURRobotModeMsg(int32_t value);
+  static std::unique_ptr<ur_dashboard_msgs::msg::RobotMode> int32ToURRobotModeMsg(int32_t value);
 
-        static std::unique_ptr<ur_dashboard_msgs::msg::SafetyMode>
-        int32ToURSafetyModeMsg(int32_t value);
+  static std::unique_ptr<ur_dashboard_msgs::msg::SafetyMode> int32ToURSafetyModeMsg(int32_t value);
 
-        static std::unique_ptr<geometry_msgs::msg::InertiaStamped>
-        vector6dToInertiaStamped(const std::vector<double> &data);
+  static std::unique_ptr<geometry_msgs::msg::InertiaStamped> vector6dToInertiaStamped(const std::vector<double>& data);
 
-        static std::unique_ptr<sensor_msgs::msg::Temperature>
-        doubleToTemperatureMsg(double value);
+  static std::unique_ptr<sensor_msgs::msg::Temperature> doubleToTemperatureMsg(double value);
 
-        static std::unique_ptr<example_interfaces::msg::UInt8>
-        uint8Tomsg(uint8_t value);
+  static std::unique_ptr<example_interfaces::msg::UInt8> uint8Tomsg(uint8_t value);
 
-        static std::unique_ptr<example_interfaces::msg::Int32MultiArray>
-        vector6intToMsg(const std::vector<int32_t> &data);
+  static std::unique_ptr<example_interfaces::msg::Int32MultiArray> vector6intToMsg(const std::vector<int32_t>& data);
 
-        static std::unique_ptr<example_interfaces::msg::Bool>
-        boolToMsg(bool value);
-    };
+  static std::unique_ptr<example_interfaces::msg::Bool> boolToMsg(bool value);
+};
 
-} // namespace ur_rtde_client
+}  // namespace ur_rtde_client

--- a/ur_rtde_client/include/ur_rtde_client/publisher.hpp
+++ b/ur_rtde_client/include/ur_rtde_client/publisher.hpp
@@ -1,3 +1,31 @@
+// Copyright 2026, Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #pragma once
 
 #include <rclcpp/rclcpp.hpp>
@@ -30,87 +58,87 @@
 
 namespace ur_rtde_client
 {
-    /**
-     * @brief Static configuration for one RTDE variable as defined by the YAML mapping.
-     */
-    struct VariableConfig
-    {
-        std::string name;
-        std::string rtde_type;
-        std::string output_type;
-        std::string topic;
-    };
+/**
+ * @brief Static configuration for one RTDE variable as defined by the YAML mapping.
+ */
+struct VariableConfig
+{
+  std::string name;
+  std::string rtde_type;
+  std::string output_type;
+  std::string topic;
+};
 
-    /**
-     * @brief Loads the YAML mapping, creates ROS publishers on demand for a given recipe,
-     *        and publishes fields extracted from UR RTDE data packages.
-     */
-    class Publisher
-    {
-    public:
-        /**
-         * @brief Constructor.
-         * @param node Reference to the ROS2 node.
-         * @param config_path Path to the YAML mapping file ('rtde_map.yaml').
-         */
-        Publisher(rclcpp::Node &node, const std::string &config_path);
+/**
+ * @brief Loads the YAML mapping, creates ROS publishers on demand for a given recipe,
+ *        and publishes fields extracted from UR RTDE data packages.
+ */
+class Publisher
+{
+public:
+  /**
+   * @brief Constructor.
+   * @param node Reference to the ROS2 node.
+   * @param config_path Path to the YAML mapping file ('rtde_map.yaml').
+   */
+  Publisher(rclcpp::Node& node, const std::string& config_path);
 
-        /**
-         * @brief Create publishers for the variables specified by the recipe.
-         * @param recipe List of RTDE variable names to activate/publish.
-         */
-        void createPublishersForRecipe(const std::vector<std::string> &recipe);
+  /**
+   * @brief Create publishers for the variables specified by the recipe.
+   * @param recipe List of RTDE variable names to activate/publish.
+   */
+  void createPublishersForRecipe(const std::vector<std::string>& recipe);
 
-        /**
-         * @brief Publish all active fields extracted from the given RTDE package.
-         * @param pkg UR RTDE data package (UR Client Library).
-         */
-        void publish(const urcl::rtde_interface::DataPackage &pkg);
+  /**
+   * @brief Publish all active fields extracted from the given RTDE package.
+   * @param pkg UR RTDE data package (UR Client Library).
+   */
+  void publish(const urcl::rtde_interface::DataPackage& pkg);
 
-        /**
-         * @brief Get the list of effective keys activated after applying the recipe.
-         * @return A copy of active variable names (keys of 'active_variables_').
-         */
-        const std::vector<std::string> effective_keys() const;
+  /**
+   * @brief Get the list of effective keys activated after applying the recipe.
+   * @return A copy of active variable names (keys of 'active_variables_').
+   */
+  const std::vector<std::string> effective_keys() const;
 
-    private:
-        /// @brief Reference to the ROS2 node used for creating publishers and logging.
-        rclcpp::Node &node_;
+private:
+  /// @brief Reference to the ROS2 node used for creating publishers and logging.
+  rclcpp::Node& node_;
 
-        /// @brief Index of all variables defined in YAML (name -> config).
-        std::map<std::string, VariableConfig> all_variables_;
+  /// @brief Index of all variables defined in YAML (name -> config).
+  std::map<std::string, VariableConfig> all_variables_;
 
-        /// @brief Active subset after applying the recipe (name -> config).
-        std::map<std::string, VariableConfig> active_variables_;
+  /// @brief Active subset after applying the recipe (name -> config).
+  std::map<std::string, VariableConfig> active_variables_;
 
-        /// @brief ROS2 publishers created per active variable
-        std::map<std::string, rclcpp::PublisherBase::SharedPtr> publishers_;
+  /// @brief ROS2 publishers created per active variable
+  std::map<std::string, rclcpp::PublisherBase::SharedPtr> publishers_;
 
-        /**
-         * @brief Load and validate the mapping YAML, filling 'all_variables_'.
-         */
-        void loadConfig(const std::string &config_path);
+  /**
+   * @brief Load and validate the mapping YAML, filling 'all_variables_'.
+   */
+  void loadConfig(const std::string& config_path);
 
-        /**
-         * @brief Create ROS2 publishers for all 'active_variables_'.
-         * @details Uses 'SensorDataQoS' by default.
-         */
-        void createPublishers();
+  /**
+   * @brief Create ROS2 publishers for all 'active_variables_'.
+   * @details Uses 'SensorDataQoS' by default.
+   */
+  void createPublishers();
 
-        /**
-         * @brief Publish a single variable by reading from the RTDE package and converting to its ROS type.
-         * @param var_name RTDE variable name.
-         * @param pkg UR RTDE package to extract data from.
-         */
-        void publishVariable(const std::string &var_name, const urcl::rtde_interface::DataPackage &pkg);
+  /**
+   * @brief Publish a single variable by reading from the RTDE package and converting to its ROS type.
+   * @param var_name RTDE variable name.
+   * @param pkg UR RTDE package to extract data from.
+   */
+  void publishVariable(const std::string& var_name, const urcl::rtde_interface::DataPackage& pkg);
 
-    private:
-        /**
-         * @brief Expand a variable pattern with range (e.g., "var_<0-5>") into individual variables.
-         * @param pattern The pattern string.
-         * @return Vector of expanded variable names.
-         */
-        std::vector<std::string> expandRange(const std::string &pattern);
-    };
+private:
+  /**
+   * @brief Expand a variable pattern with range (e.g., "var_<0-5>") into individual variables.
+   * @param pattern The pattern string.
+   * @return Vector of expanded variable names.
+   */
+  std::vector<std::string> expandRange(const std::string& pattern);
+};
 
-} // namespace ur_rtde_client
+}  // namespace ur_rtde_client

--- a/ur_rtde_client/include/ur_rtde_client/publisher.hpp
+++ b/ur_rtde_client/include/ur_rtde_client/publisher.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include "ur_client_library/rtde/rtde_client.h"
+#include "ur_rtde_client/converter.hpp"
+#include <geometry_msgs/msg/twist_stamped.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
+#include <geometry_msgs/msg/accel_stamped.hpp>
+#include <geometry_msgs/msg/inertia_stamped.hpp>
+#include <geometry_msgs/msg/vector3_stamped.hpp>
+#include <geometry_msgs/msg/point_stamped.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+#include <example_interfaces/msg/u_int32.hpp>
+#include <example_interfaces/msg/int32.hpp>
+#include <example_interfaces/msg/u_int8.hpp>
+#include <example_interfaces/msg/bool.hpp>
+#include <example_interfaces/msg/u_int64.hpp>
+#include <example_interfaces/msg/float64.hpp>
+#include <builtin_interfaces/msg/time.hpp>
+#include <example_interfaces/msg/byte_multi_array.hpp>
+#include <ur_dashboard_msgs/msg/robot_mode.hpp>
+#include <ur_dashboard_msgs/msg/safety_mode.hpp>
+#include <example_interfaces/msg/int32_multi_array.hpp>
+#include <example_interfaces/msg/float64_multi_array.hpp>
+#include <sensor_msgs/msg/temperature.hpp>
+#include <map>
+#include <memory>
+#include <functional>
+#include <yaml-cpp/yaml.h>
+
+namespace ur_rtde_client
+{
+    /**
+     * @brief Static configuration for one RTDE variable as defined by the YAML mapping.
+     */
+    struct VariableConfig
+    {
+        std::string name;
+        std::string rtde_type;
+        std::string output_type;
+        std::string topic;
+    };
+
+    /**
+     * @brief Loads the YAML mapping, creates ROS publishers on demand for a given recipe,
+     *        and publishes fields extracted from UR RTDE data packages.
+     */
+    class Publisher
+    {
+    public:
+        /**
+         * @brief Constructor.
+         * @param node Reference to the ROS2 node.
+         * @param config_path Path to the YAML mapping file ('rtde_map.yaml').
+         */
+        Publisher(rclcpp::Node &node, const std::string &config_path);
+
+        /**
+         * @brief Create publishers for the variables specified by the recipe.
+         * @param recipe List of RTDE variable names to activate/publish.
+         */
+        void createPublishersForRecipe(const std::vector<std::string> &recipe);
+
+        /**
+         * @brief Publish all active fields extracted from the given RTDE package.
+         * @param pkg UR RTDE data package (UR Client Library).
+         */
+        void publish(const urcl::rtde_interface::DataPackage &pkg);
+
+        /**
+         * @brief Get the list of effective keys activated after applying the recipe.
+         * @return A copy of active variable names (keys of 'active_variables_').
+         */
+        const std::vector<std::string> effective_keys() const;
+
+    private:
+        /// @brief Reference to the ROS2 node used for creating publishers and logging.
+        rclcpp::Node &node_;
+
+        /// @brief Index of all variables defined in YAML (name -> config).
+        std::map<std::string, VariableConfig> all_variables_;
+
+        /// @brief Active subset after applying the recipe (name -> config).
+        std::map<std::string, VariableConfig> active_variables_;
+
+        /// @brief ROS2 publishers created per active variable
+        std::map<std::string, rclcpp::PublisherBase::SharedPtr> publishers_;
+
+        /**
+         * @brief Load and validate the mapping YAML, filling 'all_variables_'.
+         */
+        void loadConfig(const std::string &config_path);
+
+        /**
+         * @brief Create ROS2 publishers for all 'active_variables_'.
+         * @details Uses 'SensorDataQoS' by default.
+         */
+        void createPublishers();
+
+        /**
+         * @brief Publish a single variable by reading from the RTDE package and converting to its ROS type.
+         * @param var_name RTDE variable name.
+         * @param pkg UR RTDE package to extract data from.
+         */
+        void publishVariable(const std::string &var_name, const urcl::rtde_interface::DataPackage &pkg);
+
+    private:
+        /**
+         * @brief Expand a variable pattern with range (e.g., "var_<0-5>") into individual variables.
+         * @param pattern The pattern string.
+         * @return Vector of expanded variable names.
+         */
+        std::vector<std::string> expandRange(const std::string &pattern);
+    };
+
+} // namespace ur_rtde_client

--- a/ur_rtde_client/include/ur_rtde_client/rtde_client_node.hpp
+++ b/ur_rtde_client/include/ur_rtde_client/rtde_client_node.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "rclcpp/rclcpp.hpp"
+#include "ur_rtde_client/rtde_manager.hpp"
+#include "ur_rtde_client/publisher.hpp"
+#include "ament_index_cpp/get_package_share_directory.hpp"
+#include "ur_rtde_client/publisher.hpp"
+
+namespace ur_rtde_client
+{
+    /**
+     * @brief ROS 2 node that bridges UR RTDE data to ROS topics.
+     */
+    class RtdeClientNode : public rclcpp::Node
+    {
+    public:
+        /**
+         * @brief Constructs the node, declares parameters, loads config, creates publishers,
+         *        and starts RTDE communication (which runs in a background thread).
+         */
+        RtdeClientNode();
+
+    private:
+        /// @brief Helper that loads YAML mapping and creates ROS publishers per RTDE variable/group.
+        std::unique_ptr<Publisher> publisher_;
+
+        /// @brief Manager that owns the URCL RTDEClient, initializes and streams data.
+        std::unique_ptr<RtdeManager> rtde_manager_;
+
+        /// @brief Recipe (list of RTDE output keys) requested to the robot and published by this node.
+        std::vector<std::string> output_recipe_;
+
+        /// @brief Robot controller IP address (declared/read as parameter).
+        std::string robot_ip_;
+
+        /// @brief Keys actually created and active after validating with the YAML mapping.
+        std::vector<std::string> effective_keys_;
+    };
+
+} // namespace ur_rtde_client

--- a/ur_rtde_client/include/ur_rtde_client/rtde_client_node.hpp
+++ b/ur_rtde_client/include/ur_rtde_client/rtde_client_node.hpp
@@ -1,3 +1,31 @@
+// Copyright 2026, Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #pragma once
 
 #include "rclcpp/rclcpp.hpp"
@@ -8,33 +36,33 @@
 
 namespace ur_rtde_client
 {
-    /**
-     * @brief ROS 2 node that bridges UR RTDE data to ROS topics.
-     */
-    class RtdeClientNode : public rclcpp::Node
-    {
-    public:
-        /**
-         * @brief Constructs the node, declares parameters, loads config, creates publishers,
-         *        and starts RTDE communication (which runs in a background thread).
-         */
-        RtdeClientNode();
+/**
+ * @brief ROS 2 node that bridges UR RTDE data to ROS topics.
+ */
+class RtdeClientNode : public rclcpp::Node
+{
+public:
+  /**
+   * @brief Constructs the node, declares parameters, loads config, creates publishers,
+   *        and starts RTDE communication (which runs in a background thread).
+   */
+  RtdeClientNode();
 
-    private:
-        /// @brief Helper that loads YAML mapping and creates ROS publishers per RTDE variable/group.
-        std::unique_ptr<Publisher> publisher_;
+private:
+  /// @brief Helper that loads YAML mapping and creates ROS publishers per RTDE variable/group.
+  std::unique_ptr<Publisher> publisher_;
 
-        /// @brief Manager that owns the URCL RTDEClient, initializes and streams data.
-        std::unique_ptr<RtdeManager> rtde_manager_;
+  /// @brief Manager that owns the URCL RTDEClient, initializes and streams data.
+  std::unique_ptr<RtdeManager> rtde_manager_;
 
-        /// @brief Recipe (list of RTDE output keys) requested to the robot and published by this node.
-        std::vector<std::string> output_recipe_;
+  /// @brief Recipe (list of RTDE output keys) requested to the robot and published by this node.
+  std::vector<std::string> output_recipe_;
 
-        /// @brief Robot controller IP address (declared/read as parameter).
-        std::string robot_ip_;
+  /// @brief Robot controller IP address (declared/read as parameter).
+  std::string robot_ip_;
 
-        /// @brief Keys actually created and active after validating with the YAML mapping.
-        std::vector<std::string> effective_keys_;
-    };
+  /// @brief Keys actually created and active after validating with the YAML mapping.
+  std::vector<std::string> effective_keys_;
+};
 
-} // namespace ur_rtde_client
+}  // namespace ur_rtde_client

--- a/ur_rtde_client/include/ur_rtde_client/rtde_manager.hpp
+++ b/ur_rtde_client/include/ur_rtde_client/rtde_manager.hpp
@@ -1,3 +1,31 @@
+// Copyright 2026, Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #pragma once
 
 #include <rclcpp/rclcpp.hpp>
@@ -14,87 +42,82 @@
 
 namespace ur_rtde_client
 {
-    /**
-     * @brief Manages the UR RTDE client lifecycle and bridges data to the Publisher.
-     */
-    class RtdeManager
-    {
-    public:
-        /**
-         * @brief Construct an RtdeManager.
-         * @param node Reference to the ROS 2 node.
-         * @param robot_ip Robot controller IP address.
-         * @param keys RTDE output recipe.
-         * @param publisher Reference to the Publisher that will publish parsed data.
-         */
-        RtdeManager(rclcpp::Node &node,
-                    std::string robot_ip,
-                    std::vector<std::string> keys,
-                    Publisher &publisher);
+/**
+ * @brief Manages the UR RTDE client lifecycle and bridges data to the Publisher.
+ */
+class RtdeManager
+{
+public:
+  /**
+   * @brief Construct an RtdeManager.
+   * @param node Reference to the ROS 2 node.
+   * @param robot_ip Robot controller IP address.
+   * @param keys RTDE output recipe.
+   * @param publisher Reference to the Publisher that will publish parsed data.
+   */
+  RtdeManager(rclcpp::Node& node, std::string robot_ip, std::vector<std::string> keys, Publisher& publisher);
 
-        /**
-         * @brief Destructor of RtdeManager.
-         * It reads the last data from the threat before removing the object.
-         */
-        ~RtdeManager();
+  /**
+   * @brief Destructor of RtdeManager.
+   * It reads the last data from the threat before removing the object.
+   */
+  ~RtdeManager();
 
-        RtdeManager(const RtdeManager &) = delete;
-        RtdeManager &operator=(const RtdeManager &) = delete;
+  RtdeManager(const RtdeManager&) = delete;
+  RtdeManager& operator=(const RtdeManager&) = delete;
 
-        /**
-         * @brief Initialize and start the UR RTDE client.
-         * @return true if initialization and start succeeded; false otherwise.
-         */
-        bool initAndStart();
+  /**
+   * @brief Initialize and start the UR RTDE client.
+   * @return true if initialization and start succeeded; false otherwise.
+   */
+  bool initAndStart();
 
-        /**
-         * @brief Perform one RTDE cycle, fetch a data package and publish active variables.
-         */
-        void spinOnce();
+  /**
+   * @brief Perform one RTDE cycle, fetch a data package and publish active variables.
+   */
+  void spinOnce();
 
-    private:
-        /// @brief Reference to the ROS 2 node.
-        rclcpp::Node &node_;
+private:
+  /// @brief Reference to the ROS 2 node.
+  rclcpp::Node& node_;
 
-        /// @brief Robot controller IP address.
-        std::string robot_ip_;
+  /// @brief Robot controller IP address.
+  std::string robot_ip_;
 
-        /// @brief RTDE output recipe.
-        std::vector<std::string> keys_;
+  /// @brief RTDE output recipe.
+  std::vector<std::string> keys_;
 
-        /// @brief Reference to the Publisher used to publish parsed data.
-        Publisher &publisher_;
+  /// @brief Reference to the Publisher used to publish parsed data.
+  Publisher& publisher_;
 
-        /// @brief URCL notifier for logging/callback hooks.
-        urcl::comm::INotifier notifier_{};
+  /// @brief URCL notifier for logging/callback hooks.
+  urcl::comm::INotifier notifier_{};
 
-        /// @brief Owned UR RTDE client.
-        std::unique_ptr<urcl::rtde_interface::RTDEClient> rtde_client_;
+  /// @brief Owned UR RTDE client.
+  std::unique_ptr<urcl::rtde_interface::RTDEClient> rtde_client_;
 
-        /// @brief Reusable buffer holding the latest RTDE data package.
-        std::unique_ptr<urcl::rtde_interface::DataPackage> pkg_;
+  /// @brief Reusable buffer holding the latest RTDE data package.
+  std::unique_ptr<urcl::rtde_interface::DataPackage> pkg_;
 
-        /// @brief Background thread that reads RTDE data when available.
-        std::thread read_thread_;
+  /// @brief Background thread that reads RTDE data when available.
+  std::thread read_thread_;
 
-        /// @brief Flag to signal the read thread to stop.
-        std::atomic<bool> stop_reading_{false};
+  /// @brief Flag to signal the read thread to stop.
+  std::atomic<bool> stop_reading_{ false };
 
-        /// @brief Worker function for the background read thread.
-        void readThreadWorker();
-    };
+  /// @brief Worker function for the background read thread.
+  void readThreadWorker();
+};
 
-    /**
-     * @brief Convenience factory that constructs, initializes, and starts an RtdeManager.
-     * @param node ROS 2 node reference.
-     * @param robot_ip Robot controller IP.
-     * @param keys RTDE output recipe.
-     * @param publisher Publisher reference.
-     * @return A valid 'RtdeManager' on success; 'nullptr' if initialization failed.
-     */
-    std::unique_ptr<RtdeManager> start_communication(rclcpp::Node &node,
-                                                     const std::string &robot_ip,
-                                                     const std::vector<std::string> &keys,
-                                                     Publisher &publisher);
+/**
+ * @brief Convenience factory that constructs, initializes, and starts an RtdeManager.
+ * @param node ROS 2 node reference.
+ * @param robot_ip Robot controller IP.
+ * @param keys RTDE output recipe.
+ * @param publisher Publisher reference.
+ * @return A valid 'RtdeManager' on success; 'nullptr' if initialization failed.
+ */
+std::unique_ptr<RtdeManager> start_communication(rclcpp::Node& node, const std::string& robot_ip,
+                                                 const std::vector<std::string>& keys, Publisher& publisher);
 
-} // namespace ur_rtde_client
+}  // namespace ur_rtde_client

--- a/ur_rtde_client/include/ur_rtde_client/rtde_manager.hpp
+++ b/ur_rtde_client/include/ur_rtde_client/rtde_manager.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <rclcpp/rclcpp.hpp>
+#include "ur_rtde_client/publisher.hpp"
+#include <ur_client_library/rtde/rtde_client.h>
+#include <ur_client_library/log.h>
+#include <ur_client_library/types.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+#include <thread>
+#include <atomic>
+
+namespace ur_rtde_client
+{
+    /**
+     * @brief Manages the UR RTDE client lifecycle and bridges data to the Publisher.
+     */
+    class RtdeManager
+    {
+    public:
+        /**
+         * @brief Construct an RtdeManager.
+         * @param node Reference to the ROS 2 node.
+         * @param robot_ip Robot controller IP address.
+         * @param keys RTDE output recipe.
+         * @param publisher Reference to the Publisher that will publish parsed data.
+         */
+        RtdeManager(rclcpp::Node &node,
+                    std::string robot_ip,
+                    std::vector<std::string> keys,
+                    Publisher &publisher);
+
+        /**
+         * @brief Destructor of RtdeManager.
+         * It reads the last data from the threat before removing the object.
+         */
+        ~RtdeManager();
+
+        RtdeManager(const RtdeManager &) = delete;
+        RtdeManager &operator=(const RtdeManager &) = delete;
+
+        /**
+         * @brief Initialize and start the UR RTDE client.
+         * @return true if initialization and start succeeded; false otherwise.
+         */
+        bool initAndStart();
+
+        /**
+         * @brief Perform one RTDE cycle, fetch a data package and publish active variables.
+         */
+        void spinOnce();
+
+    private:
+        /// @brief Reference to the ROS 2 node.
+        rclcpp::Node &node_;
+
+        /// @brief Robot controller IP address.
+        std::string robot_ip_;
+
+        /// @brief RTDE output recipe.
+        std::vector<std::string> keys_;
+
+        /// @brief Reference to the Publisher used to publish parsed data.
+        Publisher &publisher_;
+
+        /// @brief URCL notifier for logging/callback hooks.
+        urcl::comm::INotifier notifier_{};
+
+        /// @brief Owned UR RTDE client.
+        std::unique_ptr<urcl::rtde_interface::RTDEClient> rtde_client_;
+
+        /// @brief Reusable buffer holding the latest RTDE data package.
+        std::unique_ptr<urcl::rtde_interface::DataPackage> pkg_;
+
+        /// @brief Background thread that reads RTDE data when available.
+        std::thread read_thread_;
+
+        /// @brief Flag to signal the read thread to stop.
+        std::atomic<bool> stop_reading_{false};
+
+        /// @brief Worker function for the background read thread.
+        void readThreadWorker();
+    };
+
+    /**
+     * @brief Convenience factory that constructs, initializes, and starts an RtdeManager.
+     * @param node ROS 2 node reference.
+     * @param robot_ip Robot controller IP.
+     * @param keys RTDE output recipe.
+     * @param publisher Publisher reference.
+     * @return A valid 'RtdeManager' on success; 'nullptr' if initialization failed.
+     */
+    std::unique_ptr<RtdeManager> start_communication(rclcpp::Node &node,
+                                                     const std::string &robot_ip,
+                                                     const std::vector<std::string> &keys,
+                                                     Publisher &publisher);
+
+} // namespace ur_rtde_client

--- a/ur_rtde_client/launch/rtde_client.launch.xml
+++ b/ur_rtde_client/launch/rtde_client.launch.xml
@@ -1,0 +1,15 @@
+<launch>
+  <arg name="robot_ip" default="none"/>
+  <arg name="output_recipe" default="[none]"/>
+
+  <node
+    pkg="ur_rtde_client"
+    exec="rtde_client_node"
+    name="rtde_client_node"
+    output="screen">
+
+    <param name="robot_ip" value="$(var robot_ip)"/>
+    <param name="output_recipe" value="$(var output_recipe)"/>
+
+  </node>
+</launch>

--- a/ur_rtde_client/package.xml
+++ b/ur_rtde_client/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>ur_rtde_client</name>
+  <version>0.0.1</version>
+  <description>Standalone RTDE client</description>
+
+  <maintainer email="sergi.romero-valderas@teradyne-robotics.com">Sergi Romero</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>example_interfaces</depend>
+  <depend>geometry_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <depend>ur_client_library</depend>
+  <depend>ament_index_cpp</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>builtin_interfaces</depend>
+
+  <depend>yaml-cpp</depend>
+
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ur_rtde_client/src/converter.cpp
+++ b/ur_rtde_client/src/converter.cpp
@@ -1,321 +1,304 @@
+// Copyright 2026, Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #include "ur_rtde_client/converter.hpp"
 
 namespace ur_rtde_client
 {
-    std::unique_ptr<geometry_msgs::msg::TwistStamped>
-    Converter::vector6dToTwistStamped(const std::vector<double> &data)
-    {
+std::unique_ptr<geometry_msgs::msg::TwistStamped> Converter::vector6dToTwistStamped(const std::vector<double>& data)
+{
+  if (data.size() != 6 && data.size() != 3) {
+    throw std::invalid_argument("vectordToTwistStamped: expected 3 or 6 elements");
+  }
 
-        if (data.size() != 6 && data.size() != 3)
-        {
-            throw std::invalid_argument("vectordToTwistStamped: expected 3 or 6 elements");
-        }
+  auto msg = std::make_unique<geometry_msgs::msg::TwistStamped>();
+  msg->header.stamp = rclcpp::Clock().now();
+  msg->header.frame_id = "tool0";
 
-        auto msg = std::make_unique<geometry_msgs::msg::TwistStamped>();
-        msg->header.stamp = rclcpp::Clock().now();
-        msg->header.frame_id = "tool0";
+  msg->twist.linear.x = data[0];
+  msg->twist.linear.y = data[1];
+  msg->twist.linear.z = data[2];
 
-        msg->twist.linear.x = data[0];
-        msg->twist.linear.y = data[1];
-        msg->twist.linear.z = data[2];
+  if (data.size() == 6) {
+    msg->twist.angular.x = data[3];
+    msg->twist.angular.y = data[4];
+    msg->twist.angular.z = data[5];
+  } else {
+    msg->twist.angular.x = 0.0;
+    msg->twist.angular.y = 0.0;
+    msg->twist.angular.z = 0.0;
+  }
+  return msg;
+}
 
-        if (data.size() == 6)
-        {
-            msg->twist.angular.x = data[3];
-            msg->twist.angular.y = data[4];
-            msg->twist.angular.z = data[5];
-        }
-        else
-        {
-            msg->twist.angular.x = 0.0;
-            msg->twist.angular.y = 0.0;
-            msg->twist.angular.z = 0.0;
-        }
-        return msg;
-    }
+std::unique_ptr<geometry_msgs::msg::AccelStamped> Converter::vector6dToAccelStamped(const std::vector<double>& data)
+{
+  if (data.size() != 6 && data.size() != 3) {
+    throw std::invalid_argument("vectordToAccelStamped: expected 6 elements");
+  }
 
-    std::unique_ptr<geometry_msgs::msg::AccelStamped>
-    Converter::vector6dToAccelStamped(const std::vector<double> &data)
-    {
+  auto msg = std::make_unique<geometry_msgs::msg::AccelStamped>();
+  msg->header.stamp = rclcpp::Clock().now();
+  msg->header.frame_id = "tool0";
 
-        if (data.size() != 6 && data.size() != 3)
-        {
-            throw std::invalid_argument("vectordToAccelStamped: expected 6 elements");
-        }
+  msg->accel.linear.x = data[0];
+  msg->accel.linear.y = data[1];
+  msg->accel.linear.z = data[2];
+  msg->accel.angular.x = data[3];
+  msg->accel.angular.y = data[4];
+  msg->accel.angular.z = data[5];
 
-        auto msg = std::make_unique<geometry_msgs::msg::AccelStamped>();
-        msg->header.stamp = rclcpp::Clock().now();
-        msg->header.frame_id = "tool0";
+  return msg;
+}
 
-        msg->accel.linear.x = data[0];
-        msg->accel.linear.y = data[1];
-        msg->accel.linear.z = data[2];
-        msg->accel.angular.x = data[3];
-        msg->accel.angular.y = data[4];
-        msg->accel.angular.z = data[5];
+std::unique_ptr<geometry_msgs::msg::PoseStamped> Converter::vector6dToPoseStamped(const std::vector<double>& data)
+{
+  if (data.size() != 6) {
+    throw std::invalid_argument("vectordToPoseStamped: expected 6 elements");
+  }
 
-        return msg;
-    }
+  auto msg = std::make_unique<geometry_msgs::msg::PoseStamped>();
+  msg->header.stamp = rclcpp::Clock().now();
+  msg->header.frame_id = "tool0";
 
-    std::unique_ptr<geometry_msgs::msg::PoseStamped>
-    Converter::vector6dToPoseStamped(const std::vector<double> &data)
-    {
+  msg->pose.position.x = data[0];
+  msg->pose.position.y = data[1];
+  msg->pose.position.z = data[2];
 
-        if (data.size() != 6)
-        {
-            throw std::invalid_argument("vectordToPoseStamped: expected 6 elements");
-        }
+  const double rx = data[3], ry = data[4], rz = data[5];
 
-        auto msg = std::make_unique<geometry_msgs::msg::PoseStamped>();
-        msg->header.stamp = rclcpp::Clock().now();
-        msg->header.frame_id = "tool0";
+  const double theta = sqrt(rx * rx + ry * ry + rz * rz);
 
-        msg->pose.position.x = data[0];
-        msg->pose.position.y = data[1];
-        msg->pose.position.z = data[2];
+  tf2::Quaternion q;
+  if (theta < 1e-12) {
+    q.setValue(0.0, 0.0, 0.0, 1.0);
+  } else {
+    const double ax = rx / theta;
+    const double ay = ry / theta;
+    const double az = rz / theta;
+    q.setRotation(tf2::Vector3(ax, ay, az), theta);
+  }
 
-        const double rx = data[3], ry = data[4], rz = data[5];
+  msg->pose.orientation = tf2::toMsg(q);
+  return msg;
+}
 
-        const double theta = sqrt(rx * rx + ry * ry + rz * rz);
+std::unique_ptr<geometry_msgs::msg::InertiaStamped> Converter::vector6dToInertiaStamped(const std::vector<double>& data)
+{
+  if (data.size() != 6) {
+    throw std::invalid_argument("vectordToInertiaStamped: expected 6 elements");
+  }
 
-        tf2::Quaternion q;
-        if (theta < 1e-12)
-        {
-            q.setValue(0.0, 0.0, 0.0, 1.0);
-        }
-        else
-        {
-            const double ax = rx / theta;
-            const double ay = ry / theta;
-            const double az = rz / theta;
-            q.setRotation(tf2::Vector3(ax, ay, az), theta);
-        }
+  auto msg = std::make_unique<geometry_msgs::msg::InertiaStamped>();
+  msg->header.stamp = rclcpp::Clock().now();
+  msg->header.frame_id = "tool0";
 
-        msg->pose.orientation = tf2::toMsg(q);
-        return msg;
-    }
+  msg->inertia.ixx = data[0];
+  msg->inertia.iyy = data[1];
+  msg->inertia.izz = data[2];
+  msg->inertia.ixy = data[3];
+  msg->inertia.ixz = data[4];
+  msg->inertia.iyz = data[5];
 
-    std::unique_ptr<geometry_msgs::msg::InertiaStamped>
-    Converter::vector6dToInertiaStamped(const std::vector<double> &data)
-    {
+  return msg;
+}
 
-        if (data.size() != 6)
-        {
-            throw std::invalid_argument("vectordToInertiaStamped: expected 6 elements");
-        }
+std::unique_ptr<geometry_msgs::msg::WrenchStamped> Converter::vector6dToWrenchStamped(const std::vector<double>& data)
+{
+  if (data.size() != 6 && data.size() != 3) {
+    throw std::invalid_argument("vectordToWrenchStamped: expected 6 elements");
+  }
 
-        auto msg = std::make_unique<geometry_msgs::msg::InertiaStamped>();
-        msg->header.stamp = rclcpp::Clock().now();
-        msg->header.frame_id = "tool0";
+  auto msg = std::make_unique<geometry_msgs::msg::WrenchStamped>();
+  msg->header.stamp = rclcpp::Clock().now();
+  msg->header.frame_id = "tool0";
 
-        msg->inertia.ixx = data[0];
-        msg->inertia.iyy = data[1];
-        msg->inertia.izz = data[2];
-        msg->inertia.ixy = data[3];
-        msg->inertia.ixz = data[4];
-        msg->inertia.iyz = data[5];
+  msg->wrench.force.x = data[0];
+  msg->wrench.force.y = data[1];
+  msg->wrench.force.z = data[2];
+  msg->wrench.torque.x = data[3];
+  msg->wrench.torque.y = data[4];
+  msg->wrench.torque.z = data[5];
 
-        return msg;
-    }
+  return msg;
+}
 
-    std::unique_ptr<geometry_msgs::msg::WrenchStamped>
-    Converter::vector6dToWrenchStamped(const std::vector<double> &data)
-    {
+std::unique_ptr<geometry_msgs::msg::PointStamped> Converter::vector3dToPointStamped(const std::vector<double>& data)
+{
+  if (data.size() != 3) {
+    throw std::invalid_argument("vector3dToPointStamped: expected 3 elements");
+  }
 
-        if (data.size() != 6 && data.size() != 3)
-        {
-            throw std::invalid_argument("vectordToWrenchStamped: expected 6 elements");
-        }
+  auto msg = std::make_unique<geometry_msgs::msg::PointStamped>();
+  msg->header.stamp = rclcpp::Clock().now();
+  msg->header.frame_id = "tool0";
 
-        auto msg = std::make_unique<geometry_msgs::msg::WrenchStamped>();
-        msg->header.stamp = rclcpp::Clock().now();
-        msg->header.frame_id = "tool0";
+  msg->point.x = data[0];
+  msg->point.y = data[1];
+  msg->point.z = data[2];
 
-        msg->wrench.force.x = data[0];
-        msg->wrench.force.y = data[1];
-        msg->wrench.force.z = data[2];
-        msg->wrench.torque.x = data[3];
-        msg->wrench.torque.y = data[4];
-        msg->wrench.torque.z = data[5];
+  return msg;
+}
 
-        return msg;
-    }
+std::unique_ptr<geometry_msgs::msg::Vector3Stamped> Converter::vector3dToVector3Stamped(const std::vector<double>& data)
+{
+  if (data.size() != 3) {
+    throw std::invalid_argument("vector3dToVector3Stamped: expected 3 elements");
+  }
 
-    std::unique_ptr<geometry_msgs::msg::PointStamped>
-    Converter::vector3dToPointStamped(const std::vector<double> &data)
-    {
+  auto msg = std::make_unique<geometry_msgs::msg::Vector3Stamped>();
+  msg->header.stamp = rclcpp::Clock().now();
+  msg->header.frame_id = "tool0";
 
-        if (data.size() != 3)
-        {
-            throw std::invalid_argument("vector3dToPointStamped: expected 3 elements");
-        }
+  msg->vector.x = data[0];
+  msg->vector.y = data[1];
+  msg->vector.z = data[2];
 
-        auto msg = std::make_unique<geometry_msgs::msg::PointStamped>();
-        msg->header.stamp = rclcpp::Clock().now();
-        msg->header.frame_id = "tool0";
+  return msg;
+}
 
-        msg->point.x = data[0];
-        msg->point.y = data[1];
-        msg->point.z = data[2];
+std::unique_ptr<sensor_msgs::msg::Temperature> Converter::doubleToTemperatureMsg(double value)
+{
+  auto msg = std::make_unique<sensor_msgs::msg::Temperature>();
+  msg->header.stamp = rclcpp::Clock().now();
+  msg->header.frame_id = "tool0";
+  msg->temperature = value;
+  return msg;
+}
 
-        return msg;
-    }
+std::unique_ptr<example_interfaces::msg::UInt32> Converter::uint32ToMsg(uint32_t value)
+{
+  auto msg = std::make_unique<example_interfaces::msg::UInt32>();
+  msg->data = value;
+  return msg;
+}
 
-    std::unique_ptr<geometry_msgs::msg::Vector3Stamped>
-    Converter::vector3dToVector3Stamped(const std::vector<double> &data)
-    {
+std::unique_ptr<example_interfaces::msg::UInt8> Converter::uint8Tomsg(uint8_t value)
+{
+  auto msg = std::make_unique<example_interfaces::msg::UInt8>();
+  msg->data = value;
+  return msg;
+}
+std::unique_ptr<example_interfaces::msg::Int32> Converter::int32ToMsg(int32_t value)
+{
+  auto msg = std::make_unique<example_interfaces::msg::Int32>();
+  msg->data = value;
+  return msg;
+}
 
-        if (data.size() != 3)
-        {
-            throw std::invalid_argument("vector3dToVector3Stamped: expected 3 elements");
-        }
+std::unique_ptr<example_interfaces::msg::Float64> Converter::doubleToMsg(double value)
+{
+  auto msg = std::make_unique<example_interfaces::msg::Float64>();
+  msg->data = value;
+  return msg;
+}
 
-        auto msg = std::make_unique<geometry_msgs::msg::Vector3Stamped>();
-        msg->header.stamp = rclcpp::Clock().now();
-        msg->header.frame_id = "tool0";
+std::unique_ptr<example_interfaces::msg::Bool> Converter::boolToMsg(bool value)
+{
+  auto msg = std::make_unique<example_interfaces::msg::Bool>();
+  msg->data = value;
+  return msg;
+}
 
-        msg->vector.x = data[0];
-        msg->vector.y = data[1];
-        msg->vector.z = data[2];
+std::unique_ptr<builtin_interfaces::msg::Time> Converter::doubleToTimeMsg(double value)
+{
+  auto msg = std::make_unique<builtin_interfaces::msg::Time>();
+  msg->sec = static_cast<int32_t>(value);
+  msg->nanosec = static_cast<uint32_t>((value - msg->sec) * 1e9);
+  return msg;
+}
 
-        return msg;
-    }
+std::unique_ptr<ur_dashboard_msgs::msg::RobotMode> Converter::int32ToURRobotModeMsg(int32_t value)
+{
+  auto msg = std::make_unique<ur_dashboard_msgs::msg::RobotMode>();
+  msg->mode = int8_t(value);
+  return msg;
+}
+std::unique_ptr<ur_dashboard_msgs::msg::SafetyMode> Converter::int32ToURSafetyModeMsg(int32_t value)
+{
+  auto msg = std::make_unique<ur_dashboard_msgs::msg::SafetyMode>();
+  msg->mode = u_int8_t(value);
+  return msg;
+}
 
-    std::unique_ptr<sensor_msgs::msg::Temperature>
-    Converter::doubleToTemperatureMsg(double value)
-    {
-        auto msg = std::make_unique<sensor_msgs::msg::Temperature>();
-        msg->header.stamp = rclcpp::Clock().now();
-        msg->header.frame_id = "tool0";
-        msg->temperature = value;
-        return msg;
-    }
+std::unique_ptr<example_interfaces::msg::ByteMultiArray> Converter::uint32ToByteMultiArray(uint32_t value)
+{
+  auto msg = std::make_unique<example_interfaces::msg::ByteMultiArray>();
+  msg->data.reserve(32);
 
-    std::unique_ptr<example_interfaces::msg::UInt32>
-    Converter::uint32ToMsg(uint32_t value)
-    {
-        auto msg = std::make_unique<example_interfaces::msg::UInt32>();
-        msg->data = value;
-        return msg;
-    }
+  for (size_t i = 0; i < 32; ++i) {
+    uint8_t bit = static_cast<uint8_t>((value >> i) & 0x01);
+    msg->data.push_back(bit);
+  }
 
-    std::unique_ptr<example_interfaces::msg::UInt8>
-    Converter::uint8Tomsg(uint8_t value)
-    {
-        auto msg = std::make_unique<example_interfaces::msg::UInt8>();
-        msg->data = value;
-        return msg;
-    }
-    std::unique_ptr<example_interfaces::msg::Int32>
-    Converter::int32ToMsg(int32_t value)
-    {
-        auto msg = std::make_unique<example_interfaces::msg::Int32>();
-        msg->data = value;
-        return msg;
-    }
+  return msg;
+}
 
-    std::unique_ptr<example_interfaces::msg::Float64>
-    Converter::doubleToMsg(double value)
-    {
-        auto msg = std::make_unique<example_interfaces::msg::Float64>();
-        msg->data = value;
-        return msg;
-    }
+std::unique_ptr<example_interfaces::msg::ByteMultiArray> Converter::uint64ToByteMultiArray(uint64_t value)
+{
+  auto msg = std::make_unique<example_interfaces::msg::ByteMultiArray>();
+  msg->data.reserve(64);
 
-    std::unique_ptr<example_interfaces::msg::Bool>
-    Converter::boolToMsg(bool value)
-    {
-        auto msg = std::make_unique<example_interfaces::msg::Bool>();
-        msg->data = value;
-        return msg;
-    }
+  for (size_t i = 0; i < 64; ++i) {
+    uint8_t bit = static_cast<uint8_t>((value >> i) & 0x01);
+    msg->data.push_back(bit);
+  }
 
-    std::unique_ptr<builtin_interfaces::msg::Time>
-    Converter::doubleToTimeMsg(double value)
-    {
-        auto msg = std::make_unique<builtin_interfaces::msg::Time>();
-        msg->sec = static_cast<int32_t>(value);
-        msg->nanosec = static_cast<uint32_t>((value - msg->sec) * 1e9);
-        return msg;
-    }
+  return msg;
+}
 
-    std::unique_ptr<ur_dashboard_msgs::msg::RobotMode>
-    Converter::int32ToURRobotModeMsg(int32_t value)
-    {
-        auto msg = std::make_unique<ur_dashboard_msgs::msg::RobotMode>();
-        msg->mode = int8_t(value);
-        return msg;
-    }
-    std::unique_ptr<ur_dashboard_msgs::msg::SafetyMode>
-    Converter::int32ToURSafetyModeMsg(int32_t value)
-    {
-        auto msg = std::make_unique<ur_dashboard_msgs::msg::SafetyMode>();
-        msg->mode = u_int8_t(value);
-        return msg;
-    }
+std::unique_ptr<example_interfaces::msg::Float64MultiArray>
+Converter::vector6dToFloat64MultiArray(const std::vector<double>& data)
+{
+  if (data.size() != 6) {
+    throw std::invalid_argument("vector6dToFloat64MultiArray: expected 6 elements");
+  }
 
-    std::unique_ptr<example_interfaces::msg::ByteMultiArray>
-    Converter::uint32ToByteMultiArray(uint32_t value)
-    {
-        auto msg = std::make_unique<example_interfaces::msg::ByteMultiArray>();
-        msg->data.reserve(32);
+  auto msg = std::make_unique<example_interfaces::msg::Float64MultiArray>();
+  msg->data.reserve(6);
 
-        for (size_t i = 0; i < 32; ++i)
-        {
-            uint8_t bit = static_cast<uint8_t>((value >> i) & 0x01);
-            msg->data.push_back(bit);
-        }
+  for (const auto& value : data) {
+    msg->data.push_back(value);
+  }
 
-        return msg;
-    }
+  return msg;
+}
 
-    std::unique_ptr<example_interfaces::msg::ByteMultiArray>
-    Converter::uint64ToByteMultiArray(uint64_t value)
-    {
-        auto msg = std::make_unique<example_interfaces::msg::ByteMultiArray>();
-        msg->data.reserve(64);
+std::unique_ptr<example_interfaces::msg::Int32MultiArray> Converter::vector6intToMsg(const std::vector<int32_t>& data)
+{
+  auto msg = std::make_unique<example_interfaces::msg::Int32MultiArray>();
+  msg->data.reserve(6);
 
-        for (size_t i = 0; i < 64; ++i)
-        {
-            uint8_t bit = static_cast<uint8_t>((value >> i) & 0x01);
-            msg->data.push_back(bit);
-        }
+  for (const auto& value : data) {
+    msg->data.push_back(static_cast<int32_t>(value));
+  }
 
-        return msg;
-    }
+  return msg;
+}
 
-    std::unique_ptr<example_interfaces::msg::Float64MultiArray>
-    Converter::vector6dToFloat64MultiArray(const std::vector<double> &data)
-    {
-        if (data.size() != 6)
-        {
-            throw std::invalid_argument("vector6dToFloat64MultiArray: expected 6 elements");
-        }
-
-        auto msg = std::make_unique<example_interfaces::msg::Float64MultiArray>();
-        msg->data.reserve(6);
-
-        for (const auto &value : data)
-        {
-            msg->data.push_back(value);
-        }
-
-        return msg;
-    }
-
-    std::unique_ptr<example_interfaces::msg::Int32MultiArray>
-    Converter::vector6intToMsg(const std::vector<int32_t> &data)
-    {
-
-        auto msg = std::make_unique<example_interfaces::msg::Int32MultiArray>();
-        msg->data.reserve(6);
-
-        for (const auto &value : data)
-        {
-            msg->data.push_back(static_cast<int32_t>(value));
-        }
-
-        return msg;
-    }
-
-} // namespace ur_rtde_client
+}  // namespace ur_rtde_client

--- a/ur_rtde_client/src/converter.cpp
+++ b/ur_rtde_client/src/converter.cpp
@@ -1,0 +1,321 @@
+#include "ur_rtde_client/converter.hpp"
+
+namespace ur_rtde_client
+{
+    std::unique_ptr<geometry_msgs::msg::TwistStamped>
+    Converter::vector6dToTwistStamped(const std::vector<double> &data)
+    {
+
+        if (data.size() != 6 && data.size() != 3)
+        {
+            throw std::invalid_argument("vectordToTwistStamped: expected 3 or 6 elements");
+        }
+
+        auto msg = std::make_unique<geometry_msgs::msg::TwistStamped>();
+        msg->header.stamp = rclcpp::Clock().now();
+        msg->header.frame_id = "tool0";
+
+        msg->twist.linear.x = data[0];
+        msg->twist.linear.y = data[1];
+        msg->twist.linear.z = data[2];
+
+        if (data.size() == 6)
+        {
+            msg->twist.angular.x = data[3];
+            msg->twist.angular.y = data[4];
+            msg->twist.angular.z = data[5];
+        }
+        else
+        {
+            msg->twist.angular.x = 0.0;
+            msg->twist.angular.y = 0.0;
+            msg->twist.angular.z = 0.0;
+        }
+        return msg;
+    }
+
+    std::unique_ptr<geometry_msgs::msg::AccelStamped>
+    Converter::vector6dToAccelStamped(const std::vector<double> &data)
+    {
+
+        if (data.size() != 6 && data.size() != 3)
+        {
+            throw std::invalid_argument("vectordToAccelStamped: expected 6 elements");
+        }
+
+        auto msg = std::make_unique<geometry_msgs::msg::AccelStamped>();
+        msg->header.stamp = rclcpp::Clock().now();
+        msg->header.frame_id = "tool0";
+
+        msg->accel.linear.x = data[0];
+        msg->accel.linear.y = data[1];
+        msg->accel.linear.z = data[2];
+        msg->accel.angular.x = data[3];
+        msg->accel.angular.y = data[4];
+        msg->accel.angular.z = data[5];
+
+        return msg;
+    }
+
+    std::unique_ptr<geometry_msgs::msg::PoseStamped>
+    Converter::vector6dToPoseStamped(const std::vector<double> &data)
+    {
+
+        if (data.size() != 6)
+        {
+            throw std::invalid_argument("vectordToPoseStamped: expected 6 elements");
+        }
+
+        auto msg = std::make_unique<geometry_msgs::msg::PoseStamped>();
+        msg->header.stamp = rclcpp::Clock().now();
+        msg->header.frame_id = "tool0";
+
+        msg->pose.position.x = data[0];
+        msg->pose.position.y = data[1];
+        msg->pose.position.z = data[2];
+
+        const double rx = data[3], ry = data[4], rz = data[5];
+
+        const double theta = sqrt(rx * rx + ry * ry + rz * rz);
+
+        tf2::Quaternion q;
+        if (theta < 1e-12)
+        {
+            q.setValue(0.0, 0.0, 0.0, 1.0);
+        }
+        else
+        {
+            const double ax = rx / theta;
+            const double ay = ry / theta;
+            const double az = rz / theta;
+            q.setRotation(tf2::Vector3(ax, ay, az), theta);
+        }
+
+        msg->pose.orientation = tf2::toMsg(q);
+        return msg;
+    }
+
+    std::unique_ptr<geometry_msgs::msg::InertiaStamped>
+    Converter::vector6dToInertiaStamped(const std::vector<double> &data)
+    {
+
+        if (data.size() != 6)
+        {
+            throw std::invalid_argument("vectordToInertiaStamped: expected 6 elements");
+        }
+
+        auto msg = std::make_unique<geometry_msgs::msg::InertiaStamped>();
+        msg->header.stamp = rclcpp::Clock().now();
+        msg->header.frame_id = "tool0";
+
+        msg->inertia.ixx = data[0];
+        msg->inertia.iyy = data[1];
+        msg->inertia.izz = data[2];
+        msg->inertia.ixy = data[3];
+        msg->inertia.ixz = data[4];
+        msg->inertia.iyz = data[5];
+
+        return msg;
+    }
+
+    std::unique_ptr<geometry_msgs::msg::WrenchStamped>
+    Converter::vector6dToWrenchStamped(const std::vector<double> &data)
+    {
+
+        if (data.size() != 6 && data.size() != 3)
+        {
+            throw std::invalid_argument("vectordToWrenchStamped: expected 6 elements");
+        }
+
+        auto msg = std::make_unique<geometry_msgs::msg::WrenchStamped>();
+        msg->header.stamp = rclcpp::Clock().now();
+        msg->header.frame_id = "tool0";
+
+        msg->wrench.force.x = data[0];
+        msg->wrench.force.y = data[1];
+        msg->wrench.force.z = data[2];
+        msg->wrench.torque.x = data[3];
+        msg->wrench.torque.y = data[4];
+        msg->wrench.torque.z = data[5];
+
+        return msg;
+    }
+
+    std::unique_ptr<geometry_msgs::msg::PointStamped>
+    Converter::vector3dToPointStamped(const std::vector<double> &data)
+    {
+
+        if (data.size() != 3)
+        {
+            throw std::invalid_argument("vector3dToPointStamped: expected 3 elements");
+        }
+
+        auto msg = std::make_unique<geometry_msgs::msg::PointStamped>();
+        msg->header.stamp = rclcpp::Clock().now();
+        msg->header.frame_id = "tool0";
+
+        msg->point.x = data[0];
+        msg->point.y = data[1];
+        msg->point.z = data[2];
+
+        return msg;
+    }
+
+    std::unique_ptr<geometry_msgs::msg::Vector3Stamped>
+    Converter::vector3dToVector3Stamped(const std::vector<double> &data)
+    {
+
+        if (data.size() != 3)
+        {
+            throw std::invalid_argument("vector3dToVector3Stamped: expected 3 elements");
+        }
+
+        auto msg = std::make_unique<geometry_msgs::msg::Vector3Stamped>();
+        msg->header.stamp = rclcpp::Clock().now();
+        msg->header.frame_id = "tool0";
+
+        msg->vector.x = data[0];
+        msg->vector.y = data[1];
+        msg->vector.z = data[2];
+
+        return msg;
+    }
+
+    std::unique_ptr<sensor_msgs::msg::Temperature>
+    Converter::doubleToTemperatureMsg(double value)
+    {
+        auto msg = std::make_unique<sensor_msgs::msg::Temperature>();
+        msg->header.stamp = rclcpp::Clock().now();
+        msg->header.frame_id = "tool0";
+        msg->temperature = value;
+        return msg;
+    }
+
+    std::unique_ptr<example_interfaces::msg::UInt32>
+    Converter::uint32ToMsg(uint32_t value)
+    {
+        auto msg = std::make_unique<example_interfaces::msg::UInt32>();
+        msg->data = value;
+        return msg;
+    }
+
+    std::unique_ptr<example_interfaces::msg::UInt8>
+    Converter::uint8Tomsg(uint8_t value)
+    {
+        auto msg = std::make_unique<example_interfaces::msg::UInt8>();
+        msg->data = value;
+        return msg;
+    }
+    std::unique_ptr<example_interfaces::msg::Int32>
+    Converter::int32ToMsg(int32_t value)
+    {
+        auto msg = std::make_unique<example_interfaces::msg::Int32>();
+        msg->data = value;
+        return msg;
+    }
+
+    std::unique_ptr<example_interfaces::msg::Float64>
+    Converter::doubleToMsg(double value)
+    {
+        auto msg = std::make_unique<example_interfaces::msg::Float64>();
+        msg->data = value;
+        return msg;
+    }
+
+    std::unique_ptr<example_interfaces::msg::Bool>
+    Converter::boolToMsg(bool value)
+    {
+        auto msg = std::make_unique<example_interfaces::msg::Bool>();
+        msg->data = value;
+        return msg;
+    }
+
+    std::unique_ptr<builtin_interfaces::msg::Time>
+    Converter::doubleToTimeMsg(double value)
+    {
+        auto msg = std::make_unique<builtin_interfaces::msg::Time>();
+        msg->sec = static_cast<int32_t>(value);
+        msg->nanosec = static_cast<uint32_t>((value - msg->sec) * 1e9);
+        return msg;
+    }
+
+    std::unique_ptr<ur_dashboard_msgs::msg::RobotMode>
+    Converter::int32ToURRobotModeMsg(int32_t value)
+    {
+        auto msg = std::make_unique<ur_dashboard_msgs::msg::RobotMode>();
+        msg->mode = int8_t(value);
+        return msg;
+    }
+    std::unique_ptr<ur_dashboard_msgs::msg::SafetyMode>
+    Converter::int32ToURSafetyModeMsg(int32_t value)
+    {
+        auto msg = std::make_unique<ur_dashboard_msgs::msg::SafetyMode>();
+        msg->mode = u_int8_t(value);
+        return msg;
+    }
+
+    std::unique_ptr<example_interfaces::msg::ByteMultiArray>
+    Converter::uint32ToByteMultiArray(uint32_t value)
+    {
+        auto msg = std::make_unique<example_interfaces::msg::ByteMultiArray>();
+        msg->data.reserve(32);
+
+        for (size_t i = 0; i < 32; ++i)
+        {
+            uint8_t bit = static_cast<uint8_t>((value >> i) & 0x01);
+            msg->data.push_back(bit);
+        }
+
+        return msg;
+    }
+
+    std::unique_ptr<example_interfaces::msg::ByteMultiArray>
+    Converter::uint64ToByteMultiArray(uint64_t value)
+    {
+        auto msg = std::make_unique<example_interfaces::msg::ByteMultiArray>();
+        msg->data.reserve(64);
+
+        for (size_t i = 0; i < 64; ++i)
+        {
+            uint8_t bit = static_cast<uint8_t>((value >> i) & 0x01);
+            msg->data.push_back(bit);
+        }
+
+        return msg;
+    }
+
+    std::unique_ptr<example_interfaces::msg::Float64MultiArray>
+    Converter::vector6dToFloat64MultiArray(const std::vector<double> &data)
+    {
+        if (data.size() != 6)
+        {
+            throw std::invalid_argument("vector6dToFloat64MultiArray: expected 6 elements");
+        }
+
+        auto msg = std::make_unique<example_interfaces::msg::Float64MultiArray>();
+        msg->data.reserve(6);
+
+        for (const auto &value : data)
+        {
+            msg->data.push_back(value);
+        }
+
+        return msg;
+    }
+
+    std::unique_ptr<example_interfaces::msg::Int32MultiArray>
+    Converter::vector6intToMsg(const std::vector<int32_t> &data)
+    {
+
+        auto msg = std::make_unique<example_interfaces::msg::Int32MultiArray>();
+        msg->data.reserve(6);
+
+        for (const auto &value : data)
+        {
+            msg->data.push_back(static_cast<int32_t>(value));
+        }
+
+        return msg;
+    }
+
+} // namespace ur_rtde_client

--- a/ur_rtde_client/src/publisher.cpp
+++ b/ur_rtde_client/src/publisher.cpp
@@ -1,503 +1,390 @@
+// Copyright 2026, Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #include "ur_rtde_client/publisher.hpp"
 
 namespace ur_rtde_client
 {
-    Publisher::Publisher(rclcpp::Node &node, const std::string &config_path)
-        : node_(node)
-    {
-        loadConfig(config_path);
+Publisher::Publisher(rclcpp::Node& node, const std::string& config_path) : node_(node)
+{
+  loadConfig(config_path);
+}
+
+void Publisher::loadConfig(const std::string& config_path)
+{
+  YAML::Node config = YAML::LoadFile(config_path);
+
+  const auto& rtde_vars = config["rtde_variables"];
+
+  for (auto group_it = rtde_vars.begin(); group_it != rtde_vars.end(); ++group_it) {
+    std::string group_name = group_it->first.as<std::string>();
+    const auto& group_config = group_it->second;
+
+    std::string rtde_type = group_config["rtde_type"].as<std::string>();
+    std::string output_type = group_config["output_type"].as<std::string>();
+    const auto& variables = group_config["variables"];
+
+    for (const auto& var_node : variables) {
+      std::string var_pattern = var_node.as<std::string>();
+      auto expanded_vars = expandRange(var_pattern);
+
+      for (const auto& var_name : expanded_vars) {
+        VariableConfig vc;
+        vc.name = var_name;
+        vc.rtde_type = rtde_type;
+        vc.output_type = output_type;
+        vc.topic = "/rtde/" + var_name;
+
+        all_variables_[var_name] = vc;
+      }
+    }
+  }
+
+  RCLCPP_INFO(node_.get_logger(), "YAML file loaded successfully.");
+}
+
+std::vector<std::string> Publisher::expandRange(const std::string& pattern)
+{
+  size_t pos = pattern.find('<');
+  if (pos == std::string::npos) {
+    return { pattern };
+  }
+
+  std::string prefix = pattern.substr(0, pos);
+  size_t end_pos = pattern.find('>', pos);
+  if (end_pos == std::string::npos) {
+    return { pattern };
+  }
+
+  std::string range_str = pattern.substr(pos + 1, end_pos - pos - 1);
+  size_t dash_pos = range_str.find('-');
+  if (dash_pos == std::string::npos) {
+    return { pattern };
+  }
+
+  try {
+    int start = std::stoi(range_str.substr(0, dash_pos));
+    int end = std::stoi(range_str.substr(dash_pos + 1));
+
+    std::vector<std::string> expanded;
+    for (int i = start; i <= end; ++i) {
+      expanded.push_back(prefix + std::to_string(i));
+    }
+    return expanded;
+  } catch (const std::exception&) {
+    return { pattern };
+  }
+}
+
+void Publisher::createPublishersForRecipe(const std::vector<std::string>& recipe)
+{
+  active_variables_.clear();
+  publishers_.clear();
+
+  RCLCPP_INFO(node_.get_logger(), "Creating publishers for recipe with %zu variables", recipe.size());
+
+  for (const auto& var_name : recipe) {
+    auto it = all_variables_.find(var_name);
+    if (it == all_variables_.end()) {
+      RCLCPP_WARN(node_.get_logger(), "Variable %s from recipe not found in config, skipping", var_name.c_str());
+      continue;
     }
 
-    void Publisher::loadConfig(const std::string &config_path)
-    {
-        YAML::Node config = YAML::LoadFile(config_path);
+    active_variables_[var_name] = it->second;
+  }
 
-        const auto &rtde_vars = config["rtde_variables"];
+  createPublishers();
+}
 
-        for (auto group_it = rtde_vars.begin(); group_it != rtde_vars.end(); ++group_it)
-        {
-            std::string group_name = group_it->first.as<std::string>();
-            const auto &group_config = group_it->second;
+void Publisher::createPublishers()
+{
+  auto qos = rclcpp::SensorDataQoS();
 
-            std::string rtde_type = group_config["rtde_type"].as<std::string>();
-            std::string output_type = group_config["output_type"].as<std::string>();
-            const auto &variables = group_config["variables"];
-
-            for (const auto &var_node : variables)
-            {
-                std::string var_pattern = var_node.as<std::string>();
-                auto expanded_vars = expandRange(var_pattern);
-
-                for (const auto &var_name : expanded_vars)
-                {
-                    VariableConfig vc;
-                    vc.name = var_name;
-                    vc.rtde_type = rtde_type;
-                    vc.output_type = output_type;
-                    vc.topic = "/rtde/" + var_name;
-
-                    all_variables_[var_name] = vc;
-                }
-            }
-        }
-
-        RCLCPP_INFO(node_.get_logger(), "YAML file loaded successfully.");
+  for (const auto& [var_name, config] : active_variables_) {
+    if (config.output_type == "geometry_msgs/TwistStamped") {
+      auto pub = node_.create_publisher<geometry_msgs::msg::TwistStamped>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created TwistStamped publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "geometry_msgs/WrenchStamped") {
+      auto pub = node_.create_publisher<geometry_msgs::msg::WrenchStamped>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created WrenchStamped publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "geometry_msgs/PoseStamped") {
+      auto pub = node_.create_publisher<geometry_msgs::msg::PoseStamped>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created PoseStamped publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "geometry_msgs/AccelStamped") {
+      auto pub = node_.create_publisher<geometry_msgs::msg::AccelStamped>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created AccelStamped publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "geometry_msgs/PointStamped") {
+      auto pub = node_.create_publisher<geometry_msgs::msg::PointStamped>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created PointStamped publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "geometry_msgs/Vector3Stamped") {
+      auto pub = node_.create_publisher<geometry_msgs::msg::Vector3Stamped>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created Vector3Stamped publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "geometry_msgs/InertiaStamped") {
+      auto pub = node_.create_publisher<geometry_msgs::msg::InertiaStamped>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created InertiaStamped publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "example_interfaces/UInt32") {
+      auto pub = node_.create_publisher<example_interfaces::msg::UInt32>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created UInt32 publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "example_interfaces/Float64") {
+      auto pub = node_.create_publisher<example_interfaces::msg::Float64>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created Float64 publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "example_interfaces/Int32") {
+      auto pub = node_.create_publisher<example_interfaces::msg::Int32>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created Int32 publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "example_interfaces/UInt8") {
+      auto pub = node_.create_publisher<example_interfaces::msg::UInt8>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created UInt8 publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "example_interfaces/Bool") {
+      auto pub = node_.create_publisher<example_interfaces::msg::Bool>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created Bool publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "example_interfaces/ByteMultiArray") {
+      auto pub = node_.create_publisher<example_interfaces::msg::ByteMultiArray>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created ByteMultiArray publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "ur_dashboard_msgs/RobotMode") {
+      auto pub = node_.create_publisher<ur_dashboard_msgs::msg::RobotMode>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created RobotMode publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "ur_dashboard_msgs/SafetyMode") {
+      auto pub = node_.create_publisher<ur_dashboard_msgs::msg::SafetyMode>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created SafetyMode publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "builtin_interfaces/Time") {
+      auto pub = node_.create_publisher<builtin_interfaces::msg::Time>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created Time publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "sensor_msgs/Temperature") {
+      auto pub = node_.create_publisher<sensor_msgs::msg::Temperature>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created Temperature publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "example_interfaces/Float64MultiArray") {
+      auto pub = node_.create_publisher<example_interfaces::msg::Float64MultiArray>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created Float64MultiArray publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else if (config.output_type == "example_interfaces/Int32MultiArray") {
+      auto pub = node_.create_publisher<example_interfaces::msg::Int32MultiArray>(config.topic, qos);
+      publishers_[var_name] = pub;
+      RCLCPP_INFO(node_.get_logger(), "Created Int32MultiArray publisher for %s on topic %s", var_name.c_str(),
+                  config.topic.c_str());
+    } else {
+      RCLCPP_WARN(node_.get_logger(), "Unknown output type: %s for variable %s", config.output_type.c_str(),
+                  var_name.c_str());
     }
+  }
+}
 
-    std::vector<std::string> Publisher::expandRange(const std::string &pattern)
-    {
-        size_t pos = pattern.find('<');
-        if (pos == std::string::npos)
-        {
-            return {pattern};
-        }
-
-        std::string prefix = pattern.substr(0, pos);
-        size_t end_pos = pattern.find('>', pos);
-        if (end_pos == std::string::npos)
-        {
-            return {pattern};
-        }
-
-        std::string range_str = pattern.substr(pos + 1, end_pos - pos - 1);
-        size_t dash_pos = range_str.find('-');
-        if (dash_pos == std::string::npos)
-        {
-            return {pattern};
-        }
-
-        try
-        {
-            int start = std::stoi(range_str.substr(0, dash_pos));
-            int end = std::stoi(range_str.substr(dash_pos + 1));
-
-            std::vector<std::string> expanded;
-            for (int i = start; i <= end; ++i)
-            {
-                expanded.push_back(prefix + std::to_string(i));
-            }
-            return expanded;
-        }
-        catch (const std::exception &)
-        {
-            return {pattern};
-        }
+void Publisher::publish(const urcl::rtde_interface::DataPackage& pkg)
+{
+  for (const auto& [var_name, config] : active_variables_) {
+    try {
+      publishVariable(var_name, pkg);
+    } catch (const std::exception& e) {
+      RCLCPP_ERROR_THROTTLE(node_.get_logger(), *node_.get_clock(), 3000, "Error publishing %s: %s", var_name.c_str(),
+                            e.what());
     }
+  }
+}
 
-    void Publisher::createPublishersForRecipe(const std::vector<std::string> &recipe)
-    {
-        active_variables_.clear();
-        publishers_.clear();
+void Publisher::publishVariable(const std::string& var_name, const urcl::rtde_interface::DataPackage& pkg)
+{
+  auto it = active_variables_.find(var_name);
+  if (it == active_variables_.end())
+    return;
 
-        RCLCPP_INFO(node_.get_logger(), "Creating publishers for recipe with %zu variables", recipe.size());
+  const auto& config = it->second;
+  auto pub_it = publishers_.find(var_name);
+  if (pub_it == publishers_.end())
+    return;
 
-        for (const auto &var_name : recipe)
-        {
-            auto it = all_variables_.find(var_name);
-            if (it == all_variables_.end())
-            {
-                RCLCPP_WARN(node_.get_logger(),
-                            "Variable %s from recipe not found in config, skipping",
-                            var_name.c_str());
-                continue;
-            }
+  auto pub = pub_it->second;
 
-            active_variables_[var_name] = it->second;
-        }
+  try {
+    if (config.rtde_type == "VECTOR6D") {
+      std::array<double, 6> array_data;
+      if (!pkg.getData(var_name, array_data)) {
+        throw std::runtime_error("Failed to get VECTOR6D data for " + var_name);
+      }
 
-        createPublishers();
+      std::vector<double> vector_data(array_data.begin(), array_data.end());
+      if (config.output_type == "geometry_msgs/TwistStamped") {
+        auto msg = Converter::vector6dToTwistStamped(vector_data);
+        std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::TwistStamped>>(pub)->publish(*msg);
+      } else if (config.output_type == "geometry_msgs/WrenchStamped") {
+        auto msg = Converter::vector6dToWrenchStamped(vector_data);
+        std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>>(pub)->publish(*msg);
+      } else if (config.output_type == "geometry_msgs/PoseStamped") {
+        auto msg = Converter::vector6dToPoseStamped(vector_data);
+        std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::PoseStamped>>(pub)->publish(*msg);
+      } else if (config.output_type == "geometry_msgs/InertiaStamped") {
+        auto msg = Converter::vector6dToInertiaStamped(vector_data);
+        std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::InertiaStamped>>(pub)->publish(*msg);
+      } else if (config.output_type == "geometry_msgs/AccelStamped") {
+        auto msg = Converter::vector6dToAccelStamped(vector_data);
+        std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::AccelStamped>>(pub)->publish(*msg);
+      } else if (config.output_type == "example_interfaces/Float64MultiArray") {
+        auto msg = Converter::vector6dToFloat64MultiArray(vector_data);
+        std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Float64MultiArray>>(pub)->publish(*msg);
+      }
+    } else if (config.rtde_type == "UINT32") {
+      std::uint32_t uint32_data = 0;
+      if (!pkg.getData(var_name, uint32_data)) {
+        throw std::runtime_error("Failed to get UINT32 data for " + var_name);
+      }
+
+      if (config.output_type == "example_interfaces/ByteMultiArray") {
+        auto msg = Converter::uint32ToByteMultiArray(uint32_data);
+        std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::ByteMultiArray>>(pub)->publish(*msg);
+      } else if (config.output_type == "example_interfaces/UInt32") {
+        auto msg = Converter::uint32ToMsg(uint32_data);
+        std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::UInt32>>(pub)->publish(*msg);
+      }
+    } else if (config.rtde_type == "INT32") {
+      std::int32_t int32_data = 0;
+      if (!pkg.getData(var_name, int32_data)) {
+        throw std::runtime_error("Failed to get INT32 data for " + var_name);
+      }
+
+      if (config.output_type == "example_interfaces/Int32") {
+        auto msg = Converter::int32ToMsg(int32_data);
+        std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Int32>>(pub)->publish(*msg);
+      } else if (config.output_type == "ur_dashboard_msgs/RobotMode") {
+        auto msg = Converter::int32ToURRobotModeMsg(int32_data);
+        std::static_pointer_cast<rclcpp::Publisher<ur_dashboard_msgs::msg::RobotMode>>(pub)->publish(*msg);
+      } else if (config.output_type == "ur_dashboard_msgs/SafetyMode") {
+        auto msg = Converter::int32ToURSafetyModeMsg(int32_data);
+        std::static_pointer_cast<rclcpp::Publisher<ur_dashboard_msgs::msg::SafetyMode>>(pub)->publish(*msg);
+      }
+    } else if (config.rtde_type == "UINT64") {
+      std::uint64_t uint64_data = 0;
+      if (!pkg.getData(var_name, uint64_data)) {
+        throw std::runtime_error("Failed to get UINT64 data for " + var_name);
+      }
+      auto msg = Converter::uint64ToByteMultiArray(uint64_data);
+      std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::ByteMultiArray>>(pub)->publish(*msg);
+    } else if (config.rtde_type == "BOOL") {
+      bool bool_data = 0;
+      if (!pkg.getData(var_name, bool_data)) {
+        throw std::runtime_error("Failed to get Bool data for " + var_name);
+      }
+      auto msg = Converter::boolToMsg(bool_data);
+      std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Bool>>(pub)->publish(*msg);
+    } else if (config.rtde_type == "VECTOR6INT") {
+      std::array<std::int32_t, 6> array_data;
+      if (!pkg.getData(var_name, array_data)) {
+        throw std::runtime_error("Failed to get VECTOR6INT data for " + var_name);
+      }
+      std::vector<int32_t> vector_data(array_data.begin(), array_data.end());
+      auto msg = Converter::vector6intToMsg(vector_data);
+      std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Int32MultiArray>>(pub)->publish(*msg);
+    } else if (config.rtde_type == "UINT8") {
+      std::uint8_t uint8_data = 0;
+      if (!pkg.getData(var_name, uint8_data)) {
+        throw std::runtime_error("Failed to get UINT8 data for " + var_name);
+      }
+      auto msg = Converter::uint8Tomsg(uint8_data);
+      std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::UInt8>>(pub)->publish(*msg);
+    } else if (config.rtde_type == "DOUBLE") {
+      std::double_t double_data = 0;
+      if (!pkg.getData(var_name, double_data)) {
+        throw std::runtime_error("Failed to get DOUBLE data for " + var_name);
+      }
+
+      if (config.output_type == "example_interfaces/Float64") {
+        auto msg = Converter::doubleToMsg(double_data);
+        std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Float64>>(pub)->publish(*msg);
+      } else if (config.output_type == "builtin_interfaces/Time") {
+        auto msg = Converter::doubleToTimeMsg(double_data);
+        std::static_pointer_cast<rclcpp::Publisher<builtin_interfaces::msg::Time>>(pub)->publish(*msg);
+      } else if (config.output_type == "sensor_msgs/Temperature") {
+        auto msg = Converter::doubleToTemperatureMsg(double_data);
+        std::static_pointer_cast<rclcpp::Publisher<sensor_msgs::msg::Temperature>>(pub)->publish(*msg);
+      }
+    } else if (config.rtde_type == "VECTOR3D") {
+      std::array<double, 3> array_data;
+      if (!pkg.getData(var_name, array_data)) {
+        throw std::runtime_error("Failed to get VECTOR3D data for " + var_name);
+      }
+
+      std::vector<double> vector_data(array_data.begin(), array_data.end());
+
+      if (config.output_type == "geometry_msgs/TwistStamped") {
+        auto msg = Converter::vector6dToTwistStamped(vector_data);
+        std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::TwistStamped>>(pub)->publish(*msg);
+      } else if (config.output_type == "geometry_msgs/Vector3Stamped") {
+        auto msg = Converter::vector3dToVector3Stamped(vector_data);
+        std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>>(pub)->publish(*msg);
+      } else if (config.output_type == "geometry_msgs/PointStamped") {
+        auto msg = Converter::vector3dToPointStamped(vector_data);
+        std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::PointStamped>>(pub)->publish(*msg);
+      }
     }
+  } catch (const std::exception& e) {
+    throw std::runtime_error(std::string("Failed to get/convert ") + var_name + ": " + e.what());
+  }
+}
 
-    void Publisher::createPublishers()
-    {
-        auto qos = rclcpp::SensorDataQoS();
+const std::vector<std::string> Publisher::effective_keys() const
+{
+  std::vector<std::string> keys;
+  for (const auto& [name, config] : active_variables_) {
+    keys.push_back(name);
+  }
+  return keys;
+}
 
-        for (const auto &[var_name, config] : active_variables_)
-        {
-            if (config.output_type == "geometry_msgs/TwistStamped")
-            {
-                auto pub = node_.create_publisher<geometry_msgs::msg::TwistStamped>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created TwistStamped publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "geometry_msgs/WrenchStamped")
-            {
-                auto pub = node_.create_publisher<geometry_msgs::msg::WrenchStamped>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created WrenchStamped publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "geometry_msgs/PoseStamped")
-            {
-                auto pub = node_.create_publisher<geometry_msgs::msg::PoseStamped>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created PoseStamped publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "geometry_msgs/AccelStamped")
-            {
-                auto pub = node_.create_publisher<geometry_msgs::msg::AccelStamped>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created AccelStamped publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "geometry_msgs/PointStamped")
-            {
-                auto pub = node_.create_publisher<geometry_msgs::msg::PointStamped>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created PointStamped publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "geometry_msgs/Vector3Stamped")
-            {
-                auto pub = node_.create_publisher<geometry_msgs::msg::Vector3Stamped>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created Vector3Stamped publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "geometry_msgs/InertiaStamped")
-            {
-                auto pub = node_.create_publisher<geometry_msgs::msg::InertiaStamped>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created InertiaStamped publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "example_interfaces/UInt32")
-            {
-                auto pub = node_.create_publisher<example_interfaces::msg::UInt32>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created UInt32 publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "example_interfaces/Float64")
-            {
-                auto pub = node_.create_publisher<example_interfaces::msg::Float64>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created Float64 publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "example_interfaces/Int32")
-            {
-                auto pub = node_.create_publisher<example_interfaces::msg::Int32>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created Int32 publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "example_interfaces/UInt8")
-            {
-                auto pub = node_.create_publisher<example_interfaces::msg::UInt8>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created UInt8 publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "example_interfaces/Bool")
-            {
-                auto pub = node_.create_publisher<example_interfaces::msg::Bool>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created Bool publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "example_interfaces/ByteMultiArray")
-            {
-                auto pub = node_.create_publisher<example_interfaces::msg::ByteMultiArray>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created ByteMultiArray publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "ur_dashboard_msgs/RobotMode")
-            {
-                auto pub = node_.create_publisher<ur_dashboard_msgs::msg::RobotMode>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created RobotMode publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "ur_dashboard_msgs/SafetyMode")
-            {
-                auto pub = node_.create_publisher<ur_dashboard_msgs::msg::SafetyMode>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created SafetyMode publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "builtin_interfaces/Time")
-            {
-                auto pub = node_.create_publisher<builtin_interfaces::msg::Time>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created Time publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "sensor_msgs/Temperature")
-            {
-                auto pub = node_.create_publisher<sensor_msgs::msg::Temperature>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created Temperature publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "example_interfaces/Float64MultiArray")
-            {
-                auto pub = node_.create_publisher<example_interfaces::msg::Float64MultiArray>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created Float64MultiArray publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else if (config.output_type == "example_interfaces/Int32MultiArray")
-            {
-                auto pub = node_.create_publisher<example_interfaces::msg::Int32MultiArray>(config.topic, qos);
-                publishers_[var_name] = pub;
-                RCLCPP_INFO(node_.get_logger(), "Created Int32MultiArray publisher for %s on topic %s",
-                            var_name.c_str(), config.topic.c_str());
-            }
-            else
-            {
-                RCLCPP_WARN(node_.get_logger(),
-                            "Unknown output type: %s for variable %s",
-                            config.output_type.c_str(), var_name.c_str());
-            }
-        }
-    }
-
-    void Publisher::publish(const urcl::rtde_interface::DataPackage &pkg)
-    {
-        for (const auto &[var_name, config] : active_variables_)
-        {
-            try
-            {
-                publishVariable(var_name, pkg);
-            }
-            catch (const std::exception &e)
-            {
-                RCLCPP_ERROR_THROTTLE(node_.get_logger(), *node_.get_clock(), 3000,
-                                      "Error publishing %s: %s", var_name.c_str(), e.what());
-            }
-        }
-    }
-
-    void Publisher::publishVariable(const std::string &var_name,
-                                    const urcl::rtde_interface::DataPackage &pkg)
-    {
-        auto it = active_variables_.find(var_name);
-        if (it == active_variables_.end())
-            return;
-
-        const auto &config = it->second;
-        auto pub_it = publishers_.find(var_name);
-        if (pub_it == publishers_.end())
-            return;
-
-        auto pub = pub_it->second;
-
-        try
-        {
-            if (config.rtde_type == "VECTOR6D")
-            {
-                std::array<double, 6> array_data;
-                if (!pkg.getData(var_name, array_data))
-                {
-                    throw std::runtime_error("Failed to get VECTOR6D data for " + var_name);
-                }
-
-                std::vector<double> vector_data(array_data.begin(), array_data.end());
-                if (config.output_type == "geometry_msgs/TwistStamped")
-                {
-                    auto msg = Converter::vector6dToTwistStamped(vector_data);
-                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::TwistStamped>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "geometry_msgs/WrenchStamped")
-                {
-                    auto msg = Converter::vector6dToWrenchStamped(vector_data);
-                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "geometry_msgs/PoseStamped")
-                {
-                    auto msg = Converter::vector6dToPoseStamped(vector_data);
-                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::PoseStamped>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "geometry_msgs/InertiaStamped")
-                {
-                    auto msg = Converter::vector6dToInertiaStamped(vector_data);
-                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::InertiaStamped>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "geometry_msgs/AccelStamped")
-                {
-                    auto msg = Converter::vector6dToAccelStamped(vector_data);
-                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::AccelStamped>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "example_interfaces/Float64MultiArray")
-                {
-                    auto msg = Converter::vector6dToFloat64MultiArray(vector_data);
-                    std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Float64MultiArray>>(pub)
-                        ->publish(*msg);
-                }
-            }
-            else if (config.rtde_type == "UINT32")
-            {
-                std::uint32_t uint32_data = 0;
-                if (!pkg.getData(var_name, uint32_data))
-                {
-                    throw std::runtime_error("Failed to get UINT32 data for " + var_name);
-                }
-
-                if (config.output_type == "example_interfaces/ByteMultiArray")
-                {
-                    auto msg = Converter::uint32ToByteMultiArray(uint32_data);
-                    std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::ByteMultiArray>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "example_interfaces/UInt32")
-                {
-                    auto msg = Converter::uint32ToMsg(uint32_data);
-                    std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::UInt32>>(pub)
-                        ->publish(*msg);
-                }
-            }
-            else if (config.rtde_type == "INT32")
-            {
-                std::int32_t int32_data = 0;
-                if (!pkg.getData(var_name, int32_data))
-                {
-                    throw std::runtime_error("Failed to get INT32 data for " + var_name);
-                }
-
-                if (config.output_type == "example_interfaces/Int32")
-                {
-                    auto msg = Converter::int32ToMsg(int32_data);
-                    std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Int32>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "ur_dashboard_msgs/RobotMode")
-                {
-                    auto msg = Converter::int32ToURRobotModeMsg(int32_data);
-                    std::static_pointer_cast<rclcpp::Publisher<ur_dashboard_msgs::msg::RobotMode>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "ur_dashboard_msgs/SafetyMode")
-                {
-                    auto msg = Converter::int32ToURSafetyModeMsg(int32_data);
-                    std::static_pointer_cast<rclcpp::Publisher<ur_dashboard_msgs::msg::SafetyMode>>(pub)
-                        ->publish(*msg);
-                }
-            }
-            else if (config.rtde_type == "UINT64")
-            {
-                std::uint64_t uint64_data = 0;
-                if (!pkg.getData(var_name, uint64_data))
-                {
-                    throw std::runtime_error("Failed to get UINT64 data for " + var_name);
-                }
-                auto msg = Converter::uint64ToByteMultiArray(uint64_data);
-                std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::ByteMultiArray>>(pub)
-                    ->publish(*msg);
-            }
-            else if (config.rtde_type == "BOOL")
-            {
-                bool bool_data = 0;
-                if (!pkg.getData(var_name, bool_data))
-                {
-                    throw std::runtime_error("Failed to get Bool data for " + var_name);
-                }
-                auto msg = Converter::boolToMsg(bool_data);
-                std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Bool>>(pub)
-                    ->publish(*msg);
-            }
-            else if (config.rtde_type == "VECTOR6INT")
-            {
-                std::array<std::int32_t, 6> array_data;
-                if (!pkg.getData(var_name, array_data))
-                {
-                    throw std::runtime_error("Failed to get VECTOR6INT data for " + var_name);
-                }
-                std::vector<int32_t> vector_data(array_data.begin(), array_data.end());
-                auto msg = Converter::vector6intToMsg(vector_data);
-                std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Int32MultiArray>>(pub)
-                    ->publish(*msg);
-            }
-            else if (config.rtde_type == "UINT8")
-            {
-                std::uint8_t uint8_data = 0;
-                if (!pkg.getData(var_name, uint8_data))
-                {
-                    throw std::runtime_error("Failed to get UINT8 data for " + var_name);
-                }
-                auto msg = Converter::uint8Tomsg(uint8_data);
-                std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::UInt8>>(pub)
-                    ->publish(*msg);
-            }
-            else if (config.rtde_type == "DOUBLE")
-            {
-                std::double_t double_data = 0;
-                if (!pkg.getData(var_name, double_data))
-                {
-                    throw std::runtime_error("Failed to get DOUBLE data for " + var_name);
-                }
-
-                if (config.output_type == "example_interfaces/Float64")
-                {
-                    auto msg = Converter::doubleToMsg(double_data);
-                    std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Float64>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "builtin_interfaces/Time")
-                {
-                    auto msg = Converter::doubleToTimeMsg(double_data);
-                    std::static_pointer_cast<rclcpp::Publisher<builtin_interfaces::msg::Time>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "sensor_msgs/Temperature")
-                {
-                    auto msg = Converter::doubleToTemperatureMsg(double_data);
-                    std::static_pointer_cast<rclcpp::Publisher<sensor_msgs::msg::Temperature>>(pub)
-                        ->publish(*msg);
-                }
-            }
-            else if (config.rtde_type == "VECTOR3D")
-            {
-                std::array<double, 3> array_data;
-                if (!pkg.getData(var_name, array_data))
-                {
-                    throw std::runtime_error("Failed to get VECTOR3D data for " + var_name);
-                }
-
-                std::vector<double> vector_data(array_data.begin(), array_data.end());
-
-                if (config.output_type == "geometry_msgs/TwistStamped")
-                {
-                    auto msg = Converter::vector6dToTwistStamped(vector_data);
-                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::TwistStamped>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "geometry_msgs/Vector3Stamped")
-                {
-                    auto msg = Converter::vector3dToVector3Stamped(vector_data);
-                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>>(pub)
-                        ->publish(*msg);
-                }
-                else if (config.output_type == "geometry_msgs/PointStamped")
-                {
-                    auto msg = Converter::vector3dToPointStamped(vector_data);
-                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::PointStamped>>(pub)
-                        ->publish(*msg);
-                }
-            }
-        }
-        catch (const std::exception &e)
-        {
-            throw std::runtime_error(std::string("Failed to get/convert ") + var_name + ": " + e.what());
-        }
-    }
-
-    const std::vector<std::string> Publisher::effective_keys() const
-    {
-        std::vector<std::string> keys;
-        for (const auto &[name, config] : active_variables_)
-        {
-            keys.push_back(name);
-        }
-        return keys;
-    }
-
-} // namespace ur_rtde_client
+}  // namespace ur_rtde_client

--- a/ur_rtde_client/src/publisher.cpp
+++ b/ur_rtde_client/src/publisher.cpp
@@ -1,0 +1,503 @@
+#include "ur_rtde_client/publisher.hpp"
+
+namespace ur_rtde_client
+{
+    Publisher::Publisher(rclcpp::Node &node, const std::string &config_path)
+        : node_(node)
+    {
+        loadConfig(config_path);
+    }
+
+    void Publisher::loadConfig(const std::string &config_path)
+    {
+        YAML::Node config = YAML::LoadFile(config_path);
+
+        const auto &rtde_vars = config["rtde_variables"];
+
+        for (auto group_it = rtde_vars.begin(); group_it != rtde_vars.end(); ++group_it)
+        {
+            std::string group_name = group_it->first.as<std::string>();
+            const auto &group_config = group_it->second;
+
+            std::string rtde_type = group_config["rtde_type"].as<std::string>();
+            std::string output_type = group_config["output_type"].as<std::string>();
+            const auto &variables = group_config["variables"];
+
+            for (const auto &var_node : variables)
+            {
+                std::string var_pattern = var_node.as<std::string>();
+                auto expanded_vars = expandRange(var_pattern);
+
+                for (const auto &var_name : expanded_vars)
+                {
+                    VariableConfig vc;
+                    vc.name = var_name;
+                    vc.rtde_type = rtde_type;
+                    vc.output_type = output_type;
+                    vc.topic = "/rtde/" + var_name;
+
+                    all_variables_[var_name] = vc;
+                }
+            }
+        }
+
+        RCLCPP_INFO(node_.get_logger(), "YAML file loaded successfully.");
+    }
+
+    std::vector<std::string> Publisher::expandRange(const std::string &pattern)
+    {
+        size_t pos = pattern.find('<');
+        if (pos == std::string::npos)
+        {
+            return {pattern};
+        }
+
+        std::string prefix = pattern.substr(0, pos);
+        size_t end_pos = pattern.find('>', pos);
+        if (end_pos == std::string::npos)
+        {
+            return {pattern};
+        }
+
+        std::string range_str = pattern.substr(pos + 1, end_pos - pos - 1);
+        size_t dash_pos = range_str.find('-');
+        if (dash_pos == std::string::npos)
+        {
+            return {pattern};
+        }
+
+        try
+        {
+            int start = std::stoi(range_str.substr(0, dash_pos));
+            int end = std::stoi(range_str.substr(dash_pos + 1));
+
+            std::vector<std::string> expanded;
+            for (int i = start; i <= end; ++i)
+            {
+                expanded.push_back(prefix + std::to_string(i));
+            }
+            return expanded;
+        }
+        catch (const std::exception &)
+        {
+            return {pattern};
+        }
+    }
+
+    void Publisher::createPublishersForRecipe(const std::vector<std::string> &recipe)
+    {
+        active_variables_.clear();
+        publishers_.clear();
+
+        RCLCPP_INFO(node_.get_logger(), "Creating publishers for recipe with %zu variables", recipe.size());
+
+        for (const auto &var_name : recipe)
+        {
+            auto it = all_variables_.find(var_name);
+            if (it == all_variables_.end())
+            {
+                RCLCPP_WARN(node_.get_logger(),
+                            "Variable %s from recipe not found in config, skipping",
+                            var_name.c_str());
+                continue;
+            }
+
+            active_variables_[var_name] = it->second;
+        }
+
+        createPublishers();
+    }
+
+    void Publisher::createPublishers()
+    {
+        auto qos = rclcpp::SensorDataQoS();
+
+        for (const auto &[var_name, config] : active_variables_)
+        {
+            if (config.output_type == "geometry_msgs/TwistStamped")
+            {
+                auto pub = node_.create_publisher<geometry_msgs::msg::TwistStamped>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created TwistStamped publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "geometry_msgs/WrenchStamped")
+            {
+                auto pub = node_.create_publisher<geometry_msgs::msg::WrenchStamped>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created WrenchStamped publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "geometry_msgs/PoseStamped")
+            {
+                auto pub = node_.create_publisher<geometry_msgs::msg::PoseStamped>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created PoseStamped publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "geometry_msgs/AccelStamped")
+            {
+                auto pub = node_.create_publisher<geometry_msgs::msg::AccelStamped>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created AccelStamped publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "geometry_msgs/PointStamped")
+            {
+                auto pub = node_.create_publisher<geometry_msgs::msg::PointStamped>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created PointStamped publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "geometry_msgs/Vector3Stamped")
+            {
+                auto pub = node_.create_publisher<geometry_msgs::msg::Vector3Stamped>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created Vector3Stamped publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "geometry_msgs/InertiaStamped")
+            {
+                auto pub = node_.create_publisher<geometry_msgs::msg::InertiaStamped>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created InertiaStamped publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "example_interfaces/UInt32")
+            {
+                auto pub = node_.create_publisher<example_interfaces::msg::UInt32>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created UInt32 publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "example_interfaces/Float64")
+            {
+                auto pub = node_.create_publisher<example_interfaces::msg::Float64>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created Float64 publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "example_interfaces/Int32")
+            {
+                auto pub = node_.create_publisher<example_interfaces::msg::Int32>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created Int32 publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "example_interfaces/UInt8")
+            {
+                auto pub = node_.create_publisher<example_interfaces::msg::UInt8>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created UInt8 publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "example_interfaces/Bool")
+            {
+                auto pub = node_.create_publisher<example_interfaces::msg::Bool>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created Bool publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "example_interfaces/ByteMultiArray")
+            {
+                auto pub = node_.create_publisher<example_interfaces::msg::ByteMultiArray>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created ByteMultiArray publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "ur_dashboard_msgs/RobotMode")
+            {
+                auto pub = node_.create_publisher<ur_dashboard_msgs::msg::RobotMode>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created RobotMode publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "ur_dashboard_msgs/SafetyMode")
+            {
+                auto pub = node_.create_publisher<ur_dashboard_msgs::msg::SafetyMode>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created SafetyMode publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "builtin_interfaces/Time")
+            {
+                auto pub = node_.create_publisher<builtin_interfaces::msg::Time>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created Time publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "sensor_msgs/Temperature")
+            {
+                auto pub = node_.create_publisher<sensor_msgs::msg::Temperature>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created Temperature publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "example_interfaces/Float64MultiArray")
+            {
+                auto pub = node_.create_publisher<example_interfaces::msg::Float64MultiArray>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created Float64MultiArray publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else if (config.output_type == "example_interfaces/Int32MultiArray")
+            {
+                auto pub = node_.create_publisher<example_interfaces::msg::Int32MultiArray>(config.topic, qos);
+                publishers_[var_name] = pub;
+                RCLCPP_INFO(node_.get_logger(), "Created Int32MultiArray publisher for %s on topic %s",
+                            var_name.c_str(), config.topic.c_str());
+            }
+            else
+            {
+                RCLCPP_WARN(node_.get_logger(),
+                            "Unknown output type: %s for variable %s",
+                            config.output_type.c_str(), var_name.c_str());
+            }
+        }
+    }
+
+    void Publisher::publish(const urcl::rtde_interface::DataPackage &pkg)
+    {
+        for (const auto &[var_name, config] : active_variables_)
+        {
+            try
+            {
+                publishVariable(var_name, pkg);
+            }
+            catch (const std::exception &e)
+            {
+                RCLCPP_ERROR_THROTTLE(node_.get_logger(), *node_.get_clock(), 3000,
+                                      "Error publishing %s: %s", var_name.c_str(), e.what());
+            }
+        }
+    }
+
+    void Publisher::publishVariable(const std::string &var_name,
+                                    const urcl::rtde_interface::DataPackage &pkg)
+    {
+        auto it = active_variables_.find(var_name);
+        if (it == active_variables_.end())
+            return;
+
+        const auto &config = it->second;
+        auto pub_it = publishers_.find(var_name);
+        if (pub_it == publishers_.end())
+            return;
+
+        auto pub = pub_it->second;
+
+        try
+        {
+            if (config.rtde_type == "VECTOR6D")
+            {
+                std::array<double, 6> array_data;
+                if (!pkg.getData(var_name, array_data))
+                {
+                    throw std::runtime_error("Failed to get VECTOR6D data for " + var_name);
+                }
+
+                std::vector<double> vector_data(array_data.begin(), array_data.end());
+                if (config.output_type == "geometry_msgs/TwistStamped")
+                {
+                    auto msg = Converter::vector6dToTwistStamped(vector_data);
+                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::TwistStamped>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "geometry_msgs/WrenchStamped")
+                {
+                    auto msg = Converter::vector6dToWrenchStamped(vector_data);
+                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::WrenchStamped>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "geometry_msgs/PoseStamped")
+                {
+                    auto msg = Converter::vector6dToPoseStamped(vector_data);
+                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::PoseStamped>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "geometry_msgs/InertiaStamped")
+                {
+                    auto msg = Converter::vector6dToInertiaStamped(vector_data);
+                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::InertiaStamped>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "geometry_msgs/AccelStamped")
+                {
+                    auto msg = Converter::vector6dToAccelStamped(vector_data);
+                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::AccelStamped>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "example_interfaces/Float64MultiArray")
+                {
+                    auto msg = Converter::vector6dToFloat64MultiArray(vector_data);
+                    std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Float64MultiArray>>(pub)
+                        ->publish(*msg);
+                }
+            }
+            else if (config.rtde_type == "UINT32")
+            {
+                std::uint32_t uint32_data = 0;
+                if (!pkg.getData(var_name, uint32_data))
+                {
+                    throw std::runtime_error("Failed to get UINT32 data for " + var_name);
+                }
+
+                if (config.output_type == "example_interfaces/ByteMultiArray")
+                {
+                    auto msg = Converter::uint32ToByteMultiArray(uint32_data);
+                    std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::ByteMultiArray>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "example_interfaces/UInt32")
+                {
+                    auto msg = Converter::uint32ToMsg(uint32_data);
+                    std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::UInt32>>(pub)
+                        ->publish(*msg);
+                }
+            }
+            else if (config.rtde_type == "INT32")
+            {
+                std::int32_t int32_data = 0;
+                if (!pkg.getData(var_name, int32_data))
+                {
+                    throw std::runtime_error("Failed to get INT32 data for " + var_name);
+                }
+
+                if (config.output_type == "example_interfaces/Int32")
+                {
+                    auto msg = Converter::int32ToMsg(int32_data);
+                    std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Int32>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "ur_dashboard_msgs/RobotMode")
+                {
+                    auto msg = Converter::int32ToURRobotModeMsg(int32_data);
+                    std::static_pointer_cast<rclcpp::Publisher<ur_dashboard_msgs::msg::RobotMode>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "ur_dashboard_msgs/SafetyMode")
+                {
+                    auto msg = Converter::int32ToURSafetyModeMsg(int32_data);
+                    std::static_pointer_cast<rclcpp::Publisher<ur_dashboard_msgs::msg::SafetyMode>>(pub)
+                        ->publish(*msg);
+                }
+            }
+            else if (config.rtde_type == "UINT64")
+            {
+                std::uint64_t uint64_data = 0;
+                if (!pkg.getData(var_name, uint64_data))
+                {
+                    throw std::runtime_error("Failed to get UINT64 data for " + var_name);
+                }
+                auto msg = Converter::uint64ToByteMultiArray(uint64_data);
+                std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::ByteMultiArray>>(pub)
+                    ->publish(*msg);
+            }
+            else if (config.rtde_type == "BOOL")
+            {
+                bool bool_data = 0;
+                if (!pkg.getData(var_name, bool_data))
+                {
+                    throw std::runtime_error("Failed to get Bool data for " + var_name);
+                }
+                auto msg = Converter::boolToMsg(bool_data);
+                std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Bool>>(pub)
+                    ->publish(*msg);
+            }
+            else if (config.rtde_type == "VECTOR6INT")
+            {
+                std::array<std::int32_t, 6> array_data;
+                if (!pkg.getData(var_name, array_data))
+                {
+                    throw std::runtime_error("Failed to get VECTOR6INT data for " + var_name);
+                }
+                std::vector<int32_t> vector_data(array_data.begin(), array_data.end());
+                auto msg = Converter::vector6intToMsg(vector_data);
+                std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Int32MultiArray>>(pub)
+                    ->publish(*msg);
+            }
+            else if (config.rtde_type == "UINT8")
+            {
+                std::uint8_t uint8_data = 0;
+                if (!pkg.getData(var_name, uint8_data))
+                {
+                    throw std::runtime_error("Failed to get UINT8 data for " + var_name);
+                }
+                auto msg = Converter::uint8Tomsg(uint8_data);
+                std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::UInt8>>(pub)
+                    ->publish(*msg);
+            }
+            else if (config.rtde_type == "DOUBLE")
+            {
+                std::double_t double_data = 0;
+                if (!pkg.getData(var_name, double_data))
+                {
+                    throw std::runtime_error("Failed to get DOUBLE data for " + var_name);
+                }
+
+                if (config.output_type == "example_interfaces/Float64")
+                {
+                    auto msg = Converter::doubleToMsg(double_data);
+                    std::static_pointer_cast<rclcpp::Publisher<example_interfaces::msg::Float64>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "builtin_interfaces/Time")
+                {
+                    auto msg = Converter::doubleToTimeMsg(double_data);
+                    std::static_pointer_cast<rclcpp::Publisher<builtin_interfaces::msg::Time>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "sensor_msgs/Temperature")
+                {
+                    auto msg = Converter::doubleToTemperatureMsg(double_data);
+                    std::static_pointer_cast<rclcpp::Publisher<sensor_msgs::msg::Temperature>>(pub)
+                        ->publish(*msg);
+                }
+            }
+            else if (config.rtde_type == "VECTOR3D")
+            {
+                std::array<double, 3> array_data;
+                if (!pkg.getData(var_name, array_data))
+                {
+                    throw std::runtime_error("Failed to get VECTOR3D data for " + var_name);
+                }
+
+                std::vector<double> vector_data(array_data.begin(), array_data.end());
+
+                if (config.output_type == "geometry_msgs/TwistStamped")
+                {
+                    auto msg = Converter::vector6dToTwistStamped(vector_data);
+                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::TwistStamped>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "geometry_msgs/Vector3Stamped")
+                {
+                    auto msg = Converter::vector3dToVector3Stamped(vector_data);
+                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::Vector3Stamped>>(pub)
+                        ->publish(*msg);
+                }
+                else if (config.output_type == "geometry_msgs/PointStamped")
+                {
+                    auto msg = Converter::vector3dToPointStamped(vector_data);
+                    std::static_pointer_cast<rclcpp::Publisher<geometry_msgs::msg::PointStamped>>(pub)
+                        ->publish(*msg);
+                }
+            }
+        }
+        catch (const std::exception &e)
+        {
+            throw std::runtime_error(std::string("Failed to get/convert ") + var_name + ": " + e.what());
+        }
+    }
+
+    const std::vector<std::string> Publisher::effective_keys() const
+    {
+        std::vector<std::string> keys;
+        for (const auto &[name, config] : active_variables_)
+        {
+            keys.push_back(name);
+        }
+        return keys;
+    }
+
+} // namespace ur_rtde_client

--- a/ur_rtde_client/src/rtde_client_node.cpp
+++ b/ur_rtde_client/src/rtde_client_node.cpp
@@ -1,3 +1,31 @@
+// Copyright 2026, Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #include "ur_rtde_client/rtde_client_node.hpp"
 
 using namespace std::chrono_literals;
@@ -5,74 +33,67 @@ using namespace std::chrono_literals;
 namespace ur_rtde_client
 {
 
-    RtdeClientNode::RtdeClientNode()
-        : rclcpp::Node("rtde_client_node")
-    {
-        // Declare parameters
-        output_recipe_ = declare_parameter<std::vector<std::string>>("output_recipe");
-        robot_ip_ = declare_parameter<std::string>("robot_ip");
+RtdeClientNode::RtdeClientNode() : rclcpp::Node("rtde_client_node")
+{
+  // Declare parameters
+  output_recipe_ = declare_parameter<std::vector<std::string>>("output_recipe");
+  robot_ip_ = declare_parameter<std::string>("robot_ip");
 
-        if (output_recipe_[0] == "none" || robot_ip_ == "none")
-        {
-            std::ostringstream oss;
+  if (output_recipe_[0] == "none" || robot_ip_ == "none") {
+    std::ostringstream oss;
 
-            oss << "\033[1;31m"
-                << "\n"
-                << "ERROR: Missing required parameter(s): robot_ip and/or output_recipe.\n"
-                << "Provide them like this:\n"
-                << "  ros2 launch ur_rtde_client rtde_client.launch.xml \\\n"
-                << "    robot_ip:=\"172.17.0.3\" \\\n"
-                << "    output_recipe:=\"[\"payload\",\"timestamp\",\"safety_status\"]\" \033[0m \n";
+    oss << "\033[1;31m"
+        << "\n"
+        << "ERROR: Missing required parameter(s): robot_ip and/or output_recipe.\n"
+        << "Provide them like this:\n"
+        << "  ros2 launch ur_rtde_client rtde_client.launch.xml \\\n"
+        << "    robot_ip:=\"172.17.0.3\" \\\n"
+        << "    output_recipe:=\"[\"payload\",\"timestamp\",\"safety_status\"]\" \033[0m \n";
 
-            throw std::runtime_error(oss.str());
-        }
+    throw std::runtime_error(oss.str());
+  }
 
-        // Load publisher config
-        std::string package_share_dir = ament_index_cpp::get_package_share_directory("ur_rtde_client");
-        std::string config_path = package_share_dir + "/config/rtde_map.yaml";
+  // Load publisher config
+  std::string package_share_dir = ament_index_cpp::get_package_share_directory("ur_rtde_client");
+  std::string config_path = package_share_dir + "/config/rtde_map.yaml";
 
-        // Initialize publisher
-        publisher_ = std::make_unique<Publisher>(*this, config_path);
+  // Initialize publisher
+  publisher_ = std::make_unique<Publisher>(*this, config_path);
 
-        if (output_recipe_.empty())
-        {
-            RCLCPP_WARN(this->get_logger(), "output_recipe is empty, no publishers will be created");
-            return;
-        }
+  if (output_recipe_.empty()) {
+    RCLCPP_WARN(this->get_logger(), "output_recipe is empty, no publishers will be created");
+    return;
+  }
 
-        // Create publishers based on output_recipe and config
-        publisher_->createPublishersForRecipe(output_recipe_);
-        effective_keys_ = publisher_->effective_keys();
+  // Create publishers based on output_recipe and config
+  publisher_->createPublishersForRecipe(output_recipe_);
+  effective_keys_ = publisher_->effective_keys();
 
-        RCLCPP_INFO(this->get_logger(), "Created %zu publishers from recipe", effective_keys_.size());
+  RCLCPP_INFO(this->get_logger(), "Created %zu publishers from recipe", effective_keys_.size());
 
-        try
-        {
-            // Initialize RTDE communication
-            // The RtdeManager will run data reading in a background thread
-            rtde_manager_ = start_communication(*this, robot_ip_, effective_keys_, *publisher_);
+  try {
+    // Initialize RTDE communication
+    // The RtdeManager will run data reading in a background thread
+    rtde_manager_ = start_communication(*this, robot_ip_, effective_keys_, *publisher_);
 
-            if (!rtde_manager_)
-            {
-                RCLCPP_ERROR(this->get_logger(), "Failed to initialize RTDE communication");
-                return;
-            }
-
-            RCLCPP_INFO(this->get_logger(), "RTDE client node initialized successfully");
-        }
-        catch (const std::exception &e)
-        {
-            RCLCPP_ERROR(this->get_logger(), "Exception during initialization: %s", e.what());
-        }
+    if (!rtde_manager_) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to initialize RTDE communication");
+      return;
     }
 
-} // namespace ur_rtde_client
+    RCLCPP_INFO(this->get_logger(), "RTDE client node initialized successfully");
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR(this->get_logger(), "Exception during initialization: %s", e.what());
+  }
+}
 
-int main(int argc, char *argv[])
+}  // namespace ur_rtde_client
+
+int main(int argc, char* argv[])
 {
-    rclcpp::init(argc, argv);
-    auto node = std::make_shared<ur_rtde_client::RtdeClientNode>();
-    rclcpp::spin(node);
-    rclcpp::shutdown();
-    return 0;
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<ur_rtde_client::RtdeClientNode>();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+  return 0;
 }

--- a/ur_rtde_client/src/rtde_client_node.cpp
+++ b/ur_rtde_client/src/rtde_client_node.cpp
@@ -1,0 +1,78 @@
+#include "ur_rtde_client/rtde_client_node.hpp"
+
+using namespace std::chrono_literals;
+
+namespace ur_rtde_client
+{
+
+    RtdeClientNode::RtdeClientNode()
+        : rclcpp::Node("rtde_client_node")
+    {
+        // Declare parameters
+        output_recipe_ = declare_parameter<std::vector<std::string>>("output_recipe");
+        robot_ip_ = declare_parameter<std::string>("robot_ip");
+
+        if (output_recipe_[0] == "none" || robot_ip_ == "none")
+        {
+            std::ostringstream oss;
+
+            oss << "\033[1;31m"
+                << "\n"
+                << "ERROR: Missing required parameter(s): robot_ip and/or output_recipe.\n"
+                << "Provide them like this:\n"
+                << "  ros2 launch ur_rtde_client rtde_client.launch.xml \\\n"
+                << "    robot_ip:=\"172.17.0.3\" \\\n"
+                << "    output_recipe:=\"[\"payload\",\"timestamp\",\"safety_status\"]\" \033[0m \n";
+
+            throw std::runtime_error(oss.str());
+        }
+
+        // Load publisher config
+        std::string package_share_dir = ament_index_cpp::get_package_share_directory("ur_rtde_client");
+        std::string config_path = package_share_dir + "/config/rtde_map.yaml";
+
+        // Initialize publisher
+        publisher_ = std::make_unique<Publisher>(*this, config_path);
+
+        if (output_recipe_.empty())
+        {
+            RCLCPP_WARN(this->get_logger(), "output_recipe is empty, no publishers will be created");
+            return;
+        }
+
+        // Create publishers based on output_recipe and config
+        publisher_->createPublishersForRecipe(output_recipe_);
+        effective_keys_ = publisher_->effective_keys();
+
+        RCLCPP_INFO(this->get_logger(), "Created %zu publishers from recipe", effective_keys_.size());
+
+        try
+        {
+            // Initialize RTDE communication
+            // The RtdeManager will run data reading in a background thread
+            rtde_manager_ = start_communication(*this, robot_ip_, effective_keys_, *publisher_);
+
+            if (!rtde_manager_)
+            {
+                RCLCPP_ERROR(this->get_logger(), "Failed to initialize RTDE communication");
+                return;
+            }
+
+            RCLCPP_INFO(this->get_logger(), "RTDE client node initialized successfully");
+        }
+        catch (const std::exception &e)
+        {
+            RCLCPP_ERROR(this->get_logger(), "Exception during initialization: %s", e.what());
+        }
+    }
+
+} // namespace ur_rtde_client
+
+int main(int argc, char *argv[])
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<ur_rtde_client::RtdeClientNode>();
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}

--- a/ur_rtde_client/src/rtde_manager.cpp
+++ b/ur_rtde_client/src/rtde_manager.cpp
@@ -1,131 +1,130 @@
+// Copyright 2026, Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
 #include "ur_rtde_client/rtde_manager.hpp"
 
 using namespace std::chrono_literals;
 
 namespace ur_rtde_client
 {
-    RtdeManager::RtdeManager(rclcpp::Node &node,
-                             std::string robot_ip,
-                             std::vector<std::string> keys,
-                             Publisher &publisher)
-        : node_(node), robot_ip_(std::move(robot_ip)), keys_(std::move(keys)), publisher_(publisher)
-    {
+RtdeManager::RtdeManager(rclcpp::Node& node, std::string robot_ip, std::vector<std::string> keys, Publisher& publisher)
+  : node_(node), robot_ip_(std::move(robot_ip)), keys_(std::move(keys)), publisher_(publisher)
+{
+}
+
+RtdeManager::~RtdeManager()
+{
+  stop_reading_ = true;
+  if (read_thread_.joinable()) {
+    read_thread_.join();
+  }
+}
+
+bool RtdeManager::initAndStart()
+{
+  try {
+    rtde_client_ =
+        std::make_unique<urcl::rtde_interface::RTDEClient>(robot_ip_, notifier_, keys_, std::vector<std::string>{});
+
+    try {
+      rtde_client_->init();
+    } catch (const std::exception& e) {
+      RCLCPP_ERROR(node_.get_logger(), "RTDE init() UrException for ip=%s: %s", robot_ip_.c_str(), e.what());
+      rtde_client_.reset();
+      return false;
     }
 
-    RtdeManager::~RtdeManager()
-    {
-        stop_reading_ = true;
-        if (read_thread_.joinable())
-        {
-            read_thread_.join();
-        }
+    rtde_client_->start();
+
+    RCLCPP_INFO(node_.get_logger(), "RTDE client started (ip=%s) with %zu keys.", robot_ip_.c_str(), keys_.size());
+
+    stop_reading_ = false;
+    read_thread_ = std::thread(&RtdeManager::readThreadWorker, this);
+
+    return true;
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR(node_.get_logger(), "Exception during RTDE init/start: %s", e.what());
+    rtde_client_.reset();
+    return false;
+  }
+}
+
+void RtdeManager::readThreadWorker()
+{
+  RCLCPP_INFO(node_.get_logger(), "RTDE read thread started");
+
+  while (!stop_reading_) {
+    try {
+      if (rtde_client_) {
+        spinOnce();
+      }
+    } catch (const std::exception& e) {
+      RCLCPP_ERROR_THROTTLE(node_.get_logger(), *node_.get_clock(), 3000, "Exception in RTDE read thread: %s",
+                            e.what());
     }
+  }
 
-    bool RtdeManager::initAndStart()
-    {
-        try
-        {
-            rtde_client_ = std::make_unique<urcl::rtde_interface::RTDEClient>(
-                robot_ip_, notifier_, keys_, std::vector<std::string>{});
+  RCLCPP_INFO(node_.get_logger(), "RTDE read thread stopped");
+}
 
-            try
-            {
-                rtde_client_->init();
-            }
-            catch (const std::exception &e)
-            {
-                RCLCPP_ERROR(node_.get_logger(), "RTDE init() UrException for ip=%s: %s",
-                             robot_ip_.c_str(), e.what());
-                rtde_client_.reset();
-                return false;
-            }
+void RtdeManager::spinOnce()
+{
+  if (!rtde_client_) {
+    RCLCPP_WARN_THROTTLE(node_.get_logger(), *node_.get_clock(), 5000, "RTDE client not initialized. Skipping cycle.");
+    return;
+  }
 
-            rtde_client_->start();
+  if (!pkg_) {
+    pkg_ = std::make_unique<urcl::rtde_interface::DataPackage>(keys_);
+  }
 
-            RCLCPP_INFO(node_.get_logger(),
-                        "RTDE client started (ip=%s) with %zu keys.",
-                        robot_ip_.c_str(), keys_.size());
+  auto ok = rtde_client_->getDataPackage(*pkg_, 200ms);
+  if (!ok) {
+    RCLCPP_WARN_THROTTLE(node_.get_logger(), *node_.get_clock(), 5000, "No RTDE package received (timeout).");
+    return;
+  }
 
-            stop_reading_ = false;
-            read_thread_ = std::thread(&RtdeManager::readThreadWorker, this);
+  try {
+    publisher_.publish(*pkg_);
+  } catch (const std::exception& e) {
+    RCLCPP_ERROR_THROTTLE(node_.get_logger(), *node_.get_clock(), 3000, "Publisher failed to publish RTDE package: %s",
+                          e.what());
+  }
+}
 
-            return true;
-        }
-        catch (const std::exception &e)
-        {
-            RCLCPP_ERROR(node_.get_logger(), "Exception during RTDE init/start: %s", e.what());
-            rtde_client_.reset();
-            return false;
-        }
-    }
+std::unique_ptr<RtdeManager> start_communication(rclcpp::Node& node, const std::string& robot_ip,
+                                                 const std::vector<std::string>& keys, Publisher& publisher)
+{
+  auto mgr = std::make_unique<RtdeManager>(node, robot_ip, keys, publisher);
+  if (!mgr->initAndStart()) {
+    return nullptr;
+  }
+  return mgr;
+}
 
-    void RtdeManager::readThreadWorker()
-    {
-        RCLCPP_INFO(node_.get_logger(), "RTDE read thread started");
-
-        while (!stop_reading_)
-        {
-            try
-            {
-                if (rtde_client_)
-                {
-                    spinOnce();
-                }
-            }
-            catch (const std::exception &e)
-            {
-                RCLCPP_ERROR_THROTTLE(node_.get_logger(), *node_.get_clock(), 3000,
-                                      "Exception in RTDE read thread: %s", e.what());
-            }
-        }
-
-        RCLCPP_INFO(node_.get_logger(), "RTDE read thread stopped");
-    }
-
-    void RtdeManager::spinOnce()
-    {
-        if (!rtde_client_)
-        {
-            RCLCPP_WARN_THROTTLE(node_.get_logger(), *node_.get_clock(), 5000,
-                                 "RTDE client not initialized. Skipping cycle.");
-            return;
-        }
-
-        if (!pkg_)
-        {
-            pkg_ = std::make_unique<urcl::rtde_interface::DataPackage>(keys_);
-        }
-
-        auto ok = rtde_client_->getDataPackage(*pkg_, 200ms);
-        if (!ok)
-        {
-            RCLCPP_WARN_THROTTLE(node_.get_logger(), *node_.get_clock(), 5000,
-                                 "No RTDE package received (timeout).");
-            return;
-        }
-
-        try
-        {
-            publisher_.publish(*pkg_);
-        }
-        catch (const std::exception &e)
-        {
-            RCLCPP_ERROR_THROTTLE(node_.get_logger(), *node_.get_clock(), 3000,
-                                  "Publisher failed to publish RTDE package: %s", e.what());
-        }
-    }
-
-    std::unique_ptr<RtdeManager> start_communication(rclcpp::Node &node,
-                                                     const std::string &robot_ip,
-                                                     const std::vector<std::string> &keys,
-                                                     Publisher &publisher)
-    {
-        auto mgr = std::make_unique<RtdeManager>(node, robot_ip, keys, publisher);
-        if (!mgr->initAndStart())
-        {
-            return nullptr;
-        }
-        return mgr;
-    }
-
-} // namespace ur_rtde_client
+}  // namespace ur_rtde_client

--- a/ur_rtde_client/src/rtde_manager.cpp
+++ b/ur_rtde_client/src/rtde_manager.cpp
@@ -1,0 +1,131 @@
+#include "ur_rtde_client/rtde_manager.hpp"
+
+using namespace std::chrono_literals;
+
+namespace ur_rtde_client
+{
+    RtdeManager::RtdeManager(rclcpp::Node &node,
+                             std::string robot_ip,
+                             std::vector<std::string> keys,
+                             Publisher &publisher)
+        : node_(node), robot_ip_(std::move(robot_ip)), keys_(std::move(keys)), publisher_(publisher)
+    {
+    }
+
+    RtdeManager::~RtdeManager()
+    {
+        stop_reading_ = true;
+        if (read_thread_.joinable())
+        {
+            read_thread_.join();
+        }
+    }
+
+    bool RtdeManager::initAndStart()
+    {
+        try
+        {
+            rtde_client_ = std::make_unique<urcl::rtde_interface::RTDEClient>(
+                robot_ip_, notifier_, keys_, std::vector<std::string>{});
+
+            try
+            {
+                rtde_client_->init();
+            }
+            catch (const std::exception &e)
+            {
+                RCLCPP_ERROR(node_.get_logger(), "RTDE init() UrException for ip=%s: %s",
+                             robot_ip_.c_str(), e.what());
+                rtde_client_.reset();
+                return false;
+            }
+
+            rtde_client_->start();
+
+            RCLCPP_INFO(node_.get_logger(),
+                        "RTDE client started (ip=%s) with %zu keys.",
+                        robot_ip_.c_str(), keys_.size());
+
+            stop_reading_ = false;
+            read_thread_ = std::thread(&RtdeManager::readThreadWorker, this);
+
+            return true;
+        }
+        catch (const std::exception &e)
+        {
+            RCLCPP_ERROR(node_.get_logger(), "Exception during RTDE init/start: %s", e.what());
+            rtde_client_.reset();
+            return false;
+        }
+    }
+
+    void RtdeManager::readThreadWorker()
+    {
+        RCLCPP_INFO(node_.get_logger(), "RTDE read thread started");
+
+        while (!stop_reading_)
+        {
+            try
+            {
+                if (rtde_client_)
+                {
+                    spinOnce();
+                }
+            }
+            catch (const std::exception &e)
+            {
+                RCLCPP_ERROR_THROTTLE(node_.get_logger(), *node_.get_clock(), 3000,
+                                      "Exception in RTDE read thread: %s", e.what());
+            }
+        }
+
+        RCLCPP_INFO(node_.get_logger(), "RTDE read thread stopped");
+    }
+
+    void RtdeManager::spinOnce()
+    {
+        if (!rtde_client_)
+        {
+            RCLCPP_WARN_THROTTLE(node_.get_logger(), *node_.get_clock(), 5000,
+                                 "RTDE client not initialized. Skipping cycle.");
+            return;
+        }
+
+        if (!pkg_)
+        {
+            pkg_ = std::make_unique<urcl::rtde_interface::DataPackage>(keys_);
+        }
+
+        auto ok = rtde_client_->getDataPackage(*pkg_, 200ms);
+        if (!ok)
+        {
+            RCLCPP_WARN_THROTTLE(node_.get_logger(), *node_.get_clock(), 5000,
+                                 "No RTDE package received (timeout).");
+            return;
+        }
+
+        try
+        {
+            publisher_.publish(*pkg_);
+        }
+        catch (const std::exception &e)
+        {
+            RCLCPP_ERROR_THROTTLE(node_.get_logger(), *node_.get_clock(), 3000,
+                                  "Publisher failed to publish RTDE package: %s", e.what());
+        }
+    }
+
+    std::unique_ptr<RtdeManager> start_communication(rclcpp::Node &node,
+                                                     const std::string &robot_ip,
+                                                     const std::vector<std::string> &keys,
+                                                     Publisher &publisher)
+    {
+        auto mgr = std::make_unique<RtdeManager>(node, robot_ip, keys, publisher);
+        if (!mgr->initAndStart())
+        {
+            return nullptr;
+        }
+        return mgr;
+    }
+
+} // namespace ur_rtde_client


### PR DESCRIPTION
**Summary**

This PR introduces a new ROS 2 package ur_rtde_client that connects to a Universal Robots controller using RTDE and publishes ROS 2 topics for the selected RTDE field names (configured at launch time).

**How to execute it**

The launch file requires two arguments:

- robot_ip: The IP address of the UR controller.
- output_recipe: A YAML list of RTDE field names to publish. The list of available field names is documented in the official [UR RTDE Documentation](https://docs.universal-robots.com/tutorials/communication-protocol-tutorials/rtde-guide.html).

Example:

`ros2 launch ur_rtde_client rtde_client.launch.xml robot_ip:=172.17.0.3 output_recipe:="["payload", "robot_mode"]"`

This will create the following topics:

`/rtde/payload`
`/rtde/robot_mode`

**Package Structure**

- publisher.*
Loads the YAML mapping (rtde_map.yaml), creates the ROS 2 publishers at runtime, and publishes the fields extracted from the RTDE data package.

- rtde_manager.*
Manages the UR RTDE client lifecycle, performs initialization, and spawns a background thread that continuously fetches RTDE data when it is available.

- converter.*
Converts UR RTDE field values to the corresponding ROS 2 message types.

- rtde_client_node.*
ROS 2 node entrypoint. Reads launch parameters, initializes the publisher + manager, and starts communication.

- rtde_map.yaml
Defines how each RTDE variable is mapped to a ROS 2 topic and message type.

