### PR TITLE
Clarify effort control limitations in URSim

### DIFF
--- a/ur_robot_driver/doc/usage/simulation.rst
+++ b/ur_robot_driver/doc/usage/simulation.rst
@@ -75,12 +75,13 @@ With this, we can spin up a driver using
 
 When we now move the robot in Polyscope, the robot's RViz visualization should move accordingly.
 
-For details on the (PolyScopr 5 and CB3) Docker image, please see the more detailed guide :ref:`here <ursim_docker>`.
+For details on the (PolyScope 5 and CB3) Docker image, please see the more detailed guide :ref:`here <ursim_docker>`.
 
 .. note::
    Although effort control is supported in PolyScope >= 5.23.0 / 10.10.0, it has no physical effect in URSim. 
    The controller manager will accept the effort interfaces, but the simulated robot will remain stationary.
 
+Mock hardware
 -------------
 
 The package can simulate hardware with the ros2_control ``MockSystem``. This emulator enables an

--- a/ur_robot_driver/doc/usage/simulation.rst
+++ b/ur_robot_driver/doc/usage/simulation.rst
@@ -78,7 +78,7 @@ When we now move the robot in Polyscope, the robot's RViz visualization should m
 For details on the (PolyScope 5 and CB3) Docker image, please see the more detailed guide :ref:`here <ursim_docker>`.
 
 .. note::
-   Although effort control is supported in PolyScope >= 5.23.0 / 10.10.0, it has no physical effect in URSim. 
+   Although effort control is supported in PolyScope >= 5.23.0 / 10.10.0, it has no effect in URSim. 
    The controller manager will accept the effort interfaces, but the simulated robot will remain stationary.
 
 Mock hardware

--- a/ur_robot_driver/doc/usage/simulation.rst
+++ b/ur_robot_driver/doc/usage/simulation.rst
@@ -77,7 +77,10 @@ When we now move the robot in Polyscope, the robot's RViz visualization should m
 
 For details on the (PolyScopr 5 and CB3) Docker image, please see the more detailed guide :ref:`here <ursim_docker>`.
 
-Mock hardware
+.. note::
+   Although effort control is supported in PolyScope >= 5.23.0 / 10.10.0, it has no physical effect in URSim. 
+   The controller manager will accept the effort interfaces, but the simulated robot will remain stationary.
+
 -------------
 
 The package can simulate hardware with the ros2_control ``MockSystem``. This emulator enables an


### PR DESCRIPTION
## Description

This PR clarifies the behavior of effort-based control within URSim to prevent user confusion. Currently, when users try to use the `forward_effort_controller` in URSim, the controller manager accepts the interfaces (if `ur_description >= 2.9.0`), but the simulated robot does not move. 

As discussed in one repository's issue, this limitation is expected but was previously undocumented, leading users to believe there was an error in their setup.

## Changes made

* **Added a note in `simulation.rst`**: Explicitly states that while effort control is supported since PolyScope 5.23.0 / 10.10.0, it has no physical effect in URSim.
* **Fixed a minor typo**: Changed "PolyScopr" to "PolyScope" in the URSim usage section.

## Related Issue

Fixes #1642 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Updates **`simulation.rst`** so users know **effort control in URSim does not move the robot**: PolyScope ≥ 5.23.0 / 10.10.0 may expose effort interfaces and the controller manager can accept them, but the simulated arm stays still.
> 
> Also fixes a typo (**PolyScopr** → **PolyScope**) in the URSim usage section.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d46501423a77849a0c2cdb32a2b9a0374591a1e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->