### PR TITLE
Link ur_calibration against yaml-cpp target

### DIFF
--- a/ur_calibration/CMakeLists.txt
+++ b/ur_calibration/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(tf2_ros REQUIRED)
 
 find_package(Eigen3 REQUIRED)
 find_package(yaml_cpp_vendor REQUIRED)
+find_package(yaml-cpp REQUIRED)
 find_package(ur_client_library REQUIRED)
 
 ###########
@@ -37,10 +38,14 @@ target_include_directories(calibration
 target_link_libraries(calibration
   ur_client_library::urcl
   Eigen3::Eigen
-  yaml-cpp
   rclcpp::rclcpp
   ur_robot_driver::ur_robot_driver_log_handler
 )
+if(TARGET yaml-cpp::yaml-cpp)
+  target_link_libraries(calibration yaml-cpp::yaml-cpp)
+else()
+  target_link_libraries(calibration yaml-cpp)
+endif()
 
 add_executable(calibration_correction
   src/calibration_correction.cpp


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: patch/ros-rolling-ur-calibration.win.patch, authored by Daisuke Nishimatsu.

Best-guess rationale: yaml_cpp_vendor makes yaml-cpp available, but toolchains and package managers may expose the imported target as yaml-cpp::yaml-cpp rather than relying on a bare yaml-cpp library name. Finding yaml-cpp explicitly and preferring the imported target makes the link step more portable while keeping the existing fallback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CMake-only linking change with a fallback path; no application, security, or data-handling behavior is modified.
> 
> **Overview**
> **Build-only change** for `ur_calibration`: linking against YAML-CPP is made more portable across toolchains (e.g. RoboStack/Windows).
> 
> Adds `find_package(yaml-cpp REQUIRED)` alongside the existing `yaml_cpp_vendor` dependency. The `calibration` static library no longer always links the bare `yaml-cpp` library name in one shot; it links **`yaml-cpp::yaml-cpp`** when that imported target exists, otherwise falls back to **`yaml-cpp`**.
> 
> No runtime or calibration logic changes—only how the library is resolved at configure/link time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ef15b58ff808958738dc604a7d4cbeba218328c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->