### PR TITLE
[driver] Remove deprecated packages from package.xml

### DIFF
--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -56,7 +56,6 @@
   <depend>motion_primitives_controllers</depend>
   <depend>control_msgs</depend>
 
-  <exec_depend>effort_controllers</exec_depend>
   <exec_depend>force_torque_sensor_broadcaster</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
@@ -64,13 +63,11 @@
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
   <exec_depend>pose_broadcaster</exec_depend>
-  <exec_depend>position_controllers</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>socat</exec_depend>
   <exec_depend>urdf</exec_depend>
-  <exec_depend>velocity_controllers</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <test_depend>launch_testing_ament_cmake</test_depend>

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -57,6 +57,7 @@
   <depend>control_msgs</depend>
 
   <exec_depend>force_torque_sensor_broadcaster</exec_depend>
+  <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>


### PR DESCRIPTION
The controllers yaml file got migrated already, so we can savely remove the dependencies.

ros2_controllers removed the package in https://github.com/ros-controls/ros2_controllers/pull/2016. So, with the next release our package would fail to build on the buildfarm unless this being merged.