### PR TITLE
Update minimum CMake version to 3.28.3

### DIFF
--- a/ur/CMakeLists.txt
+++ b/ur/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.28.3)
 project(ur)
 
 

--- a/ur_calibration/CMakeLists.txt
+++ b/ur_calibration/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.28.3)
 project(ur_calibration)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/ur_controllers/CMakeLists.txt
+++ b/ur_controllers/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.28.3)
 project(ur_controllers)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")

--- a/ur_dashboard_msgs/CMakeLists.txt
+++ b/ur_dashboard_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.28.3)
 project(ur_dashboard_msgs)
 
 find_package(ament_cmake REQUIRED)

--- a/ur_moveit_config/CMakeLists.txt
+++ b/ur_moveit_config/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.28.3)
 project(ur_moveit_config)
 
 find_package(ament_cmake REQUIRED)

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.28.3)
 project(ur_robot_driver)
 
 # Default to off as this only works in environments where a new docker container can be started with the appropriate networking, which


### PR DESCRIPTION
Newer versions drop support for CMake < 3.10 soon, so this generates warnings. 3.28.0 is the lowest version in the lyrical requirements table, thus I'm going for this one.

See https://docs.ros.org/en/lyrical/Releases/lyrical/supported-platforms.html for details on the target platforms:
<img width="933" height="168" alt="image" src="https://github.com/user-attachments/assets/e70efdd9-0518-4d04-a966-dde47ba91695" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-metadata-only change; risk is limited to environments that cannot provide CMake ≥ 3.28.3, which would fail configuration rather than altering runtime behavior.
> 
> **Overview**
> Raises **`cmake_minimum_required`** to **3.28.3** in six packages (`ur`, `ur_calibration`, `ur_controllers`, `ur_dashboard_msgs`, `ur_moveit_config`, `ur_robot_driver`), replacing prior floors of 3.5, 3.8, or 3.22.
> 
> This aligns the stack with the **ROS Lyrical** supported-platform CMake baseline and avoids deprecation warnings from tooling that is dropping support for very old CMake versions. **No** build logic, targets, or dependencies are otherwise changed in these diffs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 168defef4d6bea26c74f5bc48aed85ad9cd715bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->