### PR TITLE
Add explicit control_msgs dependency for humble

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(ament_cmake REQUIRED)
 find_package(backward_ros REQUIRED)
 find_package(controller_manager REQUIRED)
 find_package(controller_manager_msgs REQUIRED)
+find_package(control_msgs REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
@@ -43,6 +44,7 @@ include_directories(include)
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   controller_manager
   controller_manager_msgs
+  control_msgs
   geometry_msgs
   hardware_interface
   pluginlib
@@ -137,6 +139,7 @@ target_link_libraries(trajectory_until_node PUBLIC
   ${std_msgs_TARGETS}
   rclcpp_action::rclcpp_action
   ${ur_msgs_TARGETS}
+  ${control_msgs_TARGETS}
 )
 
 install(

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -31,6 +31,7 @@
   <depend>backward_ros</depend>
   <depend>controller_manager</depend>
   <depend>controller_manager_msgs</depend>
+  <depend>control_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>


### PR DESCRIPTION
This PR adds `control_msgs` as an explicit dependency of `ur_robot_driver` for `humble` branch.

`trajectory_until_node` directly uses `control_msgs::action::FollowJointTrajectory`:

- `include/ur_robot_driver/trajectory_until_node.hpp` includes `control_msgs/action/follow_joint_trajectory.hpp`
- the node stores an action client for `control_msgs::action::FollowJointTrajectory`
- `src/trajectory_until_node.cpp` creates a `FollowJointTrajectory` action client

Currently `control_msgs` may be available transitively through other dependencies, but the direct source usage is not reflected in `package.xml` or in the CMake setup for `trajectory_until_node`.

Changes:

- Add `<depend>control_msgs</depend>` to `ur_robot_driver/package.xml`.
- Add `find_package(control_msgs REQUIRED)` to `ur_robot_driver/CMakeLists.txt`.
- Add `control_msgs` to `THIS_PACKAGE_INCLUDE_DEPENDS`.
- Link `${control_msgs_TARGETS}` to the `trajectory_until_node` target.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and dependency metadata only; no runtime or control logic changes.
> 
> **Overview**
> Declares **`control_msgs`** as a direct build dependency of `ur_robot_driver` so it matches how **`trajectory_until_node`** already uses `control_msgs::action::FollowJointTrajectory` (previously it may have been pulled in only transitively).
> 
> **`package.xml`** gains `<depend>control_msgs</depend>`. **`CMakeLists.txt`** adds `find_package(control_msgs REQUIRED)`, includes `control_msgs` in `THIS_PACKAGE_INCLUDE_DEPENDS`, and links `${control_msgs_TARGETS}` on the `trajectory_until_node` executable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e10f924398dfa4a382b1a0b16518dc38b53db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->