### PR TITLE
Only start urscript_interface node when not running mock_hw

### DIFF
--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -305,6 +305,7 @@ def launch_setup(context, *args, **kwargs):
         package="ur_robot_driver",
         executable="urscript_interface",
         parameters=[{"robot_ip": robot_ip}],
+        condition=UnlessCondition(use_fake_hardware),
         output="screen",
     )
 


### PR DESCRIPTION
In #721 the urscript_interface was added without that conditional guard. It never got recognized, since we usually have a URSim with the default IP running (as wall as in the CI).

This PR adds a conditional guard to only start the urscript_interface when we're not using mock_hw (called fake_hw on Humble).