### PR TITLE
Add realtime_tools dependency to ur_robot_driver

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -40,6 +40,7 @@ find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
+find_package(realtime_tools REQUIRED)
 find_package(rclpy REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
@@ -110,6 +111,7 @@ add_executable(ur_ros2_control_node
 ament_target_dependencies(ur_ros2_control_node
   controller_manager
   rclcpp
+  realtime_tools
 )
 
 #

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -37,6 +37,7 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>realtime_tools</depend>
   <depend>rclpy</depend>
   <depend>std_msgs</depend>
   <depend>std_srvs</depend>


### PR DESCRIPTION
This PR adds `realtime_tools` as an explicit dependency of `ur_robot_driver` on the Humble branch.

`src/ur_ros2_control_node.cpp` directly includes `realtime_tools/realtime_helpers.hpp` and calls `realtime_tools::configure_sched_fifo(50)` when starting the control loop thread.

Currently, `realtime_tools` can be available transitively through `controller_manager` and other controller packages. This change makes the package metadata and the `ur_ros2_control_node` target reflect the direct source-level use.

Changes:

- Add `<depend>realtime_tools</depend>` to `ur_robot_driver/package.xml`.
- Add `find_package(realtime_tools REQUIRED)` to `CMakeLists.txt`.
- Add `realtime_tools` to the dependencies of `ur_ros2_control_node`.

The dependency is target-scoped rather than added to `THIS_PACKAGE_INCLUDE_DEPENDS`, because no other target or exported public header uses `realtime_tools`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and package-metadata only; no runtime logic changes.
> 
> **Overview**
> **`ur_robot_driver`** now declares **`realtime_tools`** as a direct build/runtime dependency instead of relying on transitive packages such as **`controller_manager`**.
> 
> **`package.xml`** gains `<depend>realtime_tools</depend>`. **`CMakeLists.txt`** adds `find_package(realtime_tools REQUIRED)` and links **`realtime_tools`** only on the **`ur_ros2_control_node`** target (not **`THIS_PACKAGE_INCLUDE_DEPENDS`**) because that executable is the sole direct consumer of **`realtime_tools/realtime_helpers.hpp`** for FIFO RT scheduling on the control loop thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2597f630f39bd2e690dc3cb2a8478bb937be0f80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->