### PR TITLE
Fix whitespace error introduced earlier

### DIFF
--- a/ur_robot_driver/doc/usage/simulation.rst
+++ b/ur_robot_driver/doc/usage/simulation.rst
@@ -78,7 +78,7 @@ When we now move the robot in Polyscope, the robot's RViz visualization should m
 For details on the (PolyScope 5 and CB3) Docker image, please see the more detailed guide :ref:`here <ursim_docker>`.
 
 .. note::
-   Although effort control is supported in PolyScope >= 5.23.0 / 10.10.0, it has no effect in URSim. 
+   Although effort control is supported in PolyScope >= 5.23.0 / 10.10.0, it has no effect in URSim.
    The controller manager will accept the effort interfaces, but the simulated robot will remain stationary.
 
 Mock hardware


### PR DESCRIPTION
I missed that when reviewing #1800. This should fix the format ci job.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only whitespace fix with no runtime or behavioral impact.
> 
> **Overview**
> Removes trailing whitespace on the URSim effort-control note in `simulation.rst` so the documentation format CI check passes again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b625e0dd955e2e31f398507b022ebc07348f072. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->