### PR TITLE
Remove controller switch to passthrough controller

### DIFF
--- a/ur_robot_driver/test/integration_test_hand_back_control.py
+++ b/ur_robot_driver/test/integration_test_hand_back_control.py
@@ -38,7 +38,6 @@ import unittest
 import pytest
 import rclpy
 from control_msgs.action import FollowJointTrajectory
-from controller_manager_msgs.srv import SwitchController
 from rclpy.node import Node
 from std_msgs.msg import Bool
 
@@ -165,13 +164,6 @@ class HandBackControlTest(unittest.TestCase):
         self._dashboard_interface.play()
         self._controller_manager_interface.wait_for_controller(
             "joint_trajectory_controller", "active"
-        )
-        self.assertTrue(
-            self._controller_manager_interface.switch_controller(
-                strictness=SwitchController.Request.BEST_EFFORT,
-                deactivate_controllers=["passthrough_trajectory_controller"],
-                activate_controllers=["joint_trajectory_controller"],
-            ).ok
         )
 
         self.assertTrue(


### PR DESCRIPTION
The way it was implemented right now, the test was flakey, since it didn't wait for the passthrough controller to be loaded. This way, it could happen that the switch command was called while the CM didn't even know the passthrough controller resulting in the service call failing.

Switching the controller shouldn't be necessary for the test, anyway, so it is removed in this commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production driver or controller behavior modified.
> 
> **Overview**
> Removes the **pre-test controller switch** in `integration_test_hand_back_control.py` that deactivated `passthrough_trajectory_controller` and activated `joint_trajectory_controller` via `SwitchController` **BEST_EFFORT**.
> 
> The test still **plays** the UR program and **waits** for `joint_trajectory_controller` to be **active** before asserting program state and calling `hand_back_control`; it no longer depends on the passthrough controller being loaded in time for a switch service call.
> 
> Also drops the unused `SwitchController` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fbd14256a99734240dbe6975c23e6be3b64a374. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->