### PR TITLE
[FEAT] Publish robot control mode

### DIFF
--- a/ur_controllers/CMakeLists.txt
+++ b/ur_controllers/CMakeLists.txt
@@ -72,8 +72,8 @@ generate_parameter_library(
   src/gpio_controller_parameters.yaml
 )
 generate_parameter_library(
-  ur_robot_broadcaster_parameters
-  src/ur_robot_broadcaster_parameters.yaml
+  ur_robot_mode_broadcaster_parameters
+  src/ur_robot_mode_broadcaster_parameters.yaml
 )
 
 generate_parameter_library(
@@ -108,7 +108,7 @@ add_library(${PROJECT_NAME} SHARED
   src/speed_scaling_state_broadcaster.cpp
   src/freedrive_mode_controller.cpp
   src/gpio_controller.cpp
-  src/ur_robot_broadcaster.cpp
+  src/ur_robot_mode_broadcaster.cpp
   src/gravity_update_controller.cpp
   src/passthrough_trajectory_controller.cpp
   src/ur_configuration_controller.cpp)
@@ -121,7 +121,7 @@ target_link_libraries(${PROJECT_NAME}
   force_mode_controller_parameters
   friction_model_controller_parameters
   gpio_controller_parameters
-  ur_robot_broadcaster_parameters
+  ur_robot_mode_broadcaster_parameters
   gravity_update_controller_parameters
   speed_scaling_state_broadcaster_parameters
   freedrive_mode_controller_parameters

--- a/ur_controllers/CMakeLists.txt
+++ b/ur_controllers/CMakeLists.txt
@@ -71,6 +71,10 @@ generate_parameter_library(
   gpio_controller_parameters
   src/gpio_controller_parameters.yaml
 )
+generate_parameter_library(
+  ur_robot_broadcaster_parameters
+  src/ur_robot_broadcaster_parameters.yaml
+)
 
 generate_parameter_library(
   gravity_update_controller_parameters
@@ -104,6 +108,7 @@ add_library(${PROJECT_NAME} SHARED
   src/speed_scaling_state_broadcaster.cpp
   src/freedrive_mode_controller.cpp
   src/gpio_controller.cpp
+  src/ur_robot_broadcaster.cpp
   src/gravity_update_controller.cpp
   src/passthrough_trajectory_controller.cpp
   src/ur_configuration_controller.cpp)
@@ -116,6 +121,7 @@ target_link_libraries(${PROJECT_NAME}
   force_mode_controller_parameters
   friction_model_controller_parameters
   gpio_controller_parameters
+  ur_robot_broadcaster_parameters
   gravity_update_controller_parameters
   speed_scaling_state_broadcaster_parameters
   freedrive_mode_controller_parameters

--- a/ur_controllers/controller_plugins.xml
+++ b/ur_controllers/controller_plugins.xml
@@ -9,6 +9,11 @@
       This controller publishes the Tool IO.
     </description>
   </class>
+  <class name="ur_controllers/URRobotModeBroadcaster" type="ur_controllers::URRobotModeBroadcaster" base_class_type="controller_interface::ControllerInterface">
+    <description>
+      This controller publishes the robot mode data received from the primary interface.
+    </description>
+  </class>
   <class name="ur_controllers/ForceModeController" type="ur_controllers::ForceModeController" base_class_type="controller_interface::ControllerInterface">
     <description>
       Controller to use UR's force_mode.

--- a/ur_controllers/doc/index.rst
+++ b/ur_controllers/doc/index.rst
@@ -493,3 +493,45 @@ Example for a ceiling-mounted robot (gravity pointing up in the ``base`` frame):
 
    When using the mocked hardware interface, the service may report failure even though the command
    was accepted, because the mock does not emulate the asynchronous success feedback from the robot.
+
+.. _ur_robot_mode_broadcaster:
+
+ur_controllers/URRobotModeBroadcaster
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This controller publishes the ``RobotModeData`` structure as reported by the robot's primary
+interface.
+
+Published topics
+""""""""""""""""
+
+* ``~/robot_mode_data [ur_msgs/msg/RobotModeDataMsg]``: The robot's mode data
+
+Currently the ``control_mode`` field is populated. It reports which control regime the robot
+controller is in, using the constants defined in ``ur_msgs/msg/RobotModeDataMsg``:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Constant
+     - Value
+     - Meaning
+   * - ``CONTROL_MODE_POSITION``
+     - 0
+     - Position control
+   * - ``CONTROL_MODE_TEACH``
+     - 1
+     - Freedrive (teach) mode
+   * - ``CONTROL_MODE_FORCE``
+     - 2
+     - Force mode
+   * - ``CONTROL_MODE_UNKNOWN``
+     - 255
+     - Not reported by the robot. Set by the driver until the primary interface has delivered its
+       first package.
+
+.. note::
+
+   The robot broadcasts ``RobotModeData`` at approximately 10 Hz. This controller is therefore
+   configured as an asynchronous controller with ``update_rate: 10`` instead of running at the
+   controller manager's rate, since publishing faster would only repeat unchanged data.

--- a/ur_controllers/include/ur_controllers/ur_robot_mode_broadcaster.hpp
+++ b/ur_controllers/include/ur_controllers/ur_robot_mode_broadcaster.hpp
@@ -1,0 +1,72 @@
+// Copyright 2026, Arthur Haffemayer
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+  /*!\file
+   *
+   * \author  Arthur Haffemayer <arthur.haffemayer@gmail.com>
+   * \date    2026-08-03
+   *
+   */
+
+#ifndef UR_CONTROLLERS__UR_ROBOT_MODE_BROADCASTER_HPP_
+#define UR_CONTROLLERS__UR_ROBOT_MODE_BROADCASTER_HPP_
+
+#include <memory>
+
+#include <realtime_tools/realtime_publisher.hpp>
+#include <controller_interface/controller_interface.hpp>
+#include <rclcpp/time.hpp>
+#include <rclcpp/duration.hpp>
+#include <ur_msgs/msg/robot_mode_data_msg.hpp>
+#include "ur_controllers/ur_robot_mode_broadcaster_parameters.hpp"
+
+namespace ur_controllers
+{
+class URRobotModeBroadcaster : public controller_interface::ControllerInterface
+{
+  public:
+    URRobotModeBroadcaster();  
+    controller_interface::CallbackReturn on_init() override;
+    controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+    controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+    controller_interface::CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
+    controller_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
+    controller_interface::CallbackReturn on_cleanup(const rclcpp_lifecycle::State& previous_state) override;
+    controller_interface::return_type update(const rclcpp::Time& time, const rclcpp::Duration& period) override;
+
+  protected:
+    double publish_rate_;
+
+    std::shared_ptr<realtime_tools::RealtimePublisher<ur_msgs::msg::RobotModeDataMsg>> robot_mode_publisher_;
+    ur_msgs::msg::RobotModeDataMsg robot_mode_msg_;
+    // Parameters from ROS for URRobotModeBroadcaster
+    std::shared_ptr<ur_robot_mode_broadcaster::ParamListener> param_listener_;
+    ur_robot_mode_broadcaster::Params params_;
+};
+} // namespace ur_controllers
+#endif  // UR_CONTROLLERS__UR_ROBOT_MODE_BROADCASTER_HPP_

--- a/ur_controllers/include/ur_controllers/ur_robot_mode_broadcaster.hpp
+++ b/ur_controllers/include/ur_controllers/ur_robot_mode_broadcaster.hpp
@@ -60,7 +60,6 @@ class URRobotModeBroadcaster : public controller_interface::ControllerInterface
     controller_interface::return_type update(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
   protected:
-    double publish_rate_;
 
     std::shared_ptr<realtime_tools::RealtimePublisher<ur_msgs::msg::RobotModeDataMsg>> robot_mode_publisher_;
     ur_msgs::msg::RobotModeDataMsg robot_mode_msg_;

--- a/ur_controllers/src/ur_robot_mode_broadcaster.cpp
+++ b/ur_controllers/src/ur_robot_mode_broadcaster.cpp
@@ -1,0 +1,142 @@
+// Copyright 2026, Arthur Haffemayer
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+  /*!\file
+   *
+   * \author  Arthur Haffemayer <arthur.haffemayer@gmail.com>
+   * \date    2026-08-03
+   *
+   */
+
+
+#include "ur_controllers/ur_robot_mode_broadcaster.hpp"
+
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "rclcpp/clock.hpp"
+#include "rclcpp/qos.hpp"
+#include "rclcpp/time.hpp"
+#include "rclcpp_lifecycle/lifecycle_node.hpp"
+#include "rcpputils/split.hpp"
+#include "rcutils/logging_macros.h"
+
+namespace ur_controllers
+{
+URRobotModeBroadcaster::URRobotModeBroadcaster()
+{
+}
+
+controller_interface::CallbackReturn URRobotModeBroadcaster::on_init()
+{
+  try {
+    // Create the parameter listener and get the parameters
+    param_listener_ = std::make_shared<ur_robot_mode_broadcaster::ParamListener>(get_node());
+    params_ = param_listener_->get_params();
+
+    RCLCPP_INFO(get_node()->get_logger(), "Loading UR URRobotModeBroadcaster with tf_prefix: %s",
+                params_.tf_prefix.c_str());
+  } catch (std::exception& e) {
+    fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
+    return controller_interface::CallbackReturn::ERROR;
+  }
+
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::InterfaceConfiguration URRobotModeBroadcaster::command_interface_configuration() const
+{
+  return controller_interface::InterfaceConfiguration{ controller_interface::interface_configuration_type::NONE };
+}
+
+controller_interface::InterfaceConfiguration URRobotModeBroadcaster::state_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration config;
+  config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+
+  const std::string tf_prefix = params_.tf_prefix;
+  config.names.push_back(tf_prefix + "gpio/robot_control_mode");
+  return config;
+}
+
+controller_interface::CallbackReturn
+URRobotModeBroadcaster::on_configure(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  if (!param_listener_) {
+    RCLCPP_ERROR(get_node()->get_logger(), "Error encountered during init");
+    return controller_interface::CallbackReturn::ERROR;
+  }
+
+  // update the dynamic map parameters
+  param_listener_->refresh_dynamic_parameters();
+
+  // get parameters from the listener in case they were updated
+  params_ = param_listener_->get_params();
+
+  try {
+    robot_mode_publisher_ = std::make_shared<realtime_tools::RealtimePublisher<ur_msgs::msg::RobotModeDataMsg>>(
+        get_node()->create_publisher<ur_msgs::msg::RobotModeDataMsg>("~/robot_mode_data", rclcpp::SystemDefaultsQoS()));
+  } catch (const std::exception& e) {
+    // get_node() may throw, logging raw here
+    fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
+    return controller_interface::CallbackReturn::ERROR;
+  }
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+
+controller_interface::CallbackReturn
+URRobotModeBroadcaster::on_activate(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::return_type URRobotModeBroadcaster::update(const rclcpp::Time& /*time*/,
+                                                                       const rclcpp::Duration& /*period*/)
+{
+  robot_mode_msg_.control_mode = static_cast<uint8_t>(
+      state_interfaces_[0].get_optional().value_or(ur_msgs::msg::RobotModeDataMsg::CONTROL_MODE_UNKNOWN));
+
+  // publish
+  robot_mode_publisher_->try_publish(robot_mode_msg_);
+  
+  return controller_interface::return_type::OK;
+}
+
+controller_interface::CallbackReturn
+URRobotModeBroadcaster::on_cleanup(const rclcpp_lifecycle::State& /*previous_state*/)
+{
+  robot_mode_publisher_.reset();
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+} // namespace ur_controllers
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(ur_controllers::URRobotModeBroadcaster, controller_interface::ControllerInterface)
+

--- a/ur_controllers/src/ur_robot_mode_broadcaster_parameters.yaml
+++ b/ur_controllers/src/ur_robot_mode_broadcaster_parameters.yaml
@@ -1,0 +1,11 @@
+ur_robot_mode_broadcaster:
+   tf_prefix: {
+    type: string,
+    default_value: "",
+    description: "Urdf prefix of the corresponding arm"
+   }
+   state_publish_rate: {
+    type: double,
+    default_value: 10.0,
+    description: "Rate at which the robot mode data will be published."
+   }

--- a/ur_controllers/src/ur_robot_mode_broadcaster_parameters.yaml
+++ b/ur_controllers/src/ur_robot_mode_broadcaster_parameters.yaml
@@ -4,8 +4,3 @@ ur_robot_mode_broadcaster:
     default_value: "",
     description: "Urdf prefix of the corresponding arm"
    }
-   state_publish_rate: {
-    type: double,
-    default_value: 10.0,
-    description: "Rate at which the robot mode data will be published."
-   }

--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -6,6 +6,9 @@ controller_manager:
     io_and_status_controller:
       type: ur_controllers/GPIOController
 
+    ur_robot_mode_broadcaster:
+      type: ur_controllers/URRobotModeBroadcaster
+
     speed_scaling_state_broadcaster:
       type: ur_controllers/SpeedScalingStateBroadcaster
 
@@ -67,6 +70,12 @@ speed_scaling_state_broadcaster:
 io_and_status_controller:
   ros__parameters:
     tf_prefix: "$(var tf_prefix)"
+
+ur_robot_mode_broadcaster:
+  ros__parameters:
+    tf_prefix: "$(var tf_prefix)"
+    is_async: true
+    update_rate: 10
 
 ur_configuration_controller:
   ros__parameters:

--- a/ur_robot_driver/doc/usage/utility_controllers.rst
+++ b/ur_robot_driver/doc/usage/utility_controllers.rst
@@ -146,3 +146,23 @@ default in the driver's launch file.
      "{gravity: {header: {frame_id: 'base'}, vector: {x: 0.0, y: 0.0, z: -9.82}}}"
 
 See the :ref:`gravity_update_controller <gravity_update_controller>` documentation for full details.
+
+ur_robot_mode_broadcaster
+-------------------------
+
+Type: :ref:`ur_controllers/URRobotModeBroadcaster <ur_robot_mode_broadcaster>`
+
+Publishes the robot's mode data as reported by the primary interface on the ``~/robot_mode_data``
+topic as a ``ur_msgs/msg/RobotModeDataMsg``. This broadcaster is read-only and can run alongside
+any other controller.
+
+Currently the ``control_mode`` field is populated, reporting whether the robot controller is in
+position control, freedrive, or force mode. Constants for the possible values are defined in the
+message.
+
+.. note::
+
+   The robot broadcasts this data at approximately 10 Hz, so this controller runs asynchronously
+   with ``update_rate: 10`` rather than at the controller manager's rate.
+
+See the :ref:`ur_robot_mode_broadcaster <ur_robot_mode_broadcaster>` documentation for full details.

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -36,6 +36,9 @@
  *
  * \author  Mathias Fuhrer mathias.fuhrer@b-robotized.de
  * \date    2025-05-28 – Added support for usage with motion_primitives_controller
+ * 
+ * \author  Arthur Haffemayer arthur.haffemayer@gmail.com
+ * \date    2026-08-19 - Added robot mode reading
  *
  */
 //----------------------------------------------------------------------
@@ -59,8 +62,10 @@
 #include "ur_client_library/ur/ur_driver.h"
 #include "ur_client_library/ur/instruction_executor.h"
 #include "ur_client_library/ur/robot_receive_timeout.h"
+#include "ur_robot_driver/robot_mode_data_consumer.hpp"
 #include "ur_robot_driver/dashboard_client_ros.hpp"
 #include "ur_dashboard_msgs/msg/robot_mode.hpp"
+#include "ur_msgs/msg/robot_mode_data_msg.hpp"
 
 // ROS
 #include "rclcpp/macros.hpp"
@@ -171,9 +176,6 @@ public:
 
   static constexpr double NO_NEW_CMD_ = std::numeric_limits<double>::quiet_NaN();
 
-  // Not reported by UR; set by this driver when the primary interface has not
-  // yet delivered a RobotModeData package.
-  static constexpr uint8_t CONTROL_MODE_UNKNOWN_ = 255;
   void asyncThread();
 
 protected:
@@ -234,7 +236,7 @@ protected:
   double target_speed_fraction_;
   double speed_scaling_combined_;
   int32_t robot_mode_;
-  uint8_t robot_control_mode_ = CONTROL_MODE_UNKNOWN_;
+  uint8_t robot_control_mode_ = ur_msgs::msg::RobotModeDataMsg::CONTROL_MODE_UNKNOWN;
   int32_t safety_mode_;
   std::bitset<4> robot_status_bits_;
   std::bitset<11> safety_status_bits_;
@@ -367,7 +369,7 @@ protected:
   double safety_mode_copy_;
   std::array<double, 4> robot_status_bits_copy_;
   std::array<double, 11> safety_status_bits_copy_;
-  double robot_control_mode_copy_ = CONTROL_MODE_UNKNOWN_;
+  double robot_control_mode_copy_ = ur_msgs::msg::RobotModeDataMsg::CONTROL_MODE_UNKNOWN;
   std::atomic<bool> robot_program_running_;
   std::atomic<bool> stop_requested_;
   bool non_blocking_read_;
@@ -393,6 +395,8 @@ protected:
 
   std::shared_ptr<urcl::UrDriver> ur_driver_;  // changed to shared_ptr for instruction_executer
   std::shared_ptr<std::thread> async_thread_;
+
+  std::shared_ptr<RobotModeDataConsumer> robot_mode_consumer_;
 
   std::atomic_bool rtde_comm_has_been_started_ = false;
 

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -171,6 +171,9 @@ public:
 
   static constexpr double NO_NEW_CMD_ = std::numeric_limits<double>::quiet_NaN();
 
+  // Not reported by UR; set by this driver when the primary interface has not
+  // yet delivered a RobotModeData package.
+  static constexpr uint8_t CONTROL_MODE_UNKNOWN_ = 255;
   void asyncThread();
 
 protected:
@@ -231,6 +234,7 @@ protected:
   double target_speed_fraction_;
   double speed_scaling_combined_;
   int32_t robot_mode_;
+  uint8_t robot_control_mode_ = CONTROL_MODE_UNKNOWN_;
   int32_t safety_mode_;
   std::bitset<4> robot_status_bits_;
   std::bitset<11> safety_status_bits_;
@@ -363,7 +367,7 @@ protected:
   double safety_mode_copy_;
   std::array<double, 4> robot_status_bits_copy_;
   std::array<double, 11> safety_status_bits_copy_;
-
+  double robot_control_mode_copy_ = CONTROL_MODE_UNKNOWN_;
   std::atomic<bool> robot_program_running_;
   std::atomic<bool> stop_requested_;
   bool non_blocking_read_;

--- a/ur_robot_driver/include/ur_robot_driver/robot_mode_data_consumer.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/robot_mode_data_consumer.hpp
@@ -1,0 +1,70 @@
+// Copyright 2026, Arthur Haffemayer
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+  /*!\file
+   *
+   * \author  Arthur Haffemayer <arthur.haffemayer@gmail.com>
+   * \date    2026-08-03
+   *
+   */
+
+#ifndef UR_ROBOT_DRIVER__ROBOT_MODE_DATA_CONSUMER_HPP_
+#define UR_ROBOT_DRIVER__ROBOT_MODE_DATA_CONSUMER_HPP_
+
+#include <atomic>
+#include <cstdint>
+
+#include "ur_client_library/primary/primary_consumer.h"
+#include "ur_client_library/primary/robot_state/robot_mode_data.h"
+#include "ur_msgs/msg/robot_mode_data_msg.hpp"
+
+namespace ur_robot_driver
+{
+/*!
+ * \brief Receives the primary interface's RobotModeData into a lock-free buffer.
+ *
+ * Registered against the PrimaryClient so that its receive thread writes here directly.
+ */
+class RobotModeDataConsumer : public urcl::primary_interface::PrimaryConsumer
+{
+public:
+  bool consume(urcl::primary_interface::RobotModeData& pkg) override
+  {
+    control_mode_.store(pkg.control_mode_, std::memory_order_relaxed);
+    return true;
+  }
+  uint8_t control_mode() const
+  {
+    return control_mode_.load(std::memory_order_relaxed);
+  }
+
+private:
+  std::atomic<uint8_t> control_mode_{ ur_msgs::msg::RobotModeDataMsg::CONTROL_MODE_UNKNOWN };
+};
+}  // namespace ur_robot_driver
+#endif  // UR_ROBOT_DRIVER__ROBOT_MODE_DATA_CONSUMER_HPP_

--- a/ur_robot_driver/launch/ur_control.launch.py
+++ b/ur_robot_driver/launch/ur_control.launch.py
@@ -156,6 +156,7 @@ def launch_setup(context):
             {
                 "consistent_controllers": [
                     "io_and_status_controller",
+                    "ur_robot_mode_broadcaster",
                     "force_torque_sensor_broadcaster",
                     "joint_state_broadcaster",
                     "speed_scaling_state_broadcaster",
@@ -213,6 +214,7 @@ def launch_setup(context):
         "joint_state_broadcaster",
         "io_and_status_controller",
         "speed_scaling_state_broadcaster",
+        "ur_robot_mode_broadcaster",
         "force_torque_sensor_broadcaster",
         "tcp_pose_broadcaster",
         "ur_configuration_controller",

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -46,7 +46,6 @@
 #include <vector>
 
 #include "ur_client_library/exceptions.h"
-#include "ur_client_library/primary/robot_state/robot_mode_data.h"
 #include "ur_client_library/ur/tool_communication.h"
 #include "ur_client_library/ur/version_information.h"
 #include "ur_client_library/ur/robot_receive_timeout.h"
@@ -824,6 +823,8 @@ URPositionHardwareInterface::on_configure(const rclcpp_lifecycle::State& previou
     if (ur_driver_->getControlFrequency() != info_.rw_rate) {
       ur_driver_->resetRTDEClient(output_recipe_filename, input_recipe_filename, info_.rw_rate);
     }
+    robot_mode_consumer_ = std::make_shared<RobotModeDataConsumer>();
+    ur_driver_->getPrimaryClient()->addPrimaryConsumer(robot_mode_consumer_);
     data_package_buffer_ = std::make_unique<rtde::DataPackage>(ur_driver_->getRTDEOutputRecipe());
   } catch (urcl::ToolCommNotAvailable& e) {
     RCLCPP_FATAL_STREAM(rclcpp::get_logger("URPositionHardwareInterface"), "See parameter use_tool_communication");
@@ -944,6 +945,10 @@ hardware_interface::CallbackReturn URPositionHardwareInterface::stop()
     async_moprim_cmd_thread_.reset();
   }
 
+  if (ur_driver_ && robot_mode_consumer_) {
+    ur_driver_->getPrimaryClient()->removePrimaryConsumer(robot_mode_consumer_);
+    robot_mode_consumer_.reset();
+  }
   instruction_executor_.reset();
   ur_driver_.reset();
 
@@ -1029,11 +1034,8 @@ hardware_interface::return_type URPositionHardwareInterface::read(const rclcpp::
     readData(data_package_buffer_, "payload", rtde_payload_mass_);
     readData(data_package_buffer_, "payload_cog", rtde_payload_cog_);
     readData(data_package_buffer_, "payload_inertia", rtde_payload_inertia_);
-    // Not part of the RTDE package: the primary interface delivers RobotModeData
-    // at ~10 Hz on its own connection. Null until the first package arrives.
-    if (auto robot_mode_data = ur_driver_->getPrimaryClient()->getRobotModeData()) {
-      robot_control_mode_ = robot_mode_data->control_mode_;
-    }
+    // RobotModeDataConsumer is registered against the primary client, so it writes the atomic directly at ~10 Hz
+    robot_control_mode_ = robot_mode_consumer_->control_mode();
 
     // required transforms
     extractToolPose();

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -46,6 +46,7 @@
 #include <vector>
 
 #include "ur_client_library/exceptions.h"
+#include "ur_client_library/primary/robot_state/robot_mode_data.h"
 #include "ur_client_library/ur/tool_communication.h"
 #include "ur_client_library/ur/version_information.h"
 #include "ur_client_library/ur/robot_receive_timeout.h"
@@ -357,6 +358,9 @@ std::vector<hardware_interface::StateInterface> URPositionHardwareInterface::exp
 
   state_interfaces.emplace_back(
       hardware_interface::StateInterface(tf_prefix + "gpio", "robot_mode", &robot_mode_copy_));
+
+  state_interfaces.emplace_back(
+      hardware_interface::StateInterface(tf_prefix + "gpio", "robot_control_mode", &robot_control_mode_copy_));
 
   state_interfaces.emplace_back(
       hardware_interface::StateInterface(tf_prefix + "gpio", "safety_mode", &safety_mode_copy_));
@@ -1025,6 +1029,11 @@ hardware_interface::return_type URPositionHardwareInterface::read(const rclcpp::
     readData(data_package_buffer_, "payload", rtde_payload_mass_);
     readData(data_package_buffer_, "payload_cog", rtde_payload_cog_);
     readData(data_package_buffer_, "payload_inertia", rtde_payload_inertia_);
+    // Not part of the RTDE package: the primary interface delivers RobotModeData
+    // at ~10 Hz on its own connection. Null until the first package arrives.
+    if (auto robot_mode_data = ur_driver_->getPrimaryClient()->getRobotModeData()) {
+      robot_control_mode_ = robot_mode_data->control_mode_;
+    }
 
     // required transforms
     extractToolPose();
@@ -1339,6 +1348,7 @@ void URPositionHardwareInterface::updateNonDoubleValues()
 
   tool_output_voltage_copy_ = static_cast<double>(tool_output_voltage_);
   robot_mode_copy_ = static_cast<double>(robot_mode_);
+  robot_control_mode_copy_ = static_cast<double>(robot_control_mode_);
   safety_mode_copy_ = static_cast<double>(safety_mode_);
   tool_mode_copy_ = static_cast<double>(tool_mode_);
   system_interface_initialized_ = initialized_ ? 1.0 : 0.0;

--- a/ur_robot_driver/urdf/ur.ros2_control.xacro
+++ b/ur_robot_driver/urdf/ur.ros2_control.xacro
@@ -187,6 +187,7 @@
         <state_interface name="tool_analog_input_type_1"/>
 
         <state_interface name="robot_mode"/>
+        <state_interface name="robot_control_mode"/>
         <state_interface name="robot_status_bit_0"/>
         <state_interface name="robot_status_bit_1"/>
         <state_interface name="robot_status_bit_2"/>


### PR DESCRIPTION
Partial implementation of #1658. Step 1-3.5 of the plan. Opening as a draft to check direction before I do the message and finish the broadcaster.

### Content

RobotModeData is read from the primary client in read() and control_mode exposed as gpio/robot_control_mode.

Verified in URSim, 0 at rest, 1 in freedrive, 2 in force mode.

However I have 4 questions: 

- I used `getRobotModeData()` rather than `getRobotMode()`, so the broadcaster can fill the whole `RobotModeDataMsg` from one call. Also robot_mode alone is already on gpio/robot_mode from RTDE. Does that match your intent?
- There's no ControlMode enum in ur_client_library; control_mode_ is a bare uint8_t. Would you prefer one added there alongside RobotMode, or just constants in `ur_msgs/RobotModeDataMsg`?
- `getRobotModeData()` returns null until the first package arrives, so I need a "not received yet" value. Currently a local CONTROL_MODE_UNKNOWN_ = 255. Should that live in RobotModeDataMsg instead so consumers can test for it?
-  getRobotModeData() takes a mutex and a copy on every call, and read() runs at 500 Hz against a source that updates at ~10 Hz if I understood correctly. Should we move it to asyncThread instead? 

### To do
RobotModeDataMsg fields + constants, ur_robot_mode_broadcaster, docs, tests, example, real-hardware check.