### PR TITLE
Update README and ci_status pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
     <th>Humble</th>
     <th>Jazzy</th>
     <th>Kilted</th>
+    <th>Lyrical</th>
     <th>Rolling</th>
       </tr>
       <tr>
@@ -28,6 +29,7 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/humble">humble</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/jazzy">jazzy</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/kilted">main</a></td>
+        <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
       </tr>
       <tr>
@@ -53,12 +55,19 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
       <a href='https://build.ros2.org/job/Kbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/badge/icon?subject=ur_moveit_config'></a>
       <a href='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=ur_robot_driver'></a>
     </td>
+    <td> <!-- lyrical -->
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_robot_driver'></a>
+    </td>
     <td> <!-- rolling -->
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_calibration__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_calibration__ubuntu_noble_amd64__binary/badge/icon?subject=ur_calibration'></a><br/>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_controllers__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_controllers__ubuntu_noble_amd64__binary/badge/icon?subject=ur_controllers'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_dashboard_msgs__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_dashboard_msgs__ubuntu_noble_amd64__binary/badge/icon?subject=ur_dashboard_msgs'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/badge/icon?subject=ur_moveit_config'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=ur_robot_driver'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/badge/icon?subject=ur_robot_driver'></a>
     </td>
   </tr>
 </table>

--- a/ci_status.md
+++ b/ci_status.md
@@ -9,11 +9,13 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
     <th>Humble</th>
     <th>Jazzy</th>
     <th>Kilted</th>
+    <th>Lyrical</th>
     <th>Rolling</th>
   </tr>
   <tr>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/humble">humble</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/jazzy">jazzy</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
   </tr>
@@ -60,6 +62,24 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
               alt="Kilted Semi-Binary Main"/>
       </a> <br />
     </td>
+    <td> <!-- lyrical -->
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-main.yml?query=branch%3Amain+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-main.yml/badge.svg?branch=main"
+              alt="Lyrical Binary Main"/>
+      </a> <br />
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-testing.yml?query=branch%3Amain+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-testing.yml/badge.svg?branch=main"
+              alt="Lyrical Binary Testing"/>
+      </a> <br />
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-main.yml?query=branch%3Amain+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-main.yml/badge.svg?branch=main"
+              alt="Lyrical Semi-Binary Main"/>
+      </a> <br />
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-testing.yml?query=branch%3Amain+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-testing.yml/badge.svg?branch=main"
+              alt="Lyrical Semi-Binary Testing"/>
+      </a> <br />
+    </td>
     <td> <!-- rolling -->
       <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-binary-main.yml?query=branch%3Amain+">
          <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-binary-main.yml/badge.svg?branch=main"
@@ -72,6 +92,10 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
       <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-semi-binary-main.yml?query=branch%3Amain+">
          <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-semi-binary-main.yml/badge.svg?branch=main"
               alt="Rolling Semi-Binary Main"/>
+      </a> <br />
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-semi-binary-testing.yml?query=branch%3Amain+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/rolling-semi-binary-testing.yml/badge.svg?branch=main"
+              alt="Rolling Semi-Binary Testing"/>
       </a> <br />
     </td>
   </tr>
@@ -97,12 +121,19 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
       <a href='https://build.ros2.org/job/Kbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_moveit_config'></a>
       <a href='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_robot_driver'></a>
     </td>
+    <td> <!-- lyrical -->
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
+    </td>
     <td> <!-- rolling -->
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_calibration__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_calibration__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_calibration'></a><br/>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_controllers__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_controllers__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_controllers'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_dashboard_msgs__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_dashboard_msgs__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_dashboard_msgs'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_moveit_config__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_moveit_config'></a>
-      <a href='https://build.ros2.org/job/Rbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_robot_driver'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
     </td>
   </tr>
 </table>

--- a/ci_status.md
+++ b/ci_status.md
@@ -122,18 +122,18 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
       <a href='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_robot_driver'></a>
     </td>
     <td> <!-- lyrical -->
-      <a href='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
-      <a href='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
-      <a href='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
-      <a href='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
-      <a href='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
     </td>
     <td> <!-- rolling -->
-      <a href='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
-      <a href='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
-      <a href='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
-      <a href='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
-      <a href='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
     </td>
   </tr>
 </table>

--- a/ur_robot_driver/doc/usage/controllers.rst
+++ b/ur_robot_driver/doc/usage/controllers.rst
@@ -99,21 +99,21 @@ Allows setting I/O ports, controlling some UR-specific functionality and publish
 
 forward_effort_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Type: `effort_controllers/JointGroupEffortController <https://control.ros.org/rolling/doc/ros2_controllers/effort_controllers/doc/userdoc.html#effort-controllers-jointgroupeffortcontroller>`_
+Type: `effort_controllers/JointGroupEffortController <https://control.ros.org/kilted/doc/ros2_controllers/effort_controllers/doc/userdoc.html#effort-controllers-jointgroupeffortcontroller>`_
 
 Allows setting target joint efforts (torques) directly. The user is therefore responsible for sending commands that are achievable. This controller is useful when implementing compliance or force control strategies.
 
 forward_velocity_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Type: `velocity_controllers/JointGroupVelocityController <https://control.ros.org/rolling/doc/ros2_controllers/velocity_controllers/doc/userdoc.html#velocity-controllers-jointgroupvelocitycontroller>`_
+Type: `velocity_controllers/JointGroupVelocityController <https://control.ros.org/kilted/doc/ros2_controllers/velocity_controllers/doc/userdoc.html#velocity-controllers-jointgroupvelocitycontroller>`_
 
 Allows setting target joint velocities directly. The user is therefore responsible for sending commands that are achievable. This controller is particularly useful when doing servoing such as ``moveit_servo``.
 
 forward_position_controller
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Type: `position_controllers/JointGroupPositionController <https://control.ros.org/rolling/doc/ros2_controllers/position_controllers/doc/userdoc.html#position-controllers-jointgrouppositioncontroller>`_
+Type: `position_controllers/JointGroupPositionController <https://control.ros.org/kilted/doc/ros2_controllers/position_controllers/doc/userdoc.html#position-controllers-jointgrouppositioncontroller>`_
 
 Allows setting target joint positions directly. The robot tries to reach the target position as fast as possible. The user is responsible for sending commands that are achievable. This controller is particularly useful when doing servoing such as ``moveit_servo``.
 


### PR DESCRIPTION
- Contain Lyrical builds
- Move Rolling build badges to resolute


This is a manual backport of the relevant parts of #1781 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to status tables and external links; no runtime code or configuration changes.
> 
> **Overview**
> Updates `README.md` and `ci_status.md` to include a new **Lyrical** column with corresponding buildfarm and GitHub Actions badges, and switches **Rolling** buildfarm badge links from `ubuntu_noble` (`uN64`) to `ubuntu_resolute` (`uR64`) (also adding the missing `rolling-semi-binary-testing` badge).
> 
> Adjusts `ur_robot_driver/doc/usage/controllers.rst` external documentation links for the forward controllers to point at the `kilted` ros2_control docs instead of `rolling`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83de6d2d9527b3f8a7bfb3ab9907342b4ab7105a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->