### PR TITLE
Fail example move on error

### DIFF
--- a/ur_robot_driver/scripts/example_move.py
+++ b/ur_robot_driver/scripts/example_move.py
@@ -79,6 +79,7 @@ class JTCClient(rclpy.node.Node):
     def __init__(self):
         super().__init__("jtc_client")
         self.declare_parameter("controller_name", "joint_trajectory_controller")
+        self.declare_parameter("tf_prefix", "")
         self.declare_parameter(
             "joints",
             [
@@ -92,7 +93,10 @@ class JTCClient(rclpy.node.Node):
         )
 
         controller_name = self.get_parameter("controller_name").value + "/follow_joint_trajectory"
-        self.joints = self.get_parameter("joints").value
+        self.tf_prefix = self.get_parameter("tf_prefix").value
+        self.joints = [
+            self.tf_prefix + joint_name for joint_name in self.get_parameter("joints").value
+        ]
 
         if self.joints is None or len(self.joints) == 0:
             raise Exception('"joints" parameter is required')

--- a/ur_robot_driver/scripts/example_move.py
+++ b/ur_robot_driver/scripts/example_move.py
@@ -34,6 +34,7 @@
 # real-life applications, we do recommend to use something like MoveIt!
 
 import time
+import sys
 
 import rclpy
 from rclpy.action import ActionClient
@@ -204,15 +205,19 @@ class JTCClient(rclpy.node.Node):
 def main(args=None):
     rclpy.init(args=args)
 
+    exit_code = 0
+
     jtc_client = JTCClient()
     try:
         rclpy.spin(jtc_client)
     except RuntimeError as err:
         jtc_client.get_logger().error(str(err))
+        exit_code = 1
     except SystemExit:
         rclpy.logging.get_logger("jtc_client").info("Done")
 
     rclpy.shutdown()
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When a motion doesn't result in a success, return with exit code 1.

This makes the script much more usable in tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to an example script, adding parameterized joint name prefixing and returning a non-zero process exit code on trajectory execution errors.
> 
> **Overview**
> Makes `scripts/example_move.py` more test-friendly by **exiting with status 1** when trajectory execution fails (caught `RuntimeError`), and `0` on normal completion.
> 
> Adds a new `tf_prefix` parameter and applies it to all configured joint names, allowing the example to target namespaced/prefixed joint interfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1ff2633038d67991fea5985ac095e6906f83109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->