### PR TITLE
Fix `trajectory_until_node` goal acceptance handshake

### DIFF
--- a/ur_robot_driver/src/trajectory_until_node.cpp
+++ b/ur_robot_driver/src/trajectory_until_node.cpp
@@ -139,22 +139,28 @@ rclcpp_action::GoalResponse TrajectoryUntilNode::goal_received_callback(
     throw std::runtime_error("Until type not implemented. This should not happen.");
   }
 
-  // If it is not accepted within 1 seconds, it is
-  // assumed to be rejected.
-  std::unique_lock<std::mutex> until_lock(mutex_until);
-  cv_until_.wait_for(until_lock, 1s);
-  if (!until_accepted_) {
-    return rclcpp_action::GoalResponse::REJECT;
+  // If it is not accepted within 1 second, it is assumed to be rejected. The predicate protects
+  // against the acceptance callback firing before this wait starts (the clients run on a separate
+  // callback group), which would otherwise lose the notification and burn the full timeout.
+  {
+    std::unique_lock<std::mutex> until_lock(mutex_until);
+    if (!cv_until_.wait_for(until_lock, 1s, [this] { return until_accepted_.load(); })) {
+      return rclcpp_action::GoalResponse::REJECT;
+    }
   }
 
-  // Send action goal to trajectory controller and wait for it to be accepted. If it is not accepted within 1 seconds,
-  // it is assumed to be rejected.
+  // Send action goal to trajectory controller and wait for it to be accepted. If it is not accepted
+  // within 1 second, it is assumed to be rejected. This wait must use cv_trajectory_ —
+  // trajectory_response_callback notifies cv_trajectory_, not cv_until_, so waiting on cv_until_
+  // here always ran into the timeout, delaying every goal acceptance by a full second (and goals
+  // finishing inside that window had their results dropped against the not-yet-accepted goal).
   send_trajectory_goal(goal);
-  std::unique_lock<std::mutex> traj_lock(mutex_trajectory);
-  cv_until_.wait_for(traj_lock, 1s);
-  if (!trajectory_accepted_) {
-    reset_node();
-    return rclcpp_action::GoalResponse::REJECT;
+  {
+    std::unique_lock<std::mutex> traj_lock(mutex_trajectory);
+    if (!cv_trajectory_.wait_for(traj_lock, 1s, [this] { return trajectory_accepted_.load(); })) {
+      reset_node();
+      return rclcpp_action::GoalResponse::REJECT;
+    }
   }
 
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;

--- a/ur_robot_driver/src/trajectory_until_node.cpp
+++ b/ur_robot_driver/src/trajectory_until_node.cpp
@@ -150,10 +150,7 @@ rclcpp_action::GoalResponse TrajectoryUntilNode::goal_received_callback(
   }
 
   // Send action goal to trajectory controller and wait for it to be accepted. If it is not accepted
-  // within 1 second, it is assumed to be rejected. This wait must use cv_trajectory_ —
-  // trajectory_response_callback notifies cv_trajectory_, not cv_until_, so waiting on cv_until_
-  // here always ran into the timeout, delaying every goal acceptance by a full second (and goals
-  // finishing inside that window had their results dropped against the not-yet-accepted goal).
+  // within 1 second, it is assumed to be rejected.
   send_trajectory_goal(goal);
   {
     std::unique_lock<std::mutex> traj_lock(mutex_trajectory);

--- a/ur_robot_driver/test/integration_test_trajectory_until.py
+++ b/ur_robot_driver/test/integration_test_trajectory_until.py
@@ -170,3 +170,45 @@ class RobotDriverTest(unittest.TestCase):
                 deactivate_controllers=["tool_contact_controller"],
             ).ok
         )
+
+    def test_trajectory_with_tool_contact_short_goal_succeeds(self, tf_prefix):
+        # Regression test for #1908: while goal acceptance was delayed by the
+        # mismatched condition-variable waits in goal_received_callback, a
+        # trajectory finishing inside that window had its result dropped
+        # against the not-yet-accepted goal and was spuriously rejected. A
+        # short goal must be accepted and succeed like any other.
+        # NB: runs after test_trajectory_with_tool_contact_no_trigger_succeeds
+        # (alphabetical order), so the robot deterministically starts at that
+        # test's final waypoint.
+        self.assertTrue(
+            self._controller_manager_interface.switch_controller(
+                strictness=SwitchController.Request.BEST_EFFORT,
+                activate_controllers=["tool_contact_controller"],
+            ).ok
+        )
+        # Small move from the previous test's end pose, short enough to finish
+        # within the formerly-burnt acceptance window.
+        target = list(self.test_traj["waypts"][1])
+        target[5] -= 0.3
+        trajectory = JointTrajectory()
+        trajectory.joint_names = [tf_prefix + joint for joint in ROBOT_JOINTS]
+        trajectory.points = [
+            JointTrajectoryPoint(positions=target, time_from_start=Duration(sec=1, nanosec=0))
+        ]
+        goal_handle = self._trajectory_until_interface.send_goal(
+            trajectory=trajectory, until_type=FollowJointTrajectoryUntil.Goal.TOOL_CONTACT
+        )
+        self.assertTrue(goal_handle.accepted)
+        result = self._trajectory_until_interface.get_result(
+            goal_handle, TIMEOUT_EXECUTE_TRAJECTORY
+        )
+        self.assertEqual(result.error_code, FollowJointTrajectoryUntil.Result.SUCCESSFUL)
+        self.assertEqual(
+            result.until_condition_result, FollowJointTrajectoryUntil.Result.NOT_TRIGGERED
+        )
+        self.assertTrue(
+            self._controller_manager_interface.switch_controller(
+                strictness=SwitchController.Request.BEST_EFFORT,
+                deactivate_controllers=["tool_contact_controller"],
+            ).ok
+        )


### PR DESCRIPTION
Fixes #1908:

The wait for trajectory-goal acceptance used cv_until_, which nothing on the trajectory path notifies, so it always ran into its 1 s timeout; both acceptance waits were also unpredicated, losing notifications that arrived before the wait started. Every goal was accepted 1-2 s late, and goals finishing inside that window had their results dropped against the not-yet-accepted server goal (spurious rejects for trajectories under ~2 s).

Wait on the correct condition variables with predicates, and scope each lock so mutex_until is not held through the trajectory phase.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes timing and synchronization in the trajectory-until action server path; incorrect behavior would affect motion goals, but the fix is localized and covered by a new integration test.
> 
> **Overview**
> Fixes the **FollowJointTrajectoryUntil** goal handshake in `trajectory_until_node` so downstream until/trajectory goals are accepted promptly instead of always waiting out ~1–2 s timeouts.
> 
> **`goal_received_callback`** now waits on **`cv_until_`** / **`cv_trajectory_`** with predicates on `until_accepted_` and `trajectory_accepted_` (avoids missing notifications when client callbacks run on another callback group), and scopes each mutex so **`mutex_until`** is not held through the trajectory acceptance phase. The trajectory path previously waited on the wrong condition variable, so acceptance never woke early.
> 
> Adds integration test **`test_trajectory_with_tool_contact_short_goal_succeeds`** (regression for #1908): a ~1 s tool-contact trajectory must be accepted and return **SUCCESSFUL** / **NOT_TRIGGERED**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f9cd631196f0e8870d0917e75ebd5a397ca7da1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->