### PR TITLE
Add robot series to error output on mismatch

### DIFF
--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -820,9 +820,10 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
     if (robot_type != expected_type.robot_type || expected_type.robot_series != robot_series) {
       RCLCPP_FATAL_STREAM(rclcpp::get_logger("URPositionHardwareInterface"),
                           "The connected robot is of type '"
-                              << robotTypeString(robot_type) << "' and version " << version_info_
-                              << " but the driver was configured for type '" << ur_type
-                              << "'. Please check the 'ur_type' parameter and make sure it matches your "
+                              << robotTypeString(robot_type) << "' and version " << version_info_ << " ("
+                              << robotSeriesString(robot_series) << ") but the driver was configured for type '"
+                              << ur_type << "' (" << robotSeriesString(expected_type.robot_series)
+                              << "). Please check the 'ur_type' parameter and make sure it matches your "
                                  "actual robot. This can lead to critical inaccuracies of tcp positions.");
       return hardware_interface::CallbackReturn::ERROR;
     }


### PR DESCRIPTION
When the connected robot doesn't match the parameter's model / series the error output now also contains the robot series.

E.g. passing "ur5" as an argument, but connecting to a ur5e will now be more explicit:

"The connected robot is of type 'UR5' and version 10.255.0-0 (E_SERIES) but the driver was configured for type 'ur5' (CB3)"

Requires https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/510 and therefore is draft / blocked.