### PR TITLE
Report operational status with mock hardware

### DIFF
--- a/ur_robot_driver/test/test_mock_hardware.py
+++ b/ur_robot_driver/test/test_mock_hardware.py
@@ -37,8 +37,11 @@ import pytest
 import rclpy
 from geometry_msgs.msg import Inertia, Vector3
 from rclpy.node import Node
+from rclpy.qos import DurabilityPolicy, QoSProfile, ReliabilityPolicy
 from control_msgs.action import FollowJointTrajectory
 from controller_manager_msgs.srv import SwitchController
+from std_msgs.msg import Bool
+from ur_dashboard_msgs.msg import RobotMode, SafetyMode
 
 sys.path.append(os.path.dirname(__file__))
 from test_common import (  # noqa: E402
@@ -99,6 +102,46 @@ class MockHWTest(unittest.TestCase):
         self.assertEqual(
             self._configuration_controller_interface.get_robot_software_version().major, 1
         )
+
+    def test_mock_hardware_publishes_operational_status(self):
+        """Mock hardware reports deterministic happy-path status on latched topics."""
+        messages = {}
+        qos = QoSProfile(
+            depth=1,
+            durability=DurabilityPolicy.TRANSIENT_LOCAL,
+            reliability=ReliabilityPolicy.RELIABLE,
+        )
+        subscriptions = [
+            self.node.create_subscription(
+                RobotMode,
+                "/io_and_status_controller/robot_mode",
+                lambda msg: messages.setdefault("robot_mode", msg.mode),
+                qos,
+            ),
+            self.node.create_subscription(
+                SafetyMode,
+                "/io_and_status_controller/safety_mode",
+                lambda msg: messages.setdefault("safety_mode", msg.mode),
+                qos,
+            ),
+            self.node.create_subscription(
+                Bool,
+                "/io_and_status_controller/robot_program_running",
+                lambda msg: messages.setdefault("program_running", msg.data),
+                qos,
+            ),
+        ]
+
+        deadline = time.monotonic() + 10.0
+        while len(messages) < 3 and time.monotonic() < deadline:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.assertEqual(messages.get("robot_mode"), RobotMode.RUNNING)
+        self.assertEqual(messages.get("safety_mode"), SafetyMode.NORMAL)
+        self.assertIs(messages.get("program_running"), True)
+
+        for subscription in subscriptions:
+            self.node.destroy_subscription(subscription)
 
     def test_start_jtc_controller(self):
         # Deactivate controller, if it is not already

--- a/ur_robot_driver/urdf/ur.ros2_control.xacro
+++ b/ur_robot_driver/urdf/ur.ros2_control.xacro
@@ -186,13 +186,21 @@
         <state_interface name="tool_analog_input_type_0"/>
         <state_interface name="tool_analog_input_type_1"/>
 
-        <state_interface name="robot_mode"/>
+        <state_interface name="robot_mode">
+          <xacro:if value="${use_mock_hardware}">
+            <param name="initial_value">7</param>
+          </xacro:if>
+        </state_interface>
         <state_interface name="robot_status_bit_0"/>
         <state_interface name="robot_status_bit_1"/>
         <state_interface name="robot_status_bit_2"/>
         <state_interface name="robot_status_bit_3"/>
 
-        <state_interface name="safety_mode"/>
+        <state_interface name="safety_mode">
+          <xacro:if value="${use_mock_hardware}">
+            <param name="initial_value">1</param>
+          </xacro:if>
+        </state_interface>
         <state_interface name="safety_status_bit_0"/>
         <state_interface name="safety_status_bit_1"/>
         <state_interface name="safety_status_bit_2"/>
@@ -205,7 +213,11 @@
         <state_interface name="safety_status_bit_9"/>
         <state_interface name="safety_status_bit_10"/>
 
-        <state_interface name="program_running"/>
+        <state_interface name="program_running">
+          <xacro:if value="${use_mock_hardware}">
+            <param name="initial_value">1</param>
+          </xacro:if>
+        </state_interface>
       </gpio>
 
       <gpio name="${tf_prefix}payload">


### PR DESCRIPTION
## What changed
- initializes mock `robot_mode`, `safety_mode`, and `program_running` state interfaces to RUNNING, NORMAL, and true
- keeps those defaults conditional on `use_mock_hardware`, so real hardware behavior is unchanged
- adds a launch-test assertion against all three latched controller topics

## Why
The GPIO controller already publishes these ordinary state interfaces, but GenericSystem previously initialized them to zero. Mock launches therefore reported disconnected/undefined status and could not support diagnostics tests.

## Impact
This provides deterministic happy-path status for mock hardware without adding mock-specific branches to the production GPIO controller.

## Checks
- repository pre-commit suite passed for both changed files (XML, Black, Flake8, pydocstyle, codespell, copyright, and standard hooks)
- `xmllint --noout`
- Python byte-compilation
- ROS 2 is not installed on the local macOS host, so the launch test is left for hosted ROS CI

Closes #976

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are gated on `use_mock_hardware` in xacro and a test-only assertion; real robot hardware paths are untouched.
> 
> **Overview**
> Mock launches previously exposed **disconnected / zero** values on `io_and_status_controller` status topics because `GenericSystem` defaulted GPIO state interfaces to 0. This PR seeds **`robot_mode`**, **`safety_mode`**, and **`program_running`** with happy-path values (**RUNNING**, **NORMAL**, **true**) in `ur.ros2_control.xacro`, only when **`use_mock_hardware`** is enabled.
> 
> A new mock-hardware launch test subscribes to the three latched topics and asserts those values, so diagnostics and CI can rely on stable operational status without mock-specific logic in the GPIO controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8afbdb1b2df236534266ea68ab21c0a1e76cf6d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->