### PR TITLE
Release/7.0.0

### DIFF
--- a/ur/CHANGELOG.rst
+++ b/ur/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ur
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Contributors: Felix Exner
+
 6.0.0 (2026-05-12)
 ------------------
 

--- a/ur/CHANGELOG.rst
+++ b/ur/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+7.0.0 (2026-07-09)
+------------------
 * Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
 * Contributors: Felix Exner
 

--- a/ur/package.xml
+++ b/ur/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur</name>
-  <version>6.0.0</version>
+  <version>7.0.0</version>
   <description>Metapackage for universal robots</description>
   <maintainer email="feex@universal-robots.com">Felix Exner</maintainer>
   <maintainer email="rsk@universal-robots.com">Rune Søe-Knudsen</maintainer>

--- a/ur_calibration/CHANGELOG.rst
+++ b/ur_calibration/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_calibration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+7.0.0 (2026-07-09)
+------------------
 * Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
 * Contributors: Felix Exner
 

--- a/ur_calibration/CHANGELOG.rst
+++ b/ur_calibration/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ur_calibration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Contributors: Felix Exner
+
 6.0.0 (2026-05-12)
 ------------------
 

--- a/ur_calibration/package.xml
+++ b/ur_calibration/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ur_calibration</name>
-  <version>6.0.0</version>
+  <version>7.0.0</version>
   <description>Package for extracting the factory calibration from a UR robot and change it such that it can be used by ur_description to gain a correct URDF</description>
 
   <maintainer email="feex@universal-robots.com">Felix Exner</maintainer>

--- a/ur_controllers/CHANGELOG.rst
+++ b/ur_controllers/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_controllers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+7.0.0 (2026-07-09)
+------------------
 * Allow setting payload inertia matrix via set_payload service   (`#1808 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1808>`_)
 * Allow updating robot gravity (`#1606 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1606>`_)
 * Use a realtime_tools::RealtimePublisher for publishing the state (`#1822 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1822>`_)

--- a/ur_controllers/CHANGELOG.rst
+++ b/ur_controllers/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog for package ur_controllers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Allow setting payload inertia matrix via set_payload service   (`#1808 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1808>`_)
+* Allow updating robot gravity (`#1606 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1606>`_)
+* Use a realtime_tools::RealtimePublisher for publishing the state (`#1822 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1822>`_)
+* Make GPIO controller publishers realtime safe (`#1807 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1807>`_)
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Contributors: AdamPettinger, Felix Exner, Hasan Amin, Sergi Romero
+
 6.0.0 (2026-05-12)
 ------------------
 * Check payload state in gpio_controller (`#1770 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1770>`_)

--- a/ur_controllers/package.xml
+++ b/ur_controllers/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_controllers</name>
-  <version>6.0.0</version>
+  <version>7.0.0</version>
   <description>Provides controllers that use the speed scaling interface of Universal Robots.</description>
 
   <maintainer email="feex@universal-robots.com">Felix Exner</maintainer>

--- a/ur_dashboard_msgs/CHANGELOG.rst
+++ b/ur_dashboard_msgs/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_dashboard_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+7.0.0 (2026-07-09)
+------------------
 * Update safety status msg with new IO plane stop (`#1817 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1817>`_)
 * Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
 * Contributors: Felix Exner, Mads Holm Peters

--- a/ur_dashboard_msgs/CHANGELOG.rst
+++ b/ur_dashboard_msgs/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package ur_dashboard_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update safety status msg with new IO plane stop (`#1817 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1817>`_)
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Contributors: Felix Exner, Mads Holm Peters
+
 6.0.0 (2026-05-12)
 ------------------
 

--- a/ur_dashboard_msgs/package.xml
+++ b/ur_dashboard_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_dashboard_msgs</name>
-  <version>6.0.0</version>
+  <version>7.0.0</version>
   <description>Messages around the UR Dashboard server.</description>
 
   <maintainer email="feex@universal-robots.com">Felix Exner</maintainer>

--- a/ur_moveit_config/CHANGELOG.rst
+++ b/ur_moveit_config/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ur_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Contributors: Felix Exner
+
 6.0.0 (2026-05-12)
 ------------------
 * BREAKING: Remove scaled joint trajectory controller (`#1769 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1769>`_)

--- a/ur_moveit_config/CHANGELOG.rst
+++ b/ur_moveit_config/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+7.0.0 (2026-07-09)
+------------------
 * Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
 * Contributors: Felix Exner
 

--- a/ur_moveit_config/package.xml
+++ b/ur_moveit_config/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_moveit_config</name>
-  <version>6.0.0</version>
+  <version>7.0.0</version>
   <description>
      An example package with MoveIt2 configurations for UR robots.
   </description>

--- a/ur_robot_driver/CHANGELOG.rst
+++ b/ur_robot_driver/CHANGELOG.rst
@@ -1,3 +1,19 @@
+Forthcoming
+-----------
+* Allow setting payload inertia matrix via set_payload service   (`#1808 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1808>`_)
+* Migrate Urscript interface to primary client (`#1833 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1833>`_)
+* Remove controller switch to passthrough controller (`#1857 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1857>`_)
+* Replace linking to moprim controller my using its include directories (`#1853 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1853>`_)
+* Update model test (`#1848 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1848>`_)
+* Allow updating robot gravity (`#1606 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1606>`_)
+* [tests] Fix shadowed function arg (`#1835 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1835>`_)
+* Explicitly send MODE_STOPPED when returning control to the robot (`#1678 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1678>`_)
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Fix whitespace error introduced earlier (`#1805 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1805>`_)
+* Clarify effort control limitations in URSim (`#1800 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1800>`_)
+* Fail example move on error (`#1795 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1795>`_)
+* Contributors: AdamPettinger, Felix Exner, Sergi Romero, URJala
+
 6.0.0 (2026-05-12)
 ------------------
 * [driver] Remove deprecated packages from package.xml (`#1785 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1785>`_)

--- a/ur_robot_driver/CHANGELOG.rst
+++ b/ur_robot_driver/CHANGELOG.rst
@@ -1,5 +1,5 @@
-Forthcoming
------------
+7.0.0 (2026-07-09)
+------------------
 * Allow setting payload inertia matrix via set_payload service   (`#1808 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1808>`_)
 * Migrate Urscript interface to primary client (`#1833 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1833>`_)
 * Remove controller switch to passthrough controller (`#1857 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1857>`_)

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_robot_driver</name>
-  <version>6.0.0</version>
+  <version>7.0.0</version>
     <description>
       The ROS 2 driver for Universal Robots manipulators. This driver supports all robot
       models as listed in the documentation. For robot controllers, PolyScope X, PolyScope 5 and


### PR DESCRIPTION
Major version increase because of the updated ur_msgs dependency. This will not compile against earlier ur_msgs versions and the set_payload service of the gpio controller changed its interface.

I expect both rolling binary builds to fail because of the updated ur_msgs. rolling-semi-binary-main currently fails anyhow. Lyrical builds will also fail, but they don't matter, as they will get removed in by #1870

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Major version with breaking service/API dependencies and documented changes to robot control, Urscript routing, and controller switching that affect integration and upgrades.
> 
> **Overview**
> **Release 7.0.0** for the `ur` metapackage and its components (`ur_robot_driver`, `ur_controllers`, `ur_calibration`, `ur_dashboard_msgs`, `ur_moveit_config`): every `package.xml` moves **6.0.0 → 7.0.0** and each package gets a matching **7.0.0 (2026-07-09)** changelog section.
> 
> This is a **major** bump (per the PR description) because of an updated **`ur_msgs`** dependency and a **breaking change** to the GPIO controller’s **`set_payload`** service interface; consumers on older `ur_msgs` or the previous service shape need to upgrade together.
> 
> The changelog entries bundled in this release (implemented in earlier merges) highlight **payload inertia via `set_payload`**, **runtime gravity updates**, **realtime-safe GPIO/state publishing**, **Urscript on the primary client**, **explicit `MODE_STOPPED` when handing control back**, **safety status updates for IO plane stop**, **removal of automatic passthrough controller switching**, and raising the **minimum CMake to 3.28.3** across packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 851bce17c1f701263964948b47f892cc502a97e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->