### PR TITLE
Main branch updates for lyrical branch

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -31,3 +31,14 @@ pull_request_rules:
           - kilted
         labels:
           - kilted
+
+  - name: Backport to lyrical branch
+    conditions:
+      - base=main
+      - label=backport-lyrical
+    actions:
+      backport:
+        branches:
+          - lyrical
+        labels:
+          - lyrical

--- a/.github/workflows/lyrical-binary-main.yml
+++ b/.github/workflows/lyrical-binary-main.yml
@@ -1,12 +1,6 @@
 name: Lyrical Binary Build Main
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '13 4 * * *'
@@ -17,7 +11,7 @@ jobs:
     with:
       ros_distro: lyrical
       ros_repo: main
-      ref_for_scheduled_build: main
+      ref_for_scheduled_build: lyrical
       rosdep_skip_keys: >-
         moveit_configs_utils
         moveit_kinematics

--- a/.github/workflows/lyrical-binary-testing.yml
+++ b/.github/workflows/lyrical-binary-testing.yml
@@ -1,12 +1,6 @@
 name: Lyrical Binary Build Testing
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '13 4 * * *'
@@ -17,7 +11,7 @@ jobs:
     with:
       ros_distro: lyrical
       ros_repo: testing
-      ref_for_scheduled_build: main
+      ref_for_scheduled_build: lyrical
       rosdep_skip_keys: >-
         moveit_configs_utils
         moveit_kinematics

--- a/.github/workflows/lyrical-semi-binary-main.yml
+++ b/.github/workflows/lyrical-semi-binary-main.yml
@@ -1,12 +1,6 @@
 name: Lyrical Semi Binary Build Main
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '13 4 * * *'
@@ -18,7 +12,7 @@ jobs:
       ros_distro: lyrical
       ros_repo: main
       upstream_workspace: Universal_Robots_ROS2_Driver.lyrical.repos
-      ref_for_scheduled_build: main
+      ref_for_scheduled_build: lyrical
       rosdep_skip_keys: >-
         moveit_configs_utils
         moveit_kinematics

--- a/.github/workflows/lyrical-semi-binary-testing.yml
+++ b/.github/workflows/lyrical-semi-binary-testing.yml
@@ -1,12 +1,6 @@
 name: Lyrical Semi Binary Build Testing
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
   schedule:
     # Run every morning to detect flakiness and broken dependencies
     - cron: '13 4 * * *'
@@ -18,7 +12,7 @@ jobs:
       ros_distro: lyrical
       ros_repo: testing
       upstream_workspace: Universal_Robots_ROS2_Driver.lyrical.repos
-      ref_for_scheduled_build: main
+      ref_for_scheduled_build: lyrical
       rosdep_skip_keys: >-
         moveit_configs_utils
         moveit_kinematics

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Check also [presentations and videos](ur_robot_driver/doc/resources/README.md) a
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/humble">humble</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/jazzy">jazzy</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/kilted">kilted</a></td>
-        <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/lyrical">main</a></td>
+        <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/lyrical">lyrical</a></td>
         <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
       </tr>
       <tr>

--- a/ci_status.md
+++ b/ci_status.md
@@ -15,8 +15,8 @@ red pipeline there should be a corresponding issue labeled with [ci-failure](htt
   <tr>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/humble">humble</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/jazzy">jazzy</a></td>
-    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">kilted</a></td>
-    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">lyrical</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/kilted">kilted</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/lyrical">lyrical</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/tree/main">main</a></td>
   </tr>
   <tr>


### PR DESCRIPTION
Changes specifically to the main branch for branching out for lyrical. These changes should not be backported.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI, Mergify, and documentation-only changes with no runtime or application code impact.
> 
> **Overview**
> Prepares **main** for a separate **`lyrical`** release branch by updating automation and docs, without changing driver code.
> 
> **Mergify** gains a **backport to `lyrical`** rule triggered by `backport-lyrical` on PRs to `main`, matching the existing humble/jazzy/kilted pattern.
> 
> All four **lyrical** GitHub Actions workflows stop running on `main` **push/PR** and only keep **schedule** + **workflow_dispatch**. Scheduled ICI builds now use **`ref_for_scheduled_build: lyrical`** instead of `main`, so nightly jobs track the distro branch like kilted/jazzy.
> 
> **README** and **ci_status** fix branch table links so Lyrical (and Kilted in `ci_status`) point at `tree/lyrical` and `tree/kilted` rather than incorrectly labeling `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cc432ca41e63c8e099e22473ae8c619db3a3285. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->