### PR TITLE
Update model test

### DIFF
--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -63,6 +63,8 @@ jobs:
       - name: Checkout ${{ github.ref_name }} since build is not scheduled
         if: ${{ github.event_name != 'schedule' }}
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Checkout ${{ inputs.ref_for_scheduled_build }} on scheduled build
         if: ${{ github.event_name == 'schedule' }}
         uses: actions/checkout@v7
@@ -86,12 +88,33 @@ jobs:
           restore-keys: |
             ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
             ccache-${{ env.CACHE_PREFIX }}
+      - name: Detect robot models test changes
+        id: robot_models_changes
+        run: |
+          changed=false
+          set -o pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if git diff --name-only "origin/${{ github.event.pull_request.base.ref }}"...HEAD \
+                | grep -Fxq 'ur_robot_driver/test/integration_test_robot_models.py'; then
+              changed=true
+            fi
+          elif [ "${{ github.event_name }}" = "push" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            if git diff --name-only "${{ github.event.before }}" "${{ github.event.after }}" \
+                | grep -Fxq 'ur_robot_driver/test/integration_test_robot_models.py'; then
+              changed=true
+            fi
+          fi
+          echo "changed=${changed}" | tee "$GITHUB_OUTPUT"
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
           ROS_DISTRO: ${{ inputs.ros_distro }}
           ROS_REPO: ${{ inputs.ros_repo }}
-          CMAKE_ARGS: -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON
-          # ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release') && '-DUR_ROBOT_DRIVER_RUN_ROBOT_MODELS_TEST=ON' || '' }}
           ADDITIONAL_DEBS: docker.io netcat-openbsd curl  # Needed for integration tests
           OS_CODE_NAME: ${{ inputs.ros_distro == 'rolling' && 'resolute' || '' }}
+          CMAKE_ARGS: >-
+            -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON
+            ${{ (
+              (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release'))
+              || steps.robot_models_changes.outputs.changed == 'true'
+            ) && '-DUR_ROBOT_DRIVER_RUN_ROBOT_MODELS_TEST=ON' || '' }}

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -833,6 +833,7 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
                               << " but the driver was configured for type '" << ur_type
                               << "'. Please check the 'ur_type' parameter and make sure it matches your "
                                  "actual robot. This can lead to critical inaccuracies of tcp positions.");
+      ur_driver_.reset();
       return hardware_interface::CallbackReturn::ERROR;
     }
   }

--- a/ur_robot_driver/test/integration_test_robot_models.py
+++ b/ur_robot_driver/test/integration_test_robot_models.py
@@ -55,8 +55,6 @@ from rclpy.node import Node
 sys.path.append(os.path.dirname(__file__))
 from test_common import (  # noqa: E402
     ControllerManagerInterface,
-    DashboardInterface,
-    IoStatusInterface,
     generate_driver_test_description_for_model,
 )
 
@@ -108,19 +106,6 @@ class RobotModelStartupTest(unittest.TestCase):
 
     def _check_active_hardware_interface(self, ursim_type, driver_type):
         """Bring the robot up and assert the hardware component is active."""
-        # The IO controller (and therefore ``resend_robot_program``) is only
-        # available when the hardware interface configured successfully, so we
-        # connect to it lazily here.
-        dashboard_interface = DashboardInterface(self.node)
-        io_status_controller_interface = IoStatusInterface(self.node)
-
-        dashboard_interface.start_robot()
-        time.sleep(1)
-        self.assertTrue(
-            io_status_controller_interface.resend_robot_program().success,
-            f"Could not resend robot program for ursim={ursim_type}, driver={driver_type}",
-        )
-
         hardware_info = self._controller_manager_interface.list_hardware_components()
         self.assertIsNotNone(
             hardware_info,


### PR DESCRIPTION
This PR makes the model test less complex and independent of the control.launch file.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly test and CI wiring; the driver reset on configure failure is a small, safer cleanup on an already-failing path.
> 
> **Overview**
> Simplifies the **robot model integration test** so passing cases no longer start the robot via dashboard / `resend_robot_program` or depend on IO controllers from `control.launch`. Success is asserted only through the controller manager: one hardware component, **ACTIVE** state, and available command/state interfaces.
> 
> On a **model mismatch**, `on_configure` now **resets `ur_driver_`** before returning `ERROR`, so a failed verify path does not leave the driver connection open.
> 
> **CI** uses full-history checkout (`fetch-depth: 0`) and a new step that detects edits to `integration_test_robot_models.py`. The expensive robot-models test runs when a PR has the `release` label **or** that test file changed (still building integration tests in all cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75f8abcb4af4b4c1cee390f4de7621cee23ddaf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->