### PR TITLE
Replace linking to moprim controller my using its include directories

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -73,12 +73,17 @@ target_link_libraries(ur_robot_driver_plugin PUBLIC
   rclcpp::rclcpp
   rclcpp_lifecycle::rclcpp_lifecycle
   ur_client_library::urcl
-  motion_primitives_controllers::motion_primitives_controllers
 )
+# NOTE: only headers (enums) are used from motion_primitives_controllers. Linking
+# against its shared library causes it to be eagerly loaded as a DT_NEEDED
+# dependency of this plugin, which breaks class_loader's registration of the
+# MotionPrimitivesForwardController controller (results in
+# "MultiLibraryClassLoader: no factory exists for it" at runtime).
 target_include_directories(
   ur_robot_driver_plugin
   PRIVATE
   include
+  ${motion_primitives_controllers_INCLUDE_DIRS}
 )
 pluginlib_export_plugin_description_file(hardware_interface hardware_interface_plugin.xml)
 


### PR DESCRIPTION
only headers (enums) are used from motion_primitives_controllers. Linking against its shared library causes it to be eagerly loaded as a DT_NEEDED dependency of this plugin, which breaks class_loader's registration of the MotionPrimitivesForwardController controller (results in "MultiLibraryClassLoader: no factory exists for it" at runtime).

This is effectively a workaround for the issue reported in https://github.com/ros-controls/ros2_controllers/issues/2441

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CMake-only link change with no runtime logic edits; it fixes controller plugin registration while keeping header-only compile dependencies.
> 
> **Overview**
> Stops linking `motion_primitives_controllers` into `ur_robot_driver_plugin` and instead adds only `${motion_primitives_controllers_INCLUDE_DIRS}` so the driver can still compile against header enums without pulling the controller library in as a `DT_NEEDED` dependency.
> 
> This avoids eager loading that interferes with `pluginlib`/`class_loader` registration for `MotionPrimitivesForwardController` (the runtime **"MultiLibraryClassLoader: no factory exists for it"** failure). CMake comments document the workaround for [ros2_controllers#2441](https://github.com/ros-controls/ros2_controllers/issues/2441).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb324f098485cf9b2d54ec7aa068228bb507e1fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->