### PR TITLE
Update coverage-build ubuntu to resolute

### DIFF
--- a/.github/workflows/coverage-build.yml
+++ b/.github/workflows/coverage-build.yml
@@ -9,7 +9,7 @@ jobs:
     name: coverage build
     runs-on: ubuntu-22.04
     container:
-      image: ubuntu:noble
+      image: ubuntu:resolute
     strategy:
       fail-fast: false
     env:


### PR DESCRIPTION
We haven't updated that one to resolute, yet, so it runs on noble and is therefore producing errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI container image change with no application or runtime code impact.
> 
> **Overview**
> Aligns the **coverage build** GitHub Actions job with the other workflows by changing the job container image from `ubuntu:noble` to **`ubuntu:resolute`**, matching **ROS Rolling** expectations and fixing CI failures caused by running coverage on Noble.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95f6fdbea7f7e89069161192ae5b5b3fdfab962f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->