### PR TITLE
Fix buildfarm badges on ci_status

### DIFF
--- a/ci_status.md
+++ b/ci_status.md
@@ -122,18 +122,18 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
       <a href='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/'><img src='https://build.ros2.org/job/Kbin_uN64__ur_robot_driver__ubuntu_noble_amd64__binary/badge/icon?subject=uN64_ur_robot_driver'></a>
     </td>
     <td> <!-- lyrical -->
-      <a href='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
-      <a href='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
-      <a href='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
-      <a href='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
-      <a href='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Lbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
     </td>
     <td> <!-- rolling -->
-      <a href='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
-      <a href='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
-      <a href='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
-      <a href='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
-      <a href='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_questing_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_calibration__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_calibration'></a><br/>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_controllers__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_controllers'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_dashboard_msgs__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_dashboard_msgs'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_moveit_config__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_moveit_config'></a>
+      <a href='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/'><img src='https://build.ros2.org/job/Rbin_uR64__ur_robot_driver__ubuntu_resolute_amd64__binary/badge/icon?subject=uR64_ur_robot_driver'></a>
     </td>
   </tr>
 </table>


### PR DESCRIPTION
That got updated with the wrong distribution when adding lyrical.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL fixes for CI status badges; no runtime or build logic changes.
> 
> **Overview**
> Corrects **ROS buildfarm badge links** in `ci_status.md` for the **Lyrical** and **Rolling** columns so they point at the right binary jobs.
> 
> All ten badge URLs in those columns are updated from `ubuntu_questing_amd64` to **`ubuntu_resolute_amd64`** (same `Lbin_uR64_*` / `Rbin_uR64_*` job names and packages: calibration, controllers, dashboard_msgs, moveit_config, robot_driver). This aligns the status page with the distribution that was mistakenly used when Lyrical was added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55af119c88872c4d709f8c410b9e46c9aa2ccfca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->