### PR TITLE
[tests] Fix shadowed function arg

### DIFF
--- a/ur_robot_driver/test/test_common.py
+++ b/ur_robot_driver/test/test_common.py
@@ -572,8 +572,6 @@ def generate_driver_test_description(
     ursim_program_folder=None,
     urcap_folder=None,
 ):
-    ur_type = LaunchConfiguration("ur_type")
-
     launch_arguments = {
         "robot_ip": "192.168.56.101",
         "ur_type": ur_type,


### PR DESCRIPTION
The function for generating the test description was shadowing its ur_type argument by a launch_configuration query.

This is currently not used anywhere in the tests, as another generator function is used in tests where the robot type matters, but it should get fixed, anyway.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test launch-description helper only; no production driver or launch behavior change beyond fixing the intended parameter wiring.
> 
> **Overview**
> **`generate_driver_test_description`** no longer overwrites its **`ur_type`** parameter with **`LaunchConfiguration("ur_type")`**.
> 
> The helper now passes the function argument through to **`ur_control.launch.py`** and **`_ursim_action`**, so callers that set **`ur_type`** (default **`ur5e`**) get that value instead of always following the launch argument.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9281ccba75bb0818b420207136b4d81589ac8393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->