### PR TITLE
Fix link to action_definitions doc page

### DIFF
--- a/ur_robot_driver/doc/usage/script_code.rst
+++ b/ur_robot_driver/doc/usage/script_code.rst
@@ -70,7 +70,7 @@ Scripts with execution monitoring
 ---------------------------------
 The action server at ``/urscript_interface/execute_script`` allows executing script programs and getting the information when execution is done and whether there was an error during execution.
 
-The ``SendScript`` action definition can be seen in the `ur_msgs action definitions <https://docs.ros.org/en/rolling/p/ur_msgs/__action_definitions.html/>`_
+The ``SendScript`` action definition can be seen in the `ur_msgs/action/SendScript <https://docs.ros.org/en/rolling/p/ur_msgs/action/SendScript.html>`_
 
 This action server is a ROS wrapper around the `URCL primary client's <https://github.com/UniversalRobots/Universal_Robots_Client_Library/blob/master/doc/architecture/primary_client.rst/>`_
 SendScriptBlocking method, and the meaning of parameters can be seen there.


### PR DESCRIPTION
Fix broken link in action description.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fix with no runtime or API behavior changes.
> 
> **Overview**
> Updates the **Scripts with execution monitoring** section in `script_code.rst` so the `SendScript` reference points at the correct ROS 2 docs page.
> 
> The link text and URL change from the broken `ur_msgs` `__action_definitions.html` index to `ur_msgs/action/SendScript.html`, matching how `SendScript` is referenced elsewhere in the same doc (e.g. the CLI example).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f6b98c5a884743438a05fcc452e5a1e3d0cdde5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->