### PR TITLE
Update urscript interface to use primary client

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -223,6 +223,7 @@ install(PROGRAMS
   examples/force_mode.py
   examples/send_dummy_motion_primitives_ur10e.py
   examples/move_until_example.py
+  examples/urscript_sender_example.py
   DESTINATION lib/${PROJECT_NAME}
 )
 

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -138,6 +138,7 @@ add_executable(urscript_interface
 target_link_libraries(urscript_interface PUBLIC
   rclcpp::rclcpp
   ${std_msgs_TARGETS}
+  ${std_srvs_TARGETS}
   ur_client_library::urcl
 )
 

--- a/ur_robot_driver/examples/urscript_sender_example.py
+++ b/ur_robot_driver/examples/urscript_sender_example.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# Copyright 2026, Universal Robots A/S
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the copyright holder nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Publish URScript to the driver's script-command bridge (`urscript_interface`).
+
+The C++ node ``urscript_interface`` subscribes to ``~/script_command``, i.e. by
+default ``/urscript_interface/script_command``. This example is a small Python
+client ("sender") that publishes a secondary program so the main external-control
+program is left running; see ``doc/usage/script_code.rst``.
+
+NOTE: For this example to work, the urscript_interface node must be started with a robot being in
+remote_control mode. If the robot leaves remote_control mode after it has been connected, the
+urscript_interface has to be restarted.
+"""
+
+import rclpy
+from rclpy.node import Node
+from std_msgs.msg import String
+
+
+class UrscriptSenderExample(Node):
+    def __init__(self):
+        super().__init__("urscript_sender_example")
+        self._pub = self.create_publisher(String, "urscript_interface/script_command", 1)
+
+        self.timer = self.create_timer(1.0, self.timer_callback)
+        self.i = 0
+
+    def timer_callback(self):
+        self.set_output(2, (self.i % 2 == 0))
+        self.i = self.i + 1
+
+    def set_output(self, pin: int, value: bool):
+        """
+        Publish a URScript snippet that sets a digital output.
+
+        We use a secondary program (``io_program``) to avoid interfering with the main program
+        currently running on the robot. Note that not all URScript commands are allowed in a
+        secondary program; see the documentation for details.
+        """
+        script_code = "sec io_program():\n" f"  set_digital_out({pin}, {value})\n" "end\n"
+        self.send_once(script_code)
+
+    def send_once(self, script_code: str = None):
+        msg = String(data=script_code)
+        self._pub.publish(msg)
+        self.get_logger().info("Published URScript snippet")
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = UrscriptSenderExample()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/ur_robot_driver/src/urscript_interface.cpp
+++ b/ur_robot_driver/src/urscript_interface.cpp
@@ -41,8 +41,46 @@
 
 #include <memory>
 
+#include <rclcpp/parameter_value.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/string.hpp>
+#include <std_srvs/srv/trigger.hpp>
+
+class ErrorCodeConsumer : public urcl::comm::IConsumer<urcl::primary_interface::PrimaryPackage>
+{
+public:
+  virtual bool consume(std::shared_ptr<urcl::primary_interface::PrimaryPackage> pkg)
+  {
+    auto error_msg = std::dynamic_pointer_cast<urcl::primary_interface::ErrorCodeMessage>(pkg);
+    if (error_msg != nullptr) {
+      if (error_msg->message_code_ == 210)  // Socket is read-only
+      {
+        RCLCPP_WARN(rclcpp::get_logger("urscript_interface"), "Received error code 210. The script code that caused "
+                                                              "this error code to be sent to the client was not "
+                                                              "executed on the robot. This can be the robot not being "
+                                                              "in remote control mode or the client has not been "
+                                                              "reconnected when switching from remote to local control "
+                                                              "mode. Reconnection is required to be able to send "
+                                                              "script code to the robot again.");
+        reconnect_required_ = true;
+      }
+    }
+    return true;
+  }
+
+  bool isReconnectRequired() const
+  {
+    return reconnect_required_;
+  }
+
+  void clearReconnectRequired()
+  {
+    reconnect_required_ = false;
+  }
+
+private:
+  std::atomic<bool> reconnect_required_{ false };
+};
 
 class URScriptInterface : public rclcpp::Node
 {
@@ -50,13 +88,14 @@ public:
   URScriptInterface() : Node("urscript_interface")
   {
     this->declare_parameter("robot_ip", rclcpp::PARAMETER_STRING);
-    m_script_sub = this->create_subscription<std_msgs::msg::String>(
+    this->declare_parameter("reconnect_automatically", true);
+    script_sub_ = this->create_subscription<std_msgs::msg::String>(
         "~/script_command", 1, [this](const std_msgs::msg::String::SharedPtr msg) {
-          if (m_primary_client == nullptr) {
+          if (primary_client_ == nullptr) {
             RCLCPP_ERROR(this->get_logger(), "Primary client not initialized yet");
             return false;
           }
-          if (m_primary_client->sendScript(msg->data)) {
+          if (primary_client_->sendScript(msg->data)) {
             URCL_LOG_INFO("Sent program to robot:\n%s", msg->data.c_str());
             return true;
           }
@@ -64,21 +103,46 @@ public:
           URCL_LOG_ERROR("Could not send program to robot");
           return false;
         });
-    m_primary_client = std::make_unique<urcl::primary_interface::PrimaryClient>(
-        this->get_parameter("robot_ip").as_string(), m_notifier);
-    m_primary_client->start();
+    error_code_consumer_ = std::make_shared<ErrorCodeConsumer>();
+    reconnect();
 
-    auto program_with_newline = std::string("sec "
-                                            "urscript_interface_initialization():\ntextmsg(\"urscript_interface "
-                                            "connected\")\nend");
-    m_primary_client->sendScript(program_with_newline);
+    reconnect_srv_ =
+        create_service<std_srvs::srv::Trigger>("~/reconnect", [this](std_srvs::srv::Trigger::Request::SharedPtr req,
+                                                                     std_srvs::srv::Trigger::Response::SharedPtr resp) {
+          return this->reconnectSrvCallback(req, resp);
+        });
+    reconnect_timer_ = create_wall_timer(std::chrono::seconds(1), [this]() {
+      if (get_parameter("reconnect_automatically").as_bool() && error_code_consumer_->isReconnectRequired()) {
+        RCLCPP_INFO(this->get_logger(), "Reconnect required. Reconnecting primary interface client...");
+        reconnect();
+        error_code_consumer_->clearReconnectRequired();
+      }
+    });
   }
 
 private:
-  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr m_script_sub;
-  std::unique_ptr<urcl::primary_interface::PrimaryClient> m_primary_client;
-  urcl::comm::INotifier m_notifier;
-  // std::unique_ptr<urcl::comm::URStream<urcl::primary_interface::PrimaryPackage>> m_secondary_stream;
+  bool reconnectSrvCallback(std_srvs::srv::Trigger::Request::SharedPtr req,
+                            std_srvs::srv::Trigger::Response::SharedPtr resp)
+  {
+    reconnect();
+    resp->success = true;
+    return true;
+  }
+
+  void reconnect()
+  {
+    primary_client_ = std::make_unique<urcl::primary_interface::PrimaryClient>(
+        this->get_parameter("robot_ip").as_string(), notifier_);
+    primary_client_->addPrimaryConsumer(error_code_consumer_);
+    primary_client_->start();
+  }
+
+  rclcpp::Subscription<std_msgs::msg::String>::SharedPtr script_sub_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr reconnect_srv_;
+  rclcpp::TimerBase::SharedPtr reconnect_timer_;
+  std::unique_ptr<urcl::primary_interface::PrimaryClient> primary_client_;
+  urcl::comm::INotifier notifier_;
+  std::shared_ptr<ErrorCodeConsumer> error_code_consumer_;
 };
 
 int main(int argc, char** argv)

--- a/ur_robot_driver/src/urscript_interface.cpp
+++ b/ur_robot_driver/src/urscript_interface.cpp
@@ -36,6 +36,7 @@
 //----------------------------------------------------------------------
 
 #include <ur_client_library/comm/stream.h>
+#include <ur_client_library/primary/primary_client.h>
 #include <ur_client_library/primary/primary_package.h>
 
 #include <memory>
@@ -46,42 +47,38 @@
 class URScriptInterface : public rclcpp::Node
 {
 public:
-  URScriptInterface()
-    : Node("urscript_interface")
-    , m_script_sub(this->create_subscription<std_msgs::msg::String>(
-          "~/script_command", 1, [this](const std_msgs::msg::String::SharedPtr msg) {
-            auto program_with_newline = msg->data + '\n';
-
-            RCLCPP_INFO_STREAM(this->get_logger(), program_with_newline);
-
-            size_t len = program_with_newline.size();
-            const auto* data = reinterpret_cast<const uint8_t*>(program_with_newline.c_str());
-            size_t written;
-
-            if (m_secondary_stream->write(data, len, written)) {
-              URCL_LOG_INFO("Sent program to robot:\n%s", program_with_newline.c_str());
-              return true;
-            }
-            URCL_LOG_ERROR("Could not send program to robot");
-            return false;
-          }))
+  URScriptInterface() : Node("urscript_interface")
   {
     this->declare_parameter("robot_ip", rclcpp::PARAMETER_STRING);
-    m_secondary_stream = std::make_unique<urcl::comm::URStream<urcl::primary_interface::PrimaryPackage>>(
-        this->get_parameter("robot_ip").as_string(), urcl::primary_interface::UR_SECONDARY_PORT);
-    m_secondary_stream->connect();
+    m_script_sub = this->create_subscription<std_msgs::msg::String>(
+        "~/script_command", 1, [this](const std_msgs::msg::String::SharedPtr msg) {
+          if (m_primary_client == nullptr) {
+            RCLCPP_ERROR(this->get_logger(), "Primary client not initialized yet");
+            return false;
+          }
+          if (m_primary_client->sendScript(msg->data)) {
+            URCL_LOG_INFO("Sent program to robot:\n%s", msg->data.c_str());
+            return true;
+          }
 
-    auto program_with_newline = std::string("sec urscript_interface_initialization:\ntextmsg(\"urscript_interface "
-                                            "connected\")\nend\n");
-    size_t len = program_with_newline.size();
-    const auto* data = reinterpret_cast<const uint8_t*>(program_with_newline.c_str());
-    size_t written;
-    m_secondary_stream->write(data, len, written);
+          URCL_LOG_ERROR("Could not send program to robot");
+          return false;
+        });
+    m_primary_client = std::make_unique<urcl::primary_interface::PrimaryClient>(
+        this->get_parameter("robot_ip").as_string(), m_notifier);
+    m_primary_client->start();
+
+    auto program_with_newline = std::string("sec "
+                                            "urscript_interface_initialization():\ntextmsg(\"urscript_interface "
+                                            "connected\")\nend");
+    m_primary_client->sendScript(program_with_newline);
   }
 
 private:
   rclcpp::Subscription<std_msgs::msg::String>::SharedPtr m_script_sub;
-  std::unique_ptr<urcl::comm::URStream<urcl::primary_interface::PrimaryPackage>> m_secondary_stream;
+  std::unique_ptr<urcl::primary_interface::PrimaryClient> m_primary_client;
+  urcl::comm::INotifier m_notifier;
+  // std::unique_ptr<urcl::comm::URStream<urcl::primary_interface::PrimaryPackage>> m_secondary_stream;
 };
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Use a full PrimaryClient inside the urscript_sender node.

Before, it was using a secondary stream directly, which was a bit
error-prune and not that well tested as the primary client is. Also, with the bare stream we don't have any chance of doing error detection.

I also added detection for local control mode. When attempting to send script code to the primary interface while it is
connected to the read-only socket (e.g. because the robot is in local
control mode), the controller will send a A210 error. If we receive this, reconnect the primary client. This automatic reconnection behavior can be switched off by a parameter. A ROS service to trigger reconnection has been added, as well.