### PR TITLE
Fix sjtc sampling

### DIFF
--- a/ur_bringup/config/ur_controllers.yaml
+++ b/ur_bringup/config/ur_controllers.yaml
@@ -86,6 +86,7 @@ joint_trajectory_controller:
       $(var tf_prefix)wrist_1_joint: { trajectory: 0.2, goal: 0.1 }
       $(var tf_prefix)wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
       $(var tf_prefix)wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
+    update_rate: $(var update_rate)
 
 
 scaled_joint_trajectory_controller:

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -188,15 +188,17 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
     } else {
       traj_time_ += period * scaling_factor_;
     }
-    joint_trajectory_controller::TrajectoryPointConstIter start_segment_itr, end_segment_itr;
-    // Sample expected state from the trajectory
-    traj_external_point_ptr_->sample(traj_time_, interpolation_method_, state_desired_, start_segment_itr,
-                                     end_segment_itr);
-    state_desired_.time_from_start = traj_time_ - traj_external_point_ptr_->time_from_start();
+
+    // We expect the robot to be where it was commanded last. This will not be absolutely correct
+    // since
+    //  1. speed scaling will affect this
+    //  2. The cycle might not take exactly the controller's configured update period.
+    state_desired_ = last_commanded_state_;
 
     // find segment for current timestamp. Look controller period ahead, fallback to last cycle's
     // period if no update rate is configured.
     const auto& sample_period = update_period_.seconds() == 0.0 ? period : update_period_;
+    joint_trajectory_controller::TrajectoryPointConstIter start_segment_itr, end_segment_itr;
     const bool valid_point = traj_external_point_ptr_->sample(traj_time_ + sample_period, interpolation_method_,
                                                               command_next_, start_segment_itr, end_segment_itr);
     state_current_.time_from_start = time - traj_external_point_ptr_->time_from_start();

--- a/ur_controllers/src/scaled_joint_trajectory_controller.cpp
+++ b/ur_controllers/src/scaled_joint_trajectory_controller.cpp
@@ -74,7 +74,16 @@ controller_interface::InterfaceConfiguration ScaledJointTrajectoryController::st
 
 controller_interface::CallbackReturn ScaledJointTrajectoryController::on_configure(const rclcpp_lifecycle::State& state)
 {
-  update_period_ = rclcpp::Duration(0.0, static_cast<uint32_t>(1.0e9 / static_cast<double>(get_update_rate())));
+  auto update_rate = get_update_rate();
+
+  if (update_rate == 0) {
+    RCLCPP_WARN(get_node()->get_logger(), "Controller's update_rate is 0. Please configure a non-zero update_rate for "
+                                          "the controller to work properly. Falling back to sampling trajectory at "
+                                          "current_time + last period.");
+    update_period_ = rclcpp::Duration(0, 0);
+  } else {
+    update_period_ = rclcpp::Duration(0, static_cast<uint32_t>(1.0e9 / static_cast<double>(get_update_rate())));
+  }
 
   return JointTrajectoryController::on_configure(state);
 }
@@ -185,8 +194,10 @@ controller_interface::return_type ScaledJointTrajectoryController::update(const 
                                      end_segment_itr);
     state_desired_.time_from_start = traj_time_ - traj_external_point_ptr_->time_from_start();
 
-    // find segment for current timestamp
-    const bool valid_point = traj_external_point_ptr_->sample(traj_time_ + update_period_, interpolation_method_,
+    // find segment for current timestamp. Look controller period ahead, fallback to last cycle's
+    // period if no update rate is configured.
+    const auto& sample_period = update_period_.seconds() == 0.0 ? period : update_period_;
+    const bool valid_point = traj_external_point_ptr_->sample(traj_time_ + sample_period, interpolation_method_,
                                                               command_next_, start_segment_itr, end_segment_itr);
     state_current_.time_from_start = time - traj_external_point_ptr_->time_from_start();
 

--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -133,6 +133,7 @@ scaled_joint_trajectory_controller:
       $(var tf_prefix)wrist_2_joint: { trajectory: 0.2, goal: 0.1 }
       $(var tf_prefix)wrist_3_joint: { trajectory: 0.2, goal: 0.1 }
     speed_scaling_interface_name: $(var tf_prefix)speed_scaling/speed_scaling_factor
+    update_rate: $(var update_rate)
 
 passthrough_trajectory_controller:
   ros__parameters:

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -29,6 +29,8 @@
 #
 # Author: Denis Stogl
 
+import yaml
+
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterFile, ParameterValue
 from launch_ros.substitutions import FindPackagePrefix, FindPackageShare
@@ -227,6 +229,13 @@ def launch_setup(context, *args, **kwargs):
             ur_type.perform(context) + "_update_rate.yaml",
         ]
     )
+
+    # Expose the controller_manager update_rate as a launch configuration so
+    # that '$(var update_rate)' substitutions inside controller config yaml
+    # resolve to the correct rate for this ur_type.
+    with open(update_rate_config_file.perform(context)) as f:
+        update_rate = yaml.safe_load(f)["controller_manager"]["ros__parameters"]["update_rate"]
+    context.launch_configurations["update_rate"] = str(update_rate)
 
     control_node = Node(
         package="controller_manager",


### PR DESCRIPTION
This is the second attempt to #1886, fixing #1859. https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1753 also misses the updated trajectory sampling which lives in the JTC package. This PR adds an alternative approach to resolving the desired state:

Use last commanded state as desired state
    
On Humble we have to avoid sampling the trajectory twice, since sampling
will monotonically increase the pointer inside the trajectory, search
starting from that pointer.

Using the last commanded state instead is exactly the same if the
controller is updated with its expected rate, since it was sampled at
last_cycle + period.

This has been tested on URSim and two different robots using AMD64 and ARM64 machines. As far as I can see, @becketps has also tested this successfully in the setup where #1859 came from.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time motion control in the primary scaled trajectory controller; behavior is targeted at a known bug but affects path tolerance, feedback, and commanded motion on all deployments using SJTC.
> 
> **Overview**
> Fixes incorrect **scaled joint trajectory controller** behavior on Humble by avoiding **two trajectory samples per cycle**, which advanced the internal segment pointer and broke execution (#1859).
> 
> **Controller logic:** `state_desired_` is now taken from **`last_commanded_state_`** instead of a separate sample at `traj_time_`. A **single** sample at `traj_time_ + sample_period` fills **`command_next_`**, using the configured **`update_period_`** when `update_rate` is set, or the actual loop **`period`** when `update_rate` is zero (with a warning).
> 
> **Configuration:** **`update_rate: $(var update_rate)`** is added for the relevant trajectory controllers in bringup/driver YAML. **`ur_control.launch.py`** loads the robot-type **`_update_rate.yaml`** and exposes **`update_rate`** in launch substitutions so those YAML vars resolve to the controller manager rate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f945c95239f717b65e16f22c73b71c6023c69639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->