### PR TITLE
Add srdf tf prefix

### DIFF
--- a/ur_moveit_config/CMakeLists.txt
+++ b/ur_moveit_config/CMakeLists.txt
@@ -3,6 +3,12 @@ project(ur_moveit_config)
 
 find_package(ament_cmake REQUIRED)
 
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+
+  ament_add_pytest_test(test_srdf_tf_prefix test/test_srdf_tf_prefix.py)
+endif()
+
 ament_package()
 
 install(

--- a/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/ur_moveit_config/launch/ur_moveit.launch.py
@@ -103,6 +103,12 @@ def declare_arguments():
                 default_value="true",
                 description="MoveGroup publishes robot description semantic",
             ),
+            DeclareLaunchArgument(
+                "tf_prefix",
+                default_value="",
+                description="Prefix of the joint names, useful for multi-robot setup. "
+                "Must match the tf_prefix used to generate the robot description (URDF).",
+            ),
         ]
     )
 
@@ -114,10 +120,13 @@ def generate_launch_description():
     launch_servo = LaunchConfiguration("launch_servo")
     use_sim_time = LaunchConfiguration("use_sim_time")
     publish_robot_description_semantic = LaunchConfiguration("publish_robot_description_semantic")
+    tf_prefix = LaunchConfiguration("tf_prefix")
 
     moveit_config = (
         MoveItConfigsBuilder(robot_name="ur", package_name="ur_moveit_config")
-        .robot_description_semantic(Path("srdf") / "ur.srdf.xacro", {"name": ur_type})
+        .robot_description_semantic(
+            Path("srdf") / "ur.srdf.xacro", {"name": ur_type, "tf_prefix": tf_prefix}
+        )
         .to_moveit_configs()
     )
 

--- a/ur_moveit_config/package.xml
+++ b/ur_moveit_config/package.xml
@@ -35,6 +35,10 @@
   <exec_depend>warehouse_ros_sqlite</exec_depend>
   <exec_depend>xacro</exec_depend>
 
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>python3-pytest</test_depend>
+  <test_depend>ur_robot_driver</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/ur_moveit_config/srdf/ur.srdf.xacro
+++ b/ur_moveit_config/srdf/ur.srdf.xacro
@@ -4,8 +4,11 @@
   <!-- robot name parameter -->
   <xacro:arg name="name" default="ur"/>
 
+  <!-- parameters -->
+  <xacro:arg name="tf_prefix" default="" />
+
   <xacro:include filename="$(find ur_moveit_config)/srdf/ur_macro.srdf.xacro"/>
 
-  <xacro:ur_srdf/>
+  <xacro:ur_srdf tf_prefix="$(arg tf_prefix)"/>
 
 </robot>

--- a/ur_moveit_config/srdf/ur_macro.srdf.xacro
+++ b/ur_moveit_config/srdf/ur_macro.srdf.xacro
@@ -4,54 +4,54 @@
     This is a format for representing semantic information about the robot structure.
     A URDF file must exist for this robot as well, where the joints and the links that are referenced are defined
 -->
-  <xacro:macro name="ur_srdf" params="">
+  <xacro:macro name="ur_srdf" params="tf_prefix=''">
     <!--GROUPS - Representation of a set of joints and links. This can be useful for specifying DOF to plan for, defining arms, end effectors, etc-->
     <!--LINKS - When a link is specified, the parent joint of that link (if it exists) is automatically included-->
     <!--JOINTS - When a joint is specified, the child link of that joint (which will always exist) is automatically included-->
     <!--CHAINS - When a chain is specified, all the links along the chain (including endpoints) are included in the group. Additionally, all the joints that are parents to included links are also included. This means that joints along the chain and the parent joint of the base link are included in the group-->
     <!--SUBGROUPS - Groups can also be formed by referencing to already defined group names-->
     <group name="ur_manipulator">
-      <chain base_link="base_link" tip_link="tool0" />
+      <chain base_link="${tf_prefix}base_link" tip_link="${tf_prefix}tool0" />
     </group>
     <!--GROUP STATES - Purpose - Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="home" group="ur_manipulator">
-      <joint name="elbow_joint" value="0" />
-      <joint name="shoulder_lift_joint" value="-1.5707" />
-      <joint name="shoulder_pan_joint" value="0" />
-      <joint name="wrist_1_joint" value="0" />
-      <joint name="wrist_2_joint" value="0" />
-      <joint name="wrist_3_joint" value="0" />
+      <joint name="${tf_prefix}elbow_joint" value="0" />
+      <joint name="${tf_prefix}shoulder_lift_joint" value="-1.5707" />
+      <joint name="${tf_prefix}shoulder_pan_joint" value="0" />
+      <joint name="${tf_prefix}wrist_1_joint" value="0" />
+      <joint name="${tf_prefix}wrist_2_joint" value="0" />
+      <joint name="${tf_prefix}wrist_3_joint" value="0" />
     </group_state>
     <group_state name="up" group="ur_manipulator">
-      <joint name="elbow_joint" value="0" />
-      <joint name="shoulder_lift_joint" value="-1.5707" />
-      <joint name="shoulder_pan_joint" value="0" />
-      <joint name="wrist_1_joint" value="-1.5707" />
-      <joint name="wrist_2_joint" value="0" />
-      <joint name="wrist_3_joint" value="0" />
+      <joint name="${tf_prefix}elbow_joint" value="0" />
+      <joint name="${tf_prefix}shoulder_lift_joint" value="-1.5707" />
+      <joint name="${tf_prefix}shoulder_pan_joint" value="0" />
+      <joint name="${tf_prefix}wrist_1_joint" value="-1.5707" />
+      <joint name="${tf_prefix}wrist_2_joint" value="0" />
+      <joint name="${tf_prefix}wrist_3_joint" value="0" />
     </group_state>
     <group_state name="test_configuration" group="ur_manipulator">
-      <joint name="elbow_joint" value="1.4" />
-      <joint name="shoulder_lift_joint" value="-1.62" />
-      <joint name="shoulder_pan_joint" value="1.54" />
-      <joint name="wrist_1_joint" value="-1.2" />
-      <joint name="wrist_2_joint" value="-1.6" />
-      <joint name="wrist_3_joint" value="-0.11" />
+      <joint name="${tf_prefix}elbow_joint" value="1.4" />
+      <joint name="${tf_prefix}shoulder_lift_joint" value="-1.62" />
+      <joint name="${tf_prefix}shoulder_pan_joint" value="1.54" />
+      <joint name="${tf_prefix}wrist_1_joint" value="-1.2" />
+      <joint name="${tf_prefix}wrist_2_joint" value="-1.6" />
+      <joint name="${tf_prefix}wrist_3_joint" value="-0.11" />
     </group_state>
     <!--END EFFECTOR - Purpose - Represent information about an end effector.-->
     <!--VIRTUAL JOINT - Purpose - this element defines a virtual joint between a robot link and an external frame of reference (considered fixed with respect to the robot)-->
     <!--DISABLE COLLISIONS - By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
-    <disable_collisions link1="base_link" link2="base_link_inertia" reason="Adjacent" />
-    <disable_collisions link1="base_link_inertia" link2="shoulder_link" reason="Adjacent" />
-    <disable_collisions link1="tool0" link2="wrist_1_link" reason="Never" />
-    <disable_collisions link1="tool0" link2="wrist_2_link" reason="Never" />
-    <disable_collisions link1="tool0" link2="wrist_3_link" reason="Adjacent" />
-    <disable_collisions link1="forearm_link" link2="upper_arm_link" reason="Adjacent" />
-    <disable_collisions link1="forearm_link" link2="wrist_1_link" reason="Adjacent" />
-    <disable_collisions link1="shoulder_link" link2="upper_arm_link" reason="Adjacent" />
-    <disable_collisions link1="wrist_1_link" link2="wrist_2_link" reason="Adjacent" />
-    <disable_collisions link1="wrist_1_link" link2="wrist_3_link" reason="Never" />
-    <disable_collisions link1="wrist_2_link" link2="wrist_3_link" reason="Adjacent" />
+    <disable_collisions link1="${tf_prefix}base_link" link2="${tf_prefix}base_link_inertia" reason="Adjacent" />
+    <disable_collisions link1="${tf_prefix}base_link_inertia" link2="${tf_prefix}shoulder_link" reason="Adjacent" />
+    <disable_collisions link1="${tf_prefix}tool0" link2="${tf_prefix}wrist_1_link" reason="Never" />
+    <disable_collisions link1="${tf_prefix}tool0" link2="${tf_prefix}wrist_2_link" reason="Never" />
+    <disable_collisions link1="${tf_prefix}tool0" link2="${tf_prefix}wrist_3_link" reason="Adjacent" />
+    <disable_collisions link1="${tf_prefix}forearm_link" link2="${tf_prefix}upper_arm_link" reason="Adjacent" />
+    <disable_collisions link1="${tf_prefix}forearm_link" link2="${tf_prefix}wrist_1_link" reason="Adjacent" />
+    <disable_collisions link1="${tf_prefix}shoulder_link" link2="${tf_prefix}upper_arm_link" reason="Adjacent" />
+    <disable_collisions link1="${tf_prefix}wrist_1_link" link2="${tf_prefix}wrist_2_link" reason="Adjacent" />
+    <disable_collisions link1="${tf_prefix}wrist_1_link" link2="${tf_prefix}wrist_3_link" reason="Never" />
+    <disable_collisions link1="${tf_prefix}wrist_2_link" link2="${tf_prefix}wrist_3_link" reason="Adjacent" />
 
   </xacro:macro>
 </robot>

--- a/ur_moveit_config/test/test_srdf_tf_prefix.py
+++ b/ur_moveit_config/test/test_srdf_tf_prefix.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python
+# Copyright 2026, Universal Robots A/S
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""
+Unit tests for the ``tf_prefix`` support in the MoveIt SRDF.
+
+These tests expand the SRDF (and, for the consistency check, the driver URDF)
+with xacro and inspect the resulting names. They guard against a regression of
+the fix for the case where the SRDF hardcoded unprefixed link/joint names while
+the URDF supports a ``tf_prefix`` (see the "Joint prefix supported in URDF, but
+not in MoveIt SRDF" issue): with a non-empty prefix MoveIt could not build the
+``ur_manipulator`` group because the SRDF referenced joints/links that did not
+exist in the URDF.
+
+The tests only perform static xacro expansion, so they do not require URSim or a
+running MoveIt instance and run as part of the regular (non-integration) test
+set.
+"""
+
+import os
+import xml.etree.ElementTree as ET
+
+import pytest
+import xacro
+from ament_index_python.packages import get_package_share_directory
+
+
+def _expand_xacro(path, mappings):
+    """Expand a xacro file with the given mappings and return the XML root."""
+    doc = xacro.process_file(path, mappings=mappings)
+    return ET.fromstring(doc.toxml())
+
+
+def _srdf_path():
+    return os.path.join(get_package_share_directory("ur_moveit_config"), "srdf", "ur.srdf.xacro")
+
+
+def _urdf_path():
+    return os.path.join(get_package_share_directory("ur_robot_driver"), "urdf", "ur.urdf.xacro")
+
+
+def _srdf_referenced_names(root):
+    """Collect every link/joint name referenced by the SRDF.
+
+    This covers the chain endpoints, the joints listed in the group states and
+    the link pairs in the ``disable_collisions`` entries -- i.e. all names that
+    must exist in the URDF for MoveIt to accept the SRDF.
+    """
+    names = set()
+    for chain in root.iter("chain"):
+        names.add(chain.get("base_link"))
+        names.add(chain.get("tip_link"))
+    for group_state in root.iter("group_state"):
+        for joint in group_state.iter("joint"):
+            names.add(joint.get("name"))
+    for disable in root.iter("disable_collisions"):
+        names.add(disable.get("link1"))
+        names.add(disable.get("link2"))
+    names.discard(None)
+    return names
+
+
+def _urdf_names(root):
+    """Collect every link and joint name defined in the URDF."""
+    names = set()
+    for link in root.iter("link"):
+        names.add(link.get("name"))
+    for joint in root.iter("joint"):
+        names.add(joint.get("name"))
+    names.discard(None)
+    return names
+
+
+@pytest.mark.parametrize("tf_prefix", ["", "test_"])
+def test_srdf_prefixing(tf_prefix):
+    """The SRDF must apply ``tf_prefix`` to every referenced link and joint."""
+    root = _expand_xacro(_srdf_path(), {"name": "ur", "tf_prefix": tf_prefix})
+    referenced = _srdf_referenced_names(root)
+
+    assert referenced, "No link/joint references found in the expanded SRDF"
+
+    if tf_prefix:
+        unprefixed = sorted(n for n in referenced if not n.startswith(tf_prefix))
+        assert not unprefixed, f"SRDF names missing the '{tf_prefix}' prefix: {unprefixed}"
+    else:
+        # Regression guard: with an empty prefix no name may accidentally carry a
+        # prefix, and the previously broken behaviour (dropped prefixing) must
+        # keep producing the plain names.
+        prefixed = sorted(n for n in referenced if n.startswith("test_"))
+        assert not prefixed, f"Unexpected prefixed SRDF names with empty prefix: {prefixed}"
+
+    # The group name is intentionally kept unprefixed so that the shipped
+    # configs (kinematics.yaml, ur_servo.yaml, moveit.rviz) keep working.
+    group_names = {group.get("name") for group in root.iter("group")}
+    assert "ur_manipulator" in group_names
+
+
+@pytest.mark.parametrize("tf_prefix", ["", "test_"])
+def test_srdf_matches_urdf(tf_prefix):
+    """Every link/joint referenced by the SRDF must exist in the URDF.
+
+    This reproduces the exact failure from the issue ("joints/links referenced
+    in the SRDF are not known to the URDF") without launching MoveIt.
+    """
+    srdf_root = _expand_xacro(_srdf_path(), {"name": "ur", "tf_prefix": tf_prefix})
+    urdf_root = _expand_xacro(
+        _urdf_path(), {"name": "ur", "ur_type": "ur5e", "tf_prefix": tf_prefix}
+    )
+
+    referenced = _srdf_referenced_names(srdf_root)
+    urdf_names = _urdf_names(urdf_root)
+
+    missing = sorted(referenced - urdf_names)
+    assert not missing, (
+        f"SRDF references names unknown to the URDF for tf_prefix='{tf_prefix}': {missing}"
+    )


### PR DESCRIPTION
Add tf_prefix support to MoveIt SRDF
The URDF supports a tf_prefix parameter to prefix all link and joint
names, but the MoveIt SRDF hardcoded the unprefixed names. As a result,
using a non-empty tf_prefix caused MoveIt to fail building the
ur_manipulator group because the referenced joints/links did not exist
in the URDF.

Thread a tf_prefix parameter (default empty, fully backward compatible)
through the SRDF macro, its wrapper, and the ur_moveit.launch.py launch
file so the SRDF link/joint references match the generated URDF.

Ref https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1937