### PR TITLE
Resolute pipelines

### DIFF
--- a/.github/workflows/lyrical-binary-main.yml
+++ b/.github/workflows/lyrical-binary-main.yml
@@ -1,0 +1,29 @@
+name: Lyrical Binary Build Main
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '13 4 * * *'
+
+jobs:
+  lyrical_binary_main:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: lyrical
+      ros_repo: main
+      ref_for_scheduled_build: main
+      rosdep_skip_keys: >-
+        moveit_configs_utils
+        moveit_kinematics
+        moveit_planners
+        moveit_planners_chomp
+        moveit_ros_move_group
+        moveit_ros_visualization
+        moveit_servo
+        moveit_simple_controller_manager

--- a/.github/workflows/lyrical-binary-testing.yml
+++ b/.github/workflows/lyrical-binary-testing.yml
@@ -1,0 +1,30 @@
+name: Lyrical Binary Build Testing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '13 4 * * *'
+
+jobs:
+  lyrical_binary_testing:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: lyrical
+      ros_repo: testing
+      ref_for_scheduled_build: main
+      rosdep_skip_keys: >-
+        moveit_configs_utils
+        moveit_kinematics
+        moveit_planners
+        moveit_planners_chomp
+        moveit_ros_move_group
+        moveit_ros_visualization
+        moveit_servo
+        moveit_simple_controller_manager
+        warehouse_ros_sqlite

--- a/.github/workflows/lyrical-semi-binary-main.yml
+++ b/.github/workflows/lyrical-semi-binary-main.yml
@@ -1,0 +1,30 @@
+name: Lyrical Semi Binary Build Main
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '13 4 * * *'
+
+jobs:
+  lyrical_semi_main:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: lyrical
+      ros_repo: main
+      upstream_workspace: Universal_Robots_ROS2_Driver.lyrical.repos
+      ref_for_scheduled_build: main
+      rosdep_skip_keys: >-
+        moveit_configs_utils
+        moveit_kinematics
+        moveit_planners
+        moveit_planners_chomp
+        moveit_ros_move_group
+        moveit_ros_visualization
+        moveit_servo
+        moveit_simple_controller_manager

--- a/.github/workflows/lyrical-semi-binary-testing.yml
+++ b/.github/workflows/lyrical-semi-binary-testing.yml
@@ -1,0 +1,31 @@
+name: Lyrical Semi Binary Build Testing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '13 4 * * *'
+
+jobs:
+  lyrical_semi_testing:
+    uses: ./.github/workflows/reusable_ici.yml
+    with:
+      ros_distro: lyrical
+      ros_repo: testing
+      upstream_workspace: Universal_Robots_ROS2_Driver.lyrical.repos
+      ref_for_scheduled_build: main
+      rosdep_skip_keys: >-
+        moveit_configs_utils
+        moveit_kinematics
+        moveit_planners
+        moveit_planners_chomp
+        moveit_ros_move_group
+        moveit_ros_visualization
+        moveit_servo
+        moveit_simple_controller_manager
+        warehouse_ros_sqlite

--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -76,3 +76,4 @@ jobs:
           ROS_REPO: ${{ inputs.ros_repo }}
           CMAKE_ARGS: -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release') && ' -DUR_ROBOT_DRIVER_RUN_ROBOT_MODELS_TEST=ON' || '' }}
           ADDITIONAL_DEBS: docker.io netcat-openbsd curl  # Needed for integration tests
+          OS_CODE_NAME: ${{ inputs.ros_distro == 'rolling' && 'resolute' || '' }}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
     <th>Humble</th>
     <th>Jazzy</th>
     <th>Kilted</th>
+    <th>Lyrical</th>
     <th>Rolling</th>
       </tr>
       <tr>
@@ -28,6 +29,7 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/humble">humble</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/jazzy">jazzy</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/kilted">kilted</a></td>
+        <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
       </tr>
       <tr>
@@ -53,12 +55,19 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
       <a href='https://build.ros2.org/job/Kbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/badge/icon?subject=ur_moveit_config'></a>
       <a href='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=ur_robot_driver'></a>
     </td>
+    <td> <!-- lyrical -->
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_robot_driver'></a>
+    </td>
     <td> <!-- rolling -->
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_calibration__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_calibration__ubuntu_noble_amd64__binary/badge/icon?subject=ur_calibration'></a><br/>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_controllers__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_controllers__ubuntu_noble_amd64__binary/badge/icon?subject=ur_controllers'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_dashboard_msgs__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_dashboard_msgs__ubuntu_noble_amd64__binary/badge/icon?subject=ur_dashboard_msgs'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/badge/icon?subject=ur_moveit_config'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=ur_robot_driver'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_robot_driver'></a>
     </td>
   </tr>
 </table>

--- a/Universal_Robots_ROS2_Driver.lyrical.repos
+++ b/Universal_Robots_ROS2_Driver.lyrical.repos
@@ -1,0 +1,53 @@
+repositories:
+  Universal_Robots_Client_Library:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_Client_Library.git
+    version: master
+  Universal_Robots_ROS2_Description:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
+    version: rolling
+  ur_msgs:
+    type: git
+    url: https://github.com/ros-industrial/ur_msgs.git
+    version: humble-devel
+  ros2_control:
+    type: git
+    url: https://github.com/ros-controls/ros2_control.git
+    version: master
+  ros2_controllers:
+    type: git
+    url: https://github.com/ros-controls/ros2_controllers
+    version: master
+  kinematics_interface:
+    type: git
+    url: https://github.com/ros-controls/kinematics_interface.git
+    version: master
+  control_msgs:
+    type: git
+    url: https://github.com/ros-controls/control_msgs.git
+    version: master
+  control_toolbox:
+    type: git
+    url: https://github.com/ros-controls/control_toolbox.git
+    version: master
+  realtime_tools:
+    type: git
+    url: https://github.com/ros-controls/realtime_tools.git
+    version: master
+#  moveit2:
+#    type: git
+#    url: https://github.com/moveit/moveit2.git
+#    version: main
+#  moveit_msgs:
+#    type: git
+#    url: https://github.com/moveit/moveit_msgs.git
+#    version: ros2
+#  srdfdom:
+#    type: git
+#    url: https://github.com/moveit/srdfdom.git
+#    version: ros2
+#  moveit_resources:
+#    type: git
+#    url: https://github.com/moveit/moveit_resources.git
+#    version: ros2

--- a/ci_status.md
+++ b/ci_status.md
@@ -9,11 +9,13 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
     <th>Humble</th>
     <th>Jazzy</th>
     <th>Kilted</th>
+    <th>Lyrical</th>
     <th>Rolling</th>
   </tr>
   <tr>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/humble">humble</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/jazzy">jazzy</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
   </tr>
@@ -60,6 +62,24 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
               alt="Kilted Semi-Binary Main"/>
       </a> <br />
     </td>
+    <td> <!-- lyrical -->
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-main.yml?query=branch%3Amain+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-main.yml/badge.svg?branch=main"
+              alt="Lyrical Binary Main"/>
+      </a> <br />
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-testing.yml?query=branch%3Amain+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-testing.yml/badge.svg?branch=main"
+              alt="Lyrical Binary Testing"/>
+      </a> <br />
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-main.yml?query=branch%3Amain+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-main.yml/badge.svg?branch=main"
+              alt="Lyrical Semi-Binary Main"/>
+      </a> <br />
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-testing.yml?query=branch%3Amain+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-testing.yml/badge.svg?branch=main"
+              alt="Lyrical Semi-Binary Testing"/>
+      </a> <br />
+    </td>
     <td> <!-- rolling -->
       <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-binary-main.yml?query=branch%3Amain+">
          <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-binary-main.yml/badge.svg?branch=main"
@@ -72,6 +92,10 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
       <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-semi-binary-main.yml?query=branch%3Amain+">
          <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-semi-binary-main.yml/badge.svg?branch=main"
               alt="Rolling Semi-Binary Main"/>
+      </a> <br />
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-semi-binary-testing.yml?query=branch%3Amain+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-semi-binary-testing.yml/badge.svg?branch=main"
+              alt="Rolling Semi-Binary Testing"/>
       </a> <br />
     </td>
   </tr>
@@ -97,12 +121,19 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
       <a href='https://build.ros2.org/job/Kbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_moveit_config'></a>
       <a href='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_robot_driver'></a>
     </td>
+    <td> <!-- lyrical -->
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
+    </td>
     <td> <!-- rolling -->
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_calibration__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_calibration__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_calibration'></a><br/>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_controllers__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_controllers__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_controllers'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_dashboard_msgs__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_dashboard_msgs__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_dashboard_msgs'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_moveit_config'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_robot_driver'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
Updates workflows, README and ci_status to contain builds for ROS Lyrical and move Rolling builds to ubuntu resolute.

**Note:** At this point I only expect the Testing binary builds to fail because

- The resolute main repos miss essential packages and will fail very early
- The semi-binary builds fail, since building the complete ros2_control repository fails due to dependencies not being there, yet.