### PR TITLE
Make GPIO controller publishers realtime safe

### DIFF
--- a/ur_controllers/include/ur_controllers/gpio_controller.hpp
+++ b/ur_controllers/include/ur_controllers/gpio_controller.hpp
@@ -129,6 +129,11 @@ public:
   CallbackReturn on_init() override;
 
 private:
+  // Rejects a service request when the controller is not active.
+  // Returns true if the controller is active and the request may proceed.
+  template <typename ResponseT>
+  bool ensureActive(const ResponseT& resp);
+
   bool setIO(ur_msgs::srv::SetIO::Request::SharedPtr req, ur_msgs::srv::SetIO::Response::SharedPtr resp);
 
   bool setAnalogOutput(ur_msgs::srv::SetAnalogOutput::Request::SharedPtr req,

--- a/ur_controllers/include/ur_controllers/gpio_controller.hpp
+++ b/ur_controllers/include/ur_controllers/gpio_controller.hpp
@@ -124,6 +124,8 @@ public:
 
   CallbackReturn on_deactivate(const rclcpp_lifecycle::State& previous_state) override;
 
+  CallbackReturn on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
+
   CallbackReturn on_init() override;
 
 private:

--- a/ur_controllers/include/ur_controllers/gpio_controller.hpp
+++ b/ur_controllers/include/ur_controllers/gpio_controller.hpp
@@ -57,6 +57,7 @@
 #include "rclcpp/time.hpp"
 #include "rclcpp/duration.hpp"
 #include "std_msgs/msg/bool.hpp"
+#include "realtime_tools/realtime_publisher.hpp"
 #include "ur_controllers/gpio_controller_parameters.hpp"
 
 namespace ur_controllers
@@ -174,11 +175,12 @@ protected:
   rclcpp::Service<ur_msgs::srv::SetPayload>::SharedPtr set_payload_srv_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr tare_sensor_srv_;
 
-  std::shared_ptr<rclcpp::Publisher<ur_msgs::msg::IOStates>> io_pub_;
-  std::shared_ptr<rclcpp::Publisher<ur_msgs::msg::ToolDataMsg>> tool_data_pub_;
-  std::shared_ptr<rclcpp::Publisher<ur_dashboard_msgs::msg::RobotMode>> robot_mode_pub_;
-  std::shared_ptr<rclcpp::Publisher<ur_dashboard_msgs::msg::SafetyMode>> safety_mode_pub_;
-  std::shared_ptr<rclcpp::Publisher<std_msgs::msg::Bool>> program_state_pub_;
+  // Publishing in realtime ros2_control loop, so these are wrapped in non-blocking tries to prevent controller overrun
+  std::shared_ptr<realtime_tools::RealtimePublisher<ur_msgs::msg::IOStates>> io_pub_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<ur_msgs::msg::ToolDataMsg>> tool_data_pub_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<ur_dashboard_msgs::msg::RobotMode>> robot_mode_pub_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<ur_dashboard_msgs::msg::SafetyMode>> safety_mode_pub_;
+  std::shared_ptr<realtime_tools::RealtimePublisher<std_msgs::msg::Bool>> program_state_pub_;
 
   ur_msgs::msg::IOStates io_msg_;
   ur_msgs::msg::ToolDataMsg tool_data_msg_;

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -255,8 +255,11 @@ void GPIOController::publishRobotMode()
   auto robot_mode = static_cast<int8_t>(state_interfaces_[StateInterfaces::ROBOT_MODE].get_optional().value_or(0.0));
 
   if (robot_mode_msg_.mode != robot_mode) {
-    robot_mode_msg_.mode = robot_mode;
-    robot_mode_pub_->try_publish(robot_mode_msg_);
+    auto msg = robot_mode_msg_;
+    msg.mode = robot_mode;
+    if (robot_mode_pub_->try_publish(msg)) {
+      robot_mode_msg_.mode = robot_mode;
+    }
   }
 }
 
@@ -265,8 +268,11 @@ void GPIOController::publishSafetyMode()
   auto safety_mode = static_cast<uint8_t>(state_interfaces_[StateInterfaces::SAFETY_MODE].get_optional().value_or(0.0));
 
   if (safety_mode_msg_.mode != safety_mode) {
-    safety_mode_msg_.mode = safety_mode;
-    safety_mode_pub_->try_publish(safety_mode_msg_);
+    auto msg = safety_mode_msg_;
+    msg.mode = safety_mode;
+    if (safety_mode_pub_->try_publish(msg)) {
+      safety_mode_msg_.mode = safety_mode;
+    }
   }
 }
 
@@ -276,8 +282,11 @@ void GPIOController::publishProgramRunning()
       static_cast<uint8_t>(state_interfaces_[StateInterfaces::PROGRAM_RUNNING].get_optional().value_or(0.0));
   bool program_running = program_running_value == 1.0 ? true : false;
   if (program_running_msg_.data != program_running) {
-    program_running_msg_.data = program_running;
-    program_state_pub_->try_publish(program_running_msg_);
+    auto msg = program_running_msg_;
+    msg.data = program_running;
+    if (program_state_pub_->try_publish(msg)) {
+      program_running_msg_.data = program_running;
+    }
   }
 }
 

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -362,7 +362,12 @@ ur_controllers::GPIOController::on_deactivate(const rclcpp_lifecycle::State& /*p
   // joins a worker thread that may be mid-publish, so teardown is in on_cleanup.
   try {
     set_io_srv_.reset();
+    set_analog_output_srv_.reset();
     set_speed_slider_srv_.reset();
+    resend_robot_program_srv_.reset();
+    hand_back_control_srv_.reset();
+    set_payload_srv_.reset();
+    tare_sensor_srv_.reset();
   } catch (...) {
     return LifecycleNodeInterface::CallbackReturn::ERROR;
   }

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -42,6 +42,25 @@
 
 namespace ur_controllers
 {
+namespace
+{
+// Publishes only when `field` changes, and commits the new value into `msg` only on a successful
+// try_publish. If the publish is dropped (lock contention), `msg` is left unchanged so the change is
+// retried on the next cycle rather than being silently lost.
+template <typename MsgT, typename FieldT, typename ValueT>
+void try_publish_on_change(const std::shared_ptr<realtime_tools::RealtimePublisher<MsgT>>& pub, MsgT& msg,
+                           FieldT MsgT::*field, ValueT new_value)
+{
+  if (msg.*field != new_value) {
+    MsgT candidate = msg;
+    candidate.*field = new_value;
+    if (pub->try_publish(candidate)) {
+      msg.*field = new_value;
+    }
+  }
+}
+}  // namespace
+
 controller_interface::CallbackReturn GPIOController::on_init()
 {
   try {
@@ -253,27 +272,13 @@ void GPIOController::publishToolData()
 void GPIOController::publishRobotMode()
 {
   auto robot_mode = static_cast<int8_t>(state_interfaces_[StateInterfaces::ROBOT_MODE].get_optional().value_or(0.0));
-
-  if (robot_mode_msg_.mode != robot_mode) {
-    auto msg = robot_mode_msg_;
-    msg.mode = robot_mode;
-    if (robot_mode_pub_->try_publish(msg)) {
-      robot_mode_msg_.mode = robot_mode;
-    }
-  }
+  try_publish_on_change(robot_mode_pub_, robot_mode_msg_, &ur_dashboard_msgs::msg::RobotMode::mode, robot_mode);
 }
 
 void GPIOController::publishSafetyMode()
 {
   auto safety_mode = static_cast<uint8_t>(state_interfaces_[StateInterfaces::SAFETY_MODE].get_optional().value_or(0.0));
-
-  if (safety_mode_msg_.mode != safety_mode) {
-    auto msg = safety_mode_msg_;
-    msg.mode = safety_mode;
-    if (safety_mode_pub_->try_publish(msg)) {
-      safety_mode_msg_.mode = safety_mode;
-    }
-  }
+  try_publish_on_change(safety_mode_pub_, safety_mode_msg_, &ur_dashboard_msgs::msg::SafetyMode::mode, safety_mode);
 }
 
 void GPIOController::publishProgramRunning()
@@ -281,13 +286,7 @@ void GPIOController::publishProgramRunning()
   auto program_running_value =
       static_cast<uint8_t>(state_interfaces_[StateInterfaces::PROGRAM_RUNNING].get_optional().value_or(0.0));
   bool program_running = program_running_value == 1.0 ? true : false;
-  if (program_running_msg_.data != program_running) {
-    auto msg = program_running_msg_;
-    msg.data = program_running;
-    if (program_state_pub_->try_publish(msg)) {
-      program_running_msg_.data = program_running;
-    }
-  }
+  try_publish_on_change(program_state_pub_, program_running_msg_, &std_msgs::msg::Bool::data, program_running);
 }
 
 controller_interface::CallbackReturn

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -216,6 +216,29 @@ ur_controllers::GPIOController::on_configure(const rclcpp_lifecycle::State& /*pr
   // get parameters from the listener in case they were updated
   params_ = param_listener_->get_params();
 
+  try {
+    auto qos_latched = rclcpp::SystemDefaultsQoS();
+    qos_latched.transient_local();
+    qos_latched.reliable();
+    // register publishers outside the realtime update loop
+    io_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_msgs::msg::IOStates>>(
+        get_node()->create_publisher<ur_msgs::msg::IOStates>("~/io_states", rclcpp::SystemDefaultsQoS()));
+
+    tool_data_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_msgs::msg::ToolDataMsg>>(
+        get_node()->create_publisher<ur_msgs::msg::ToolDataMsg>("~/tool_data", rclcpp::SystemDefaultsQoS()));
+
+    robot_mode_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_dashboard_msgs::msg::RobotMode>>(
+        get_node()->create_publisher<ur_dashboard_msgs::msg::RobotMode>("~/robot_mode", qos_latched));
+
+    safety_mode_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_dashboard_msgs::msg::SafetyMode>>(
+        get_node()->create_publisher<ur_dashboard_msgs::msg::SafetyMode>("~/safety_mode", qos_latched));
+
+    program_state_pub_ = std::make_shared<realtime_tools::RealtimePublisher<std_msgs::msg::Bool>>(
+        get_node()->create_publisher<std_msgs::msg::Bool>("~/robot_program_running", qos_latched));
+  } catch (...) {
+    return LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
+
   return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
@@ -299,24 +322,6 @@ ur_controllers::GPIOController::on_activate(const rclcpp_lifecycle::State& /*pre
   }
 
   try {
-    auto qos_latched = rclcpp::SystemDefaultsQoS();
-    qos_latched.transient_local();
-    qos_latched.reliable();
-    // register publishers with realtime publishers to prevent blocking on publish
-    io_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_msgs::msg::IOStates>>(
-        get_node()->create_publisher<ur_msgs::msg::IOStates>("~/io_states", rclcpp::SystemDefaultsQoS()));
-
-    tool_data_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_msgs::msg::ToolDataMsg>>(
-        get_node()->create_publisher<ur_msgs::msg::ToolDataMsg>("~/tool_data", rclcpp::SystemDefaultsQoS()));
-
-    robot_mode_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_dashboard_msgs::msg::RobotMode>>(
-        get_node()->create_publisher<ur_dashboard_msgs::msg::RobotMode>("~/robot_mode", qos_latched));
-
-    safety_mode_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_dashboard_msgs::msg::SafetyMode>>(
-        get_node()->create_publisher<ur_dashboard_msgs::msg::SafetyMode>("~/safety_mode", qos_latched));
-
-    program_state_pub_ = std::make_shared<realtime_tools::RealtimePublisher<std_msgs::msg::Bool>>(
-        get_node()->create_publisher<std_msgs::msg::Bool>("~/robot_program_running", qos_latched));
     set_io_srv_ = get_node()->create_service<ur_msgs::srv::SetIO>(
         "~/set_io", std::bind(&GPIOController::setIO, this, std::placeholders::_1, std::placeholders::_2));
     set_analog_output_srv_ = get_node()->create_service<ur_msgs::srv::SetAnalogOutput>(
@@ -350,15 +355,26 @@ ur_controllers::GPIOController::on_activate(const rclcpp_lifecycle::State& /*pre
 controller_interface::CallbackReturn
 ur_controllers::GPIOController::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
 {
+  // Publishers survive deactivation: on_deactivate also runs inside the realtime update loop. Destroying publisher
+  // joins a worker thread that may be mid-publish, so teardown is in on_cleanup.
   try {
-    // reset publisher
+    set_io_srv_.reset();
+    set_speed_slider_srv_.reset();
+  } catch (...) {
+    return LifecycleNodeInterface::CallbackReturn::ERROR;
+  }
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn
+ur_controllers::GPIOController::on_cleanup(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  try {
     io_pub_.reset();
     tool_data_pub_.reset();
     robot_mode_pub_.reset();
     safety_mode_pub_.reset();
     program_state_pub_.reset();
-    set_io_srv_.reset();
-    set_speed_slider_srv_.reset();
   } catch (...) {
     return LifecycleNodeInterface::CallbackReturn::ERROR;
   }

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -38,6 +38,7 @@
 #include "ur_controllers/gpio_controller.hpp"
 
 #include <cmath>
+#include <lifecycle_msgs/msg/state.hpp>
 #include <string>
 
 namespace ur_controllers
@@ -64,6 +65,17 @@ bool try_publish_on_change(realtime_tools::RealtimePublisher<MsgT>& pub, MsgT& m
   return true;
 }
 }  // namespace
+
+template <typename ResponseT>
+bool GPIOController::ensureActive(const ResponseT& resp)
+{
+  if (get_lifecycle_state().id() == lifecycle_msgs::msg::State::PRIMARY_STATE_INACTIVE) {
+    RCLCPP_ERROR(get_node()->get_logger(), "Can't accept new requests. Controller is not running.");
+    resp->success = false;
+    return false;
+  }
+  return true;
+}
 
 controller_interface::CallbackReturn GPIOController::on_init()
 {
@@ -238,6 +250,32 @@ ur_controllers::GPIOController::on_configure(const rclcpp_lifecycle::State& /*pr
 
     program_state_pub_ = std::make_shared<realtime_tools::RealtimePublisher<std_msgs::msg::Bool>>(
         get_node()->create_publisher<std_msgs::msg::Bool>("~/robot_program_running", qos_latched));
+
+    // register services outside the realtime update loop; calls are rejected while the controller is not active
+    set_io_srv_ = get_node()->create_service<ur_msgs::srv::SetIO>(
+        "~/set_io", std::bind(&GPIOController::setIO, this, std::placeholders::_1, std::placeholders::_2));
+    set_analog_output_srv_ = get_node()->create_service<ur_msgs::srv::SetAnalogOutput>(
+        "~/set_analog_output",
+        std::bind(&GPIOController::setAnalogOutput, this, std::placeholders::_1, std::placeholders::_2));
+
+    set_speed_slider_srv_ = get_node()->create_service<ur_msgs::srv::SetSpeedSliderFraction>(
+        "~/set_speed_slider",
+        std::bind(&GPIOController::setSpeedSlider, this, std::placeholders::_1, std::placeholders::_2));
+
+    resend_robot_program_srv_ = get_node()->create_service<std_srvs::srv::Trigger>(
+        "~/resend_robot_program",
+        std::bind(&GPIOController::resendRobotProgram, this, std::placeholders::_1, std::placeholders::_2));
+
+    hand_back_control_srv_ = get_node()->create_service<std_srvs::srv::Trigger>(
+        "~/hand_back_control",
+        std::bind(&GPIOController::handBackControl, this, std::placeholders::_1, std::placeholders::_2));
+
+    set_payload_srv_ = get_node()->create_service<ur_msgs::srv::SetPayload>(
+        "~/set_payload", std::bind(&GPIOController::setPayload, this, std::placeholders::_1, std::placeholders::_2));
+
+    tare_sensor_srv_ = get_node()->create_service<std_srvs::srv::Trigger>(
+        "~/zero_ftsensor",
+        std::bind(&GPIOController::zeroFTSensor, this, std::placeholders::_1, std::placeholders::_2));
   } catch (...) {
     return LifecycleNodeInterface::CallbackReturn::ERROR;
   }
@@ -324,43 +362,27 @@ ur_controllers::GPIOController::on_activate(const rclcpp_lifecycle::State& /*pre
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
   }
 
-  try {
-    set_io_srv_ = get_node()->create_service<ur_msgs::srv::SetIO>(
-        "~/set_io", std::bind(&GPIOController::setIO, this, std::placeholders::_1, std::placeholders::_2));
-    set_analog_output_srv_ = get_node()->create_service<ur_msgs::srv::SetAnalogOutput>(
-        "~/set_analog_output",
-        std::bind(&GPIOController::setAnalogOutput, this, std::placeholders::_1, std::placeholders::_2));
-
-    set_speed_slider_srv_ = get_node()->create_service<ur_msgs::srv::SetSpeedSliderFraction>(
-        "~/set_speed_slider",
-        std::bind(&GPIOController::setSpeedSlider, this, std::placeholders::_1, std::placeholders::_2));
-
-    resend_robot_program_srv_ = get_node()->create_service<std_srvs::srv::Trigger>(
-        "~/resend_robot_program",
-        std::bind(&GPIOController::resendRobotProgram, this, std::placeholders::_1, std::placeholders::_2));
-
-    hand_back_control_srv_ = get_node()->create_service<std_srvs::srv::Trigger>(
-        "~/hand_back_control",
-        std::bind(&GPIOController::handBackControl, this, std::placeholders::_1, std::placeholders::_2));
-
-    set_payload_srv_ = get_node()->create_service<ur_msgs::srv::SetPayload>(
-        "~/set_payload", std::bind(&GPIOController::setPayload, this, std::placeholders::_1, std::placeholders::_2));
-
-    tare_sensor_srv_ = get_node()->create_service<std_srvs::srv::Trigger>(
-        "~/zero_ftsensor",
-        std::bind(&GPIOController::zeroFTSensor, this, std::placeholders::_1, std::placeholders::_2));
-  } catch (...) {
-    return LifecycleNodeInterface::CallbackReturn::ERROR;
-  }
   return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
 controller_interface::CallbackReturn
 ur_controllers::GPIOController::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
 {
-  // Publishers survive deactivation: on_deactivate also runs inside the realtime update loop. Destroying publisher
-  // joins a worker thread that may be mid-publish, so teardown is in on_cleanup.
+  // Nothing to tear down here. Publishers and services are created in on_configure and released in on_cleanup.
+  // on_activate/on_deactivate run inside the realtime update loop, so we keep DDS entity creation/destruction out of
+  // them to avoid stalling the controller_manager update cycle.
+  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn
+ur_controllers::GPIOController::on_cleanup(const rclcpp_lifecycle::State& /*previous_state*/)
+{
   try {
+    io_pub_.reset();
+    tool_data_pub_.reset();
+    robot_mode_pub_.reset();
+    safety_mode_pub_.reset();
+    program_state_pub_.reset();
     set_io_srv_.reset();
     set_analog_output_srv_.reset();
     set_speed_slider_srv_.reset();
@@ -374,23 +396,12 @@ ur_controllers::GPIOController::on_deactivate(const rclcpp_lifecycle::State& /*p
   return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 
-controller_interface::CallbackReturn
-ur_controllers::GPIOController::on_cleanup(const rclcpp_lifecycle::State& /*previous_state*/)
-{
-  try {
-    io_pub_.reset();
-    tool_data_pub_.reset();
-    robot_mode_pub_.reset();
-    safety_mode_pub_.reset();
-    program_state_pub_.reset();
-  } catch (...) {
-    return LifecycleNodeInterface::CallbackReturn::ERROR;
-  }
-  return LifecycleNodeInterface::CallbackReturn::SUCCESS;
-}
-
 bool GPIOController::setIO(ur_msgs::srv::SetIO::Request::SharedPtr req, ur_msgs::srv::SetIO::Response::SharedPtr resp)
 {
+  if (!ensureActive(resp)) {
+    return false;
+  }
+
   if (req->fun == req->FUN_SET_DIGITAL_OUT && req->pin >= 0 && req->pin <= 17) {
     // io async success
     std::ignore = command_interfaces_[CommandInterfaces::IO_ASYNC_SUCCESS].set_value(ASYNC_WAITING);
@@ -450,6 +461,10 @@ bool GPIOController::setIO(ur_msgs::srv::SetIO::Request::SharedPtr req, ur_msgs:
 bool GPIOController::setAnalogOutput(ur_msgs::srv::SetAnalogOutput::Request::SharedPtr req,
                                      ur_msgs::srv::SetAnalogOutput::Response::SharedPtr resp)
 {
+  if (!ensureActive(resp)) {
+    return false;
+  }
+
   std::string domain_string = "UNKNOWN";
   switch (req->data.domain) {
     case ur_msgs::msg::Analog::CURRENT:
@@ -493,6 +508,10 @@ bool GPIOController::setAnalogOutput(ur_msgs::srv::SetAnalogOutput::Request::Sha
 bool GPIOController::setSpeedSlider(ur_msgs::srv::SetSpeedSliderFraction::Request::SharedPtr req,
                                     ur_msgs::srv::SetSpeedSliderFraction::Response::SharedPtr resp)
 {
+  if (!ensureActive(resp)) {
+    return false;
+  }
+
   if (req->speed_slider_fraction >= 0.01 && req->speed_slider_fraction <= 1.0) {
     RCLCPP_INFO(get_node()->get_logger(), "Setting speed slider to %.2f%%.", req->speed_slider_fraction * 100.0);
     // reset success flag
@@ -523,6 +542,10 @@ bool GPIOController::setSpeedSlider(ur_msgs::srv::SetSpeedSliderFraction::Reques
 bool GPIOController::resendRobotProgram(std_srvs::srv::Trigger::Request::SharedPtr /*req*/,
                                         std_srvs::srv::Trigger::Response::SharedPtr resp)
 {
+  if (!ensureActive(resp)) {
+    return false;
+  }
+
   // reset success flag
   std::ignore = command_interfaces_[CommandInterfaces::RESEND_ROBOT_PROGRAM_ASYNC_SUCCESS].set_value(ASYNC_WAITING);
   // call the service in the hardware
@@ -552,6 +575,10 @@ bool GPIOController::resendRobotProgram(std_srvs::srv::Trigger::Request::SharedP
 bool GPIOController::handBackControl(std_srvs::srv::Trigger::Request::SharedPtr /*req*/,
                                      std_srvs::srv::Trigger::Response::SharedPtr resp)
 {
+  if (!ensureActive(resp)) {
+    return false;
+  }
+
   // reset success flag
   std::ignore = command_interfaces_[CommandInterfaces::HAND_BACK_CONTROL_ASYNC_SUCCESS].set_value(ASYNC_WAITING);
   // call the service in the hardware
@@ -580,6 +607,10 @@ bool GPIOController::handBackControl(std_srvs::srv::Trigger::Request::SharedPtr 
 bool GPIOController::setPayload(const ur_msgs::srv::SetPayload::Request::SharedPtr req,
                                 ur_msgs::srv::SetPayload::Response::SharedPtr resp)
 {
+  if (!ensureActive(resp)) {
+    return false;
+  }
+
   // reset success flag
   std::ignore = command_interfaces_[CommandInterfaces::PAYLOAD_ASYNC_SUCCESS].set_value(ASYNC_WAITING);
 
@@ -623,6 +654,10 @@ bool GPIOController::setPayload(const ur_msgs::srv::SetPayload::Request::SharedP
 bool GPIOController::zeroFTSensor(std_srvs::srv::Trigger::Request::SharedPtr /*req*/,
                                   std_srvs::srv::Trigger::Response::SharedPtr resp)
 {
+  if (!ensureActive(resp)) {
+    return false;
+  }
+
   // reset success flag
   std::ignore = command_interfaces_[CommandInterfaces::ZERO_FTSENSOR_ASYNC_SUCCESS].set_value(ASYNC_WAITING);
   // call the service in the hardware

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -226,7 +226,7 @@ void GPIOController::publishIO()
         static_cast<uint8_t>(state_interfaces_[i + StateInterfaces::ANALOG_IO_TYPES + 2].get_optional().value_or(0.0));
   }
 
-  io_pub_->publish(io_msg_);
+  io_pub_->try_publish(io_msg_);
 }
 
 void GPIOController::publishToolData()
@@ -247,7 +247,7 @@ void GPIOController::publishToolData()
       static_cast<float>(state_interfaces_[StateInterfaces::TOOL_OUTPUT_CURRENT].get_optional().value_or(0.0));
   tool_data_msg_.tool_temperature =
       static_cast<float>(state_interfaces_[StateInterfaces::TOOL_TEMPERATURE].get_optional().value_or(0.0));
-  tool_data_pub_->publish(tool_data_msg_);
+  tool_data_pub_->try_publish(tool_data_msg_);
 }
 
 void GPIOController::publishRobotMode()
@@ -256,7 +256,7 @@ void GPIOController::publishRobotMode()
 
   if (robot_mode_msg_.mode != robot_mode) {
     robot_mode_msg_.mode = robot_mode;
-    robot_mode_pub_->publish(robot_mode_msg_);
+    robot_mode_pub_->try_publish(robot_mode_msg_);
   }
 }
 
@@ -266,7 +266,7 @@ void GPIOController::publishSafetyMode()
 
   if (safety_mode_msg_.mode != safety_mode) {
     safety_mode_msg_.mode = safety_mode;
-    safety_mode_pub_->publish(safety_mode_msg_);
+    safety_mode_pub_->try_publish(safety_mode_msg_);
   }
 }
 
@@ -277,7 +277,7 @@ void GPIOController::publishProgramRunning()
   bool program_running = program_running_value == 1.0 ? true : false;
   if (program_running_msg_.data != program_running) {
     program_running_msg_.data = program_running;
-    program_state_pub_->publish(program_running_msg_);
+    program_state_pub_->try_publish(program_running_msg_);
   }
 }
 
@@ -293,17 +293,21 @@ ur_controllers::GPIOController::on_activate(const rclcpp_lifecycle::State& /*pre
     auto qos_latched = rclcpp::SystemDefaultsQoS();
     qos_latched.transient_local();
     qos_latched.reliable();
-    // register publisher
-    io_pub_ = get_node()->create_publisher<ur_msgs::msg::IOStates>("~/io_states", rclcpp::SystemDefaultsQoS());
+    // register publishers with realtime publishers to prevent blocking on publish
+    io_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_msgs::msg::IOStates>>(
+        get_node()->create_publisher<ur_msgs::msg::IOStates>("~/io_states", rclcpp::SystemDefaultsQoS()));
 
-    tool_data_pub_ =
-        get_node()->create_publisher<ur_msgs::msg::ToolDataMsg>("~/tool_data", rclcpp::SystemDefaultsQoS());
+    tool_data_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_msgs::msg::ToolDataMsg>>(
+        get_node()->create_publisher<ur_msgs::msg::ToolDataMsg>("~/tool_data", rclcpp::SystemDefaultsQoS()));
 
-    robot_mode_pub_ = get_node()->create_publisher<ur_dashboard_msgs::msg::RobotMode>("~/robot_mode", qos_latched);
+    robot_mode_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_dashboard_msgs::msg::RobotMode>>(
+        get_node()->create_publisher<ur_dashboard_msgs::msg::RobotMode>("~/robot_mode", qos_latched));
 
-    safety_mode_pub_ = get_node()->create_publisher<ur_dashboard_msgs::msg::SafetyMode>("~/safety_mode", qos_latched);
+    safety_mode_pub_ = std::make_shared<realtime_tools::RealtimePublisher<ur_dashboard_msgs::msg::SafetyMode>>(
+        get_node()->create_publisher<ur_dashboard_msgs::msg::SafetyMode>("~/safety_mode", qos_latched));
 
-    program_state_pub_ = get_node()->create_publisher<std_msgs::msg::Bool>("~/robot_program_running", qos_latched);
+    program_state_pub_ = std::make_shared<realtime_tools::RealtimePublisher<std_msgs::msg::Bool>>(
+        get_node()->create_publisher<std_msgs::msg::Bool>("~/robot_program_running", qos_latched));
     set_io_srv_ = get_node()->create_service<ur_msgs::srv::SetIO>(
         "~/set_io", std::bind(&GPIOController::setIO, this, std::placeholders::_1, std::placeholders::_2));
     set_analog_output_srv_ = get_node()->create_service<ur_msgs::srv::SetAnalogOutput>(

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -368,9 +368,9 @@ ur_controllers::GPIOController::on_activate(const rclcpp_lifecycle::State& /*pre
 controller_interface::CallbackReturn
 ur_controllers::GPIOController::on_deactivate(const rclcpp_lifecycle::State& /*previous_state*/)
 {
-  // Nothing to tear down here. Publishers and services are created in on_configure and released in on_cleanup.
-  // on_activate/on_deactivate run inside the realtime update loop, so we keep DDS entity creation/destruction out of
-  // them to avoid stalling the controller_manager update cycle.
+  // No teardown. Publishers and services are created in on_configure and released in on_cleanup.
+  // on_activate/on_deactivate run inside the realtime update loop, so we keep DDS management separate to avoid
+  // stalling the controller_manager update cycle.
   return LifecycleNodeInterface::CallbackReturn::SUCCESS;
 }
 

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -45,11 +45,12 @@ namespace ur_controllers
 namespace
 {
 // Publishes only when `field` changes, and commits the new value into `msg` only on a successful
-// try_publish. If the publish is dropped (lock contention), `msg` is left unchanged so the change is
-// retried on the next cycle rather than being silently lost.
+// try_publish.
+// If the publish is dropped (e.g. lock contention), `msg` is left unchanged and the change is retried on the next
+// cycle.
 template <typename MsgT, typename FieldT, typename ValueT>
 void try_publish_on_change(const std::shared_ptr<realtime_tools::RealtimePublisher<MsgT>>& pub, MsgT& msg,
-                           FieldT MsgT::*field, ValueT new_value)
+                           FieldT MsgT::* field, ValueT new_value)
 {
   if (msg.*field != new_value) {
     MsgT candidate = msg;

--- a/ur_controllers/src/gpio_controller.cpp
+++ b/ur_controllers/src/gpio_controller.cpp
@@ -48,17 +48,20 @@ namespace
 // try_publish.
 // If the publish is dropped (e.g. lock contention), `msg` is left unchanged and the change is retried on the next
 // cycle.
-template <typename MsgT, typename FieldT, typename ValueT>
-void try_publish_on_change(const std::shared_ptr<realtime_tools::RealtimePublisher<MsgT>>& pub, MsgT& msg,
-                           FieldT MsgT::* field, ValueT new_value)
+template <typename MsgT, typename FieldT>
+bool try_publish_on_change(realtime_tools::RealtimePublisher<MsgT>& pub, MsgT& msg, FieldT MsgT::* field,
+                           const FieldT& new_value)
 {
-  if (msg.*field != new_value) {
-    MsgT candidate = msg;
-    candidate.*field = new_value;
-    if (pub->try_publish(candidate)) {
-      msg.*field = new_value;
-    }
+  if (msg.*field == new_value) {
+    return true;
   }
+  MsgT candidate = msg;
+  candidate.*field = new_value;
+  if (!pub.try_publish(candidate)) {
+    return false;
+  }
+  msg.*field = new_value;
+  return true;
 }
 }  // namespace
 
@@ -296,13 +299,13 @@ void GPIOController::publishToolData()
 void GPIOController::publishRobotMode()
 {
   auto robot_mode = static_cast<int8_t>(state_interfaces_[StateInterfaces::ROBOT_MODE].get_optional().value_or(0.0));
-  try_publish_on_change(robot_mode_pub_, robot_mode_msg_, &ur_dashboard_msgs::msg::RobotMode::mode, robot_mode);
+  try_publish_on_change(*robot_mode_pub_, robot_mode_msg_, &ur_dashboard_msgs::msg::RobotMode::mode, robot_mode);
 }
 
 void GPIOController::publishSafetyMode()
 {
   auto safety_mode = static_cast<uint8_t>(state_interfaces_[StateInterfaces::SAFETY_MODE].get_optional().value_or(0.0));
-  try_publish_on_change(safety_mode_pub_, safety_mode_msg_, &ur_dashboard_msgs::msg::SafetyMode::mode, safety_mode);
+  try_publish_on_change(*safety_mode_pub_, safety_mode_msg_, &ur_dashboard_msgs::msg::SafetyMode::mode, safety_mode);
 }
 
 void GPIOController::publishProgramRunning()
@@ -310,7 +313,7 @@ void GPIOController::publishProgramRunning()
   auto program_running_value =
       static_cast<uint8_t>(state_interfaces_[StateInterfaces::PROGRAM_RUNNING].get_optional().value_or(0.0));
   bool program_running = program_running_value == 1.0 ? true : false;
-  try_publish_on_change(program_state_pub_, program_running_msg_, &std_msgs::msg::Bool::data, program_running);
+  try_publish_on_change(*program_state_pub_, program_running_msg_, &std_msgs::msg::Bool::data, program_running);
 }
 
 controller_interface::CallbackReturn


### PR DESCRIPTION
We are finding great use of these GPIO publishers but they bog down ros2 control as they run inline on the controller manager update loop (i.e. 200 Hz) which we are not finding achievable at all, as the realtime middleware layer forces reliable publish.

This change wraps the publishers in `try_publish` which is used by most stock `ros2_control` broadcasters (`joint_state_broadcaster` etc.).  If contention is occur we allow a `false` return and hand off to a separate publishing thread instead of blocking and stalling the cycle. 

This fix works well for us after testing. We could also just push for the `io_pub_` and `tool_data_pub` to be implemented in this way.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches robot I/O and command services (set_io, payload, hand_back_control) and changes when topics are available vs inactive; publishing may drop or delay under contention instead of blocking.
> 
> **Overview**
> Makes GPIO controller publishing **non-blocking** in the `ros2_control` update loop so high-rate reliable DDS publish no longer stalls the controller manager (e.g. at ~200 Hz).
> 
> All five GPIO-related publishers are wrapped in `realtime_tools::RealtimePublisher` and the update path uses **`try_publish`** instead of synchronous `publish`. Robot mode, safety mode, and program-running topics use a **`try_publish_on_change`** helper so cached message state only advances after a successful publish (retries on the next cycle if the realtime lock is contended).
> 
> **Lifecycle / DDS:** Publisher and service registration moves from **`on_activate`** to **`on_configure`**, with full reset in a new **`on_cleanup`** (including all service handles). **`on_deactivate`** no longer tears down DDS objects, avoiding blocking work on the realtime activate/deactivate path. Service handlers gain **`ensureActive`** to fail requests with `success=false` while the controller is inactive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea893eb1fb1296125289b28f74d9c15a5a722594. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->