### PR TITLE
Update README and ci_status for lyrical branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/humble">humble</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/jazzy">jazzy</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/kilted">kilted</a></td>
-        <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
+        <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/lyrical">main</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
       </tr>
       <tr>

--- a/ci_status.md
+++ b/ci_status.md
@@ -15,8 +15,8 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
   <tr>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/humble">humble</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/jazzy">jazzy</a></td>
-    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
-    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">kilted</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">lyrical</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
   </tr>
   <tr>
@@ -63,20 +63,20 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
       </a> <br />
     </td>
     <td> <!-- lyrical -->
-      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-main.yml?query=branch%3Amain+">
-         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-main.yml/badge.svg?branch=main"
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-main.yml?query=event%3Aschedule+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-main.yml/badge.svg?event=schedule"
               alt="Lyrical Binary Main"/>
       </a> <br />
-      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-testing.yml?query=branch%3Amain+">
-         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-testing.yml/badge.svg?branch=main"
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-testing.yml?query=event%3Aschedule+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-binary-testing.yml/badge.svg?event=schedule"
               alt="Lyrical Binary Testing"/>
       </a> <br />
-      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-main.yml?query=branch%3Amain+">
-         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-main.yml/badge.svg?branch=main"
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-main.yml?query=event%3Aschedule+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-main.yml/badge.svg?event=schedule"
               alt="Lyrical Semi-Binary Main"/>
       </a> <br />
-      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-testing.yml?query=branch%3Amain+">
-         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-testing.yml/badge.svg?branch=main"
+      <a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-testing.yml?query=event%3Aschedule+">
+         <img src="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/actions/workflows/lyrical-semi-binary-testing.yml/badge.svg?event=schedule"
               alt="Lyrical Semi-Binary Testing"/>
       </a> <br />
     </td>


### PR DESCRIPTION
With the lyrical branch now being present, let's update the README and ci_status.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes to README and ci_status; no runtime or driver behavior is affected.
> 
> **Overview**
> Updates **release-status documentation** so the Lyrical ROS 2 distro is reflected consistently in branch links and CI badge URLs.
> 
> In `README.md`, the **Lyrical** column branch link now targets `tree/lyrical` instead of `tree/main` (link text remains `main`).
> 
> In `ci_status.md`, the **Kilted** and **Lyrical** branch row labels are renamed from `main` to `kilted` and `lyrical`. All four **Lyrical** GitHub Actions badge embeds switch from `branch=main` filters to **`event=schedule`**, matching how Humble/Jazzy/Kilted nightly badges are wired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 023fd57be260d8b44e7c4f74ae35ef1fbd030984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->