### PR TITLE
Jazzy update model test

### DIFF
--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -58,6 +58,8 @@ jobs:
       - name: Checkout ${{ github.ref_name }} since build is not scheduled
         if: ${{ github.event_name != 'schedule' }}
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - name: Checkout ${{ inputs.ref_for_scheduled_build }} on scheduled build
         if: ${{ github.event_name == 'schedule' }}
         uses: actions/checkout@v7
@@ -81,10 +83,32 @@ jobs:
           restore-keys: |
             ccache-${{ env.CACHE_PREFIX }}-${{ github.sha }}
             ccache-${{ env.CACHE_PREFIX }}
+      - name: Detect robot models test changes
+        id: robot_models_changes
+        run: |
+          changed=false
+          set -o pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            if git diff --name-only "origin/${{ github.event.pull_request.base.ref }}"...HEAD \
+                | grep -Fxq 'ur_robot_driver/test/integration_test_robot_models.py'; then
+              changed=true
+            fi
+          elif [ "${{ github.event_name }}" = "push" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            if git diff --name-only "${{ github.event.before }}" "${{ github.event.after }}" \
+                | grep -Fxq 'ur_robot_driver/test/integration_test_robot_models.py'; then
+              changed=true
+            fi
+          fi
+          echo "changed=${changed}" | tee "$GITHUB_OUTPUT"
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
           ROS_DISTRO: ${{ inputs.ros_distro }}
           ROS_REPO: ${{ inputs.ros_repo }}
-          CMAKE_ARGS: -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release') && ' -DUR_ROBOT_DRIVER_RUN_ROBOT_MODELS_TEST=ON' || '' }}
           ADDITIONAL_DEBS: docker.io netcat-openbsd curl  # Needed for integration tests
+          CMAKE_ARGS: >-
+            -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=ON
+            ${{ (
+              (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'release'))
+              || steps.robot_models_changes.outputs.changed == 'true'
+            ) && '-DUR_ROBOT_DRIVER_RUN_ROBOT_MODELS_TEST=ON' || '' }}

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -744,6 +744,7 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
                               << " but the driver was configured for type '" << ur_type
                               << "'. Please check the 'ur_type' parameter and make sure it matches your "
                                  "actual robot. This can lead to critical inaccuracies of tcp positions.");
+      ur_driver_.reset();
       return hardware_interface::CallbackReturn::ERROR;
     }
   }

--- a/ur_robot_driver/test/integration_test_robot_models.py
+++ b/ur_robot_driver/test/integration_test_robot_models.py
@@ -49,14 +49,12 @@ import unittest
 import launch_testing
 import pytest
 import rclpy
-from lifecycle_msgs.msg import State
+from lifecycle_msgs.msg import State as LifecycleState
 from rclpy.node import Node
 
 sys.path.append(os.path.dirname(__file__))
 from test_common import (  # noqa: E402
     ControllerManagerInterface,
-    DashboardInterface,
-    IoStatusInterface,
     generate_driver_test_description_for_model,
 )
 
@@ -88,7 +86,9 @@ ROBOT_MODEL_CASES = [
 @pytest.mark.launch_test
 @launch_testing.parametrize("ursim_type, driver_type", ROBOT_MODEL_CASES)
 def generate_test_description(ursim_type, driver_type):
-    return generate_driver_test_description_for_model(ur_type=driver_type, ursim_type=ursim_type)
+    return generate_driver_test_description_for_model(
+        ur_type=driver_type, ursim_type=ursim_type, hw_name=driver_type
+    )
 
 
 class RobotModelStartupTest(unittest.TestCase):
@@ -97,8 +97,6 @@ class RobotModelStartupTest(unittest.TestCase):
         rclpy.init()
         cls.node = Node("robot_model_startup_test")
         time.sleep(1)
-        # The controller_manager service is always available, regardless of whether
-        # the hardware interface actually reaches the active state.
         cls._controller_manager_interface = ControllerManagerInterface(cls.node)
 
     @classmethod
@@ -106,21 +104,7 @@ class RobotModelStartupTest(unittest.TestCase):
         cls.node.destroy_node()
         rclpy.shutdown()
 
-    def _check_active_hardware_interface(self, ursim_type, driver_type):
-        """Bring the robot up and assert the hardware component is active."""
-        # The IO controller (and therefore ``resend_robot_program``) is only
-        # available when the hardware interface configured successfully, so we
-        # connect to it lazily here.
-        dashboard_interface = DashboardInterface(self.node)
-        io_status_controller_interface = IoStatusInterface(self.node)
-
-        dashboard_interface.start_robot()
-        time.sleep(1)
-        self.assertTrue(
-            io_status_controller_interface.resend_robot_program().success,
-            f"Could not resend robot program for ursim={ursim_type}, driver={driver_type}",
-        )
-
+    def _get_hardware_component_state(self, ursim_type, driver_type):
         hardware_info = self._controller_manager_interface.list_hardware_components()
         self.assertIsNotNone(
             hardware_info,
@@ -132,66 +116,9 @@ class RobotModelStartupTest(unittest.TestCase):
             f"Expected exactly one hardware component for ursim={ursim_type}, "
             f"driver={driver_type}, got {len(hardware_info.component)}",
         )
-
         component = hardware_info.component[0]
-        self.assertEqual(
-            component.state.id,
-            State.PRIMARY_STATE_ACTIVE,
-            f"Hardware component '{component.name}' for ursim={ursim_type}, "
-            f"driver={driver_type} is not active (state id={component.state.id})",
-        )
-
-        for interface in component.command_interfaces:
-            self.assertTrue(
-                interface.is_available,
-                f"Command interface {interface.name} not available for "
-                f"ursim={ursim_type}, driver={driver_type}",
-            )
-        for interface in component.state_interfaces:
-            self.assertTrue(
-                interface.is_available,
-                f"State interface {interface.name} not available for "
-                f"ursim={ursim_type}, driver={driver_type}",
-            )
-
-    def _check_unconfigured_hardware_interface(self, ursim_type, driver_type):
-        """
-        Assert the hardware component never rises above ``unconfigured``.
-
-        With ``verify_robot_model`` enabled (the default), the hardware interface's
-        ``on_configure`` returns ERROR when the driver's ``ur_type`` does not match
-        the robot reported by URSim, leaving the component in
-        ``PRIMARY_STATE_UNCONFIGURED``. Poll for a generous amount of time to make
-        sure we don't accidentally race the state transition.
-        """
-        timeout = 60.0
-        end_time = time.time() + timeout
-        last_state = None
-        while time.time() < end_time:
-            hardware_info = self._controller_manager_interface.list_hardware_components()
-            if hardware_info is not None and len(hardware_info.component) == 1:
-                last_state = hardware_info.component[0].state.id
-                self.assertNotEqual(
-                    last_state,
-                    State.PRIMARY_STATE_ACTIVE,
-                    f"Hardware interface unexpectedly reached ACTIVE for ursim={ursim_type}, "
-                    f"driver={driver_type} (model mismatch should have prevented this)",
-                )
-                self.assertNotEqual(
-                    last_state,
-                    State.PRIMARY_STATE_INACTIVE,
-                    f"Hardware interface unexpectedly reached INACTIVE for ursim={ursim_type}, "
-                    f"driver={driver_type} (model mismatch should have kept it unconfigured)",
-                )
-            time.sleep(2.0)
-
-        self.assertEqual(
-            last_state,
-            State.PRIMARY_STATE_UNCONFIGURED,
-            f"Hardware interface for ursim={ursim_type}, driver={driver_type} ended in "
-            f"state id={last_state}, expected PRIMARY_STATE_UNCONFIGURED "
-            f"({State.PRIMARY_STATE_UNCONFIGURED}) due to model mismatch",
-        )
+        self.assertEqual(component.name, driver_type)
+        return component.state
 
     def test_driver_starts_for_robot_model(self, ursim_type, driver_type):
         """
@@ -210,7 +137,26 @@ class RobotModelStartupTest(unittest.TestCase):
             driver_type,
             ursim_type != driver_type,
         )
+
+        self.assertEqual(
+            self._get_hardware_component_state(ursim_type, driver_type).id,
+            LifecycleState.PRIMARY_STATE_UNCONFIGURED,
+        )
+
+        target_state = LifecycleState(id=LifecycleState.PRIMARY_STATE_INACTIVE, label="inactive")
+        result = self._controller_manager_interface.set_hardware_component_state(
+            name=driver_type, target_state=target_state
+        )
         if ursim_type == driver_type:
-            self._check_active_hardware_interface(ursim_type, driver_type)
+            self.assertTrue(
+                result.ok,
+                f"Hardware component '{driver_type}' for ursim={ursim_type}, "
+                f"driver={driver_type} did not reach state '{target_state.label}' but is in state '{result.state.label}'",
+            )
+            self.assertEqual(result.state, target_state)
         else:
-            self._check_unconfigured_hardware_interface(ursim_type, driver_type)
+            self.assertFalse(
+                result.ok,
+                f"Hardware interface unexpectedly reached {target_state.label} for ursim={ursim_type}, "
+                f"driver={driver_type} (model mismatch should have prevented this)",
+            )

--- a/ur_robot_driver/test/test_common.py
+++ b/ur_robot_driver/test/test_common.py
@@ -47,6 +47,7 @@ from launch.actions import (
 from launch.event_handlers import OnProcessExit
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackagePrefix, FindPackageShare
 from launch_testing.actions import ReadyToTest
 from rclpy.action import ActionClient
@@ -623,9 +624,7 @@ def generate_driver_test_description(
 
 def generate_driver_test_description_for_model(
     ur_type,
-    tf_prefix="",
-    initial_joint_controller="joint_trajectory_controller",
-    controller_spawner_timeout=TIMEOUT_WAIT_SERVICE_INITIAL,
+    hw_name="ur",
     ursim_version="latest",
     ursim_type=None,
 ):
@@ -645,28 +644,29 @@ def generate_driver_test_description_for_model(
     if ursim_type is None:
         ursim_type = ur_type
 
-    launch_arguments = {
-        "robot_ip": "192.168.56.101",
-        "ur_type": ur_type,
-        "launch_rviz": "false",
-        "controller_spawner_timeout": str(controller_spawner_timeout),
-        "initial_joint_controller": initial_joint_controller,
-        "headless_mode": "true",
-        "launch_dashboard_client": "true",
-        "start_joint_controller": "false",
-        "verify_robot_model": "true",
-    }
-    if tf_prefix:
-        launch_arguments["tf_prefix"] = tf_prefix
-
-    robot_driver = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            PathJoinSubstitution(
-                [FindPackageShare("ur_robot_driver"), "launch", "ur_control.launch.py"]
-            )
-        ),
-        launch_arguments=launch_arguments.items(),
+    description_launchfile = (
+        PathJoinSubstitution([FindPackageShare("ur_robot_driver"), "launch", "ur_rsp.launch.py"]),
     )
+
+    rsp = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(description_launchfile),
+        launch_arguments={
+            "robot_ip": "192.168.56.101",
+            "ur_type": ur_type,
+            "verify_robot_model": "true",
+        }.items(),
+    )
+
+    control_node = Node(
+        package="controller_manager",
+        executable="ros2_control_node",
+        parameters=[
+            {"update_rate": 125},  # that fits all models
+            {"hardware_components_initial_state": {"unconfigured": [ur_type]}},
+        ],
+        output="screen",
+    )
+
     wait_dashboard_server = ExecuteProcess(
         cmd=[
             PathJoinSubstitution(
@@ -677,7 +677,7 @@ def generate_driver_test_description_for_model(
         output="screen",
     )
     driver_starter = RegisterEventHandler(
-        OnProcessExit(target_action=wait_dashboard_server, on_exit=robot_driver)
+        OnProcessExit(target_action=wait_dashboard_server, on_exit=control_node)
     )
 
     # Use a per-model container name so leftover containers from a previous
@@ -685,10 +685,10 @@ def generate_driver_test_description_for_model(
     container_name = f"ursim_{ursim_type}"
 
     return LaunchDescription(
-        _declare_launch_arguments()
-        + [
+        [
             ReadyToTest(),
             wait_dashboard_server,
+            rsp,
             _ursim_action(
                 ursim_version=ursim_version, ur_type=ursim_type, container_name=container_name
             ),


### PR DESCRIPTION
Jazzy version of #1790 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The hardware interface change alters configure failure cleanup on model mismatch; the rest is CI and integration-test behavior with limited production runtime impact.
> 
> **Overview**
> Updates the **robot model integration test** and CI so it matches Jazzy-style **ros2_control** lifecycle checks instead of assuming the hardware is already active after launch.
> 
> **CI** uses full git history (`fetch-depth: 0`) and a new step that detects edits to `integration_test_robot_models.py`; the expensive `UR_ROBOT_DRIVER_RUN_ROBOT_MODELS_TEST` CMake flag is enabled for PRs with the `release` label **or** when that test file changes (not only on release-labeled PRs).
> 
> **Test harness** (`generate_driver_test_description_for_model`) no longer brings up full `ur_control.launch.py`; it loads `ur_rsp.launch.py` plus a bare `ros2_control_node` with the hardware component left **unconfigured**, so configure/activate is driven explicitly from the test.
> 
> **Integration test** drops dashboard/IO “start robot and resend program” checks and instead asserts the component starts unconfigured, then calls `set_hardware_component_state` to **inactive**: success for matching URSim/driver types, failure for mismatches (e.g. ur5e vs ur20).
> 
> **Driver fix:** on `verify_robot_model` failure in `on_configure`, **`ur_driver_` is reset** before returning ERROR so a rejected configure does not leave a live robot connection behind.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5a4f580827a3f539d682c6a3e538974e516da08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->