### PR TITLE
Fix whitespace errors

### DIFF
--- a/ur_robot_driver/doc/usage/script_code.rst
+++ b/ur_robot_driver/doc/usage/script_code.rst
@@ -73,7 +73,7 @@ The action server at ``/urscript_interface/execute_script`` allows executing scr
 The ``SendScript`` action definition can be seen in the `ur_msgs action definitions <https://docs.ros.org/en/rolling/p/ur_msgs/__action_definitions.html/>`_
 
 This action server is a ROS wrapper around the `URCL primary client's <https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/master/doc/architecture/primary_client.rst/>`_
-SendScriptBlocking method, and the meaning of parameters can be seen there. 
+SendScriptBlocking method, and the meaning of parameters can be seen there.
 The action will be reported as successful if no errors occur during script execution. See :ref:`script-cancel` for additional info about when the action might be reported as successful.
 If an error is detected, a message explaining what went wrong will be made available in the action result.
 While the action server is waiting for a script to finish execution, it will reject any further action goals, and the ``/urscript_interface/script_command`` topic will also be ignored during this time.
@@ -98,7 +98,7 @@ The action server can be called from the command line like this:
     script_name: "cmd_line_example",
     start_timeout: {sec: 1.0, nanosec: 0},
     fail_on_warnings: true}'
-    
+
 Parameters
 ^^^^^^^^^^
 - ``robot_ip`` (string, **required**)
@@ -110,6 +110,6 @@ Parameters
   When the client is currently connected to a read-only interface (because the robot is not in
   remote_control mode / was put to local control mode since the client connected) script code will
   not be accepted by the primary interface.
-  
-  When set to ``true`` the client will attempt to reconnect to the primary interface and send the 
+
+  When set to ``true`` the client will attempt to reconnect to the primary interface and send the
   script again once. This mechanism is only active when using the action interface.


### PR DESCRIPTION
Fix errors introduced in #1833 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation formatting only; no runtime or API impact.
> 
> **Overview**
> **Whitespace-only cleanup** in `ur_robot_driver/doc/usage/script_code.rst`, following issues from #1833.
> 
> Removes trailing spaces on the URCL `SendScriptBlocking` paragraph, after the `execute_script` CLI example, and in the `retry_on_readonly_interface` parameter description (including a blank line before the continuation sentence). **No wording or behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 595c35d18e71ca6b54c6895f2828cdc3eebf3f73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->