### PR TITLE
SJTC: Correctly handle an unset update rate

### DIFF
--- a/ur_bringup/config/ur_controllers.yaml
+++ b/ur_bringup/config/ur_controllers.yaml
@@ -86,6 +86,7 @@ joint_trajectory_controller:
       $(var tf_prefix)wrist_1_joint: { trajectory: 0.2, goal: 0.1 }
       $(var tf_prefix)wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
       $(var tf_prefix)wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
+    update_rate: $(var update_rate)
 
 
 scaled_joint_trajectory_controller:

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -74,7 +74,16 @@ controller_interface::InterfaceConfiguration ScaledJointTrajectoryController::st
 
 controller_interface::CallbackReturn ScaledJointTrajectoryController::on_configure(const rclcpp_lifecycle::State& state)
 {
-  update_period_ = rclcpp::Duration(0.0, static_cast<uint32_t>(1.0e9 / static_cast<double>(get_update_rate())));
+  auto update_rate = get_update_rate();
+
+  if (update_rate == 0) {
+    RCLCPP_WARN(get_node()->get_logger(), "Controller's update_rate is 0. Please configure a non-zero update_rate for "
+                                          "the controller to work properly. Falling back to sampling trajectory at "
+                                          "current_time + last period.");
+    update_period_ = rclcpp::Duration(0, 0);
+  } else {
+    update_period_ = rclcpp::Duration(0, static_cast<uint32_t>(1.0e9 / static_cast<double>(get_update_rate())));
+  }
 
   return JointTrajectoryController::on_configure(state);
 }
@@ -185,8 +194,10 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
                                      end_segment_itr);
     state_desired_.time_from_start = traj_time_ - traj_external_point_ptr_->time_from_start();
 
-    // find segment for current timestamp
-    const bool valid_point = traj_external_point_ptr_->sample(traj_time_ + update_period_, interpolation_method_,
+    // find segment for current timestamp. Look controller period ahead, fallback to last cycle's
+    // period if no update rate is configured.
+    const auto& sample_period = update_period_.seconds() == 0.0 ? period : update_period_;
+    const bool valid_point = traj_external_point_ptr_->sample(traj_time_ + sample_period, interpolation_method_,
                                                               command_next_, start_segment_itr, end_segment_itr);
     state_current_.time_from_start = time - traj_external_point_ptr_->time_from_start();
 

--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -133,6 +133,7 @@ scaled_joint_trajectory_controller:
       $(var tf_prefix)wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
       $(var tf_prefix)wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
     speed_scaling_interface_name: $(var tf_prefix)speed_scaling/speed_scaling_factor
+    update_rate: $(var update_rate)
 
 passthrough_trajectory_controller:
   ros__parameters:

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -29,6 +29,8 @@
 #
 # Author: Denis Stogl
 
+import yaml
+
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterFile, ParameterValue
 from launch_ros.substitutions import FindPackagePrefix, FindPackageShare
@@ -227,6 +229,13 @@ def launch_setup(context, *args, **kwargs):
             ur_type.perform(context) + "_update_rate.yaml",
         ]
     )
+
+    # Expose the controller_manager update_rate as a launch configuration so
+    # that '$(var update_rate)' substitutions inside controller config yaml
+    # resolve to the correct rate for this ur_type.
+    with open(update_rate_config_file.perform(context)) as f:
+        update_rate = yaml.safe_load(f)["controller_manager"]["ros__parameters"]["update_rate"]
+    context.launch_configurations["update_rate"] = str(update_rate)
 
     control_node = Node(
         package="controller_manager",


### PR DESCRIPTION
When backporting the controller's Jazzy implementation in #1753 I missed that on Humble, the controller's update rate isn't initialized with the CM's update rate as it is done from Jazzy on.

Thus, the update rate is 0 by default. When not catching this, conversion to the `update_period_` member devides by 0 which is undefined behavior. On AMD64 this seems to result in a Duration of 0.0 seconds (as part of the static casts probably). On ARM64 that results in a very large number, though, effectively configuring the period at ~4.2 seconds.

Both isn't the desired result, so I've added  a catch for this and a fallback using the last cycle's period if a target update rate is unavailable.

Also, this PR sets the controller's update rate to the CM's update rate when using launch and config files from this package.

This should close #1859 

Note, this is explicitly a Humble bug. That part of code doesn't exist on Jazzy or later.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time trajectory sampling in the primary UR motion controller; misconfiguration could still affect motion, but the fix targets a known Humble default and adds a safe fallback.
> 
> **Overview**
> Fixes **ScaledJointTrajectoryController** on Humble when `update_rate` is left at **0** (unlike newer distros, it is not auto-filled from the controller manager). `on_configure` no longer divides by zero when building `update_period_`; it logs a warning, sets a zero period, and in `update()` uses the **last control cycle’s `period`** for the trajectory lookahead sample when no rate is configured.
> 
> Package launch and YAML now wire the controller manager rate into trajectory controllers: **`ur_control.launch.py`** loads the robot-type `*_update_rate.yaml` and exposes `update_rate` for substitutions, and **`ur_controllers.yaml`** in bringup/driver sets `update_rate: $(var update_rate)` on the relevant joint trajectory controllers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 894ff028713e31ff5e55f890e329ad462a777953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->