### PR TITLE
Fix a typo in launch file arg docstring

### DIFF
--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -67,7 +67,7 @@ def declare_arguments():
             DeclareLaunchArgument("launch_rviz", default_value="true", description="Launch RViz?"),
             DeclareLaunchArgument(
                 "ur_type",
-                description="Type/series of used UR robot.",
+                description="Robot model of the used UR robot.",
                 choices=[
                     "ur3",
                     "ur5",

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -67,7 +67,7 @@ def declare_arguments():
             DeclareLaunchArgument("launch_rviz", default_value="true", description="Launch RViz?"),
             DeclareLaunchArgument(
                 "ur_type",
-                description="Typo/series of used UR robot.",
+                description="Type/series of used UR robot.",
                 choices=[
                     "ur3",
                     "ur5",

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -265,7 +265,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "ur_type",
-            description="Type/series of used UR robot.",
+            description="Robot model of the used UR robot.",
             choices=[
                 "ur3",
                 "ur5",

--- a/ur_robot_driver/launch/ur_rsp.launch.py
+++ b/ur_robot_driver/launch/ur_rsp.launch.py
@@ -202,7 +202,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "ur_type",
-            description="Type/series of used UR robot.",
+            description="Robot model of the used UR robot.",
             choices=[
                 "ur3",
                 "ur5",

--- a/ur_robot_driver/launch/ur_rsp.launch.py
+++ b/ur_robot_driver/launch/ur_rsp.launch.py
@@ -202,7 +202,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "ur_type",
-            description="Typo/series of used UR robot.",
+            description="Type/series of used UR robot.",
             choices=[
                 "ur3",
                 "ur5",


### PR DESCRIPTION
The Typo should be a Type.

I stumbled upon this by accident, this is relevant in other packages, as well. @urrsk should we simply fix the typo or should we change the help text? My proposal would be to change it to "Robot model of the used UR robot".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Help-string only; no runtime or configuration behavior changes.
> 
> **Overview**
> Updates the **`ur_type`** launch argument description in three launch files (`ur_moveit.launch.py`, `ur_control.launch.py`, `ur_rsp.launch.py`) from the incorrect **"Typo/series"** / **"Type/series"** wording to **"Robot model of the used UR robot."**
> 
> This is documentation-only for CLI/help when launching; argument names, choices, and defaults are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f13a127fabf817cfb1860e31a926abaa22ad6ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->