### PR TITLE
Set command interface in tool contact controller

### DIFF
--- a/ur_controllers/src/tool_contact_controller.cpp
+++ b/ur_controllers/src/tool_contact_controller.cpp
@@ -356,6 +356,9 @@ controller_interface::return_type ToolContactController::update(const rclcpp::Ti
           active_goal->setAborted(result);
           should_reset_goal = true;
         }
+      } else {
+        // Set command interface, so "startToolContact" is only sent once in the hardware interface
+        write_success &= tool_contact_set_state_interface_->get().set_value(TOOL_CONTACT_EXECUTING);
       }
     } break;
 


### PR DESCRIPTION
Previously, when a tool contact action was accepted and executed, the command interface would stay at TOOL_CONTACT_WAITING_BEGIN, and trigger startToolContact from the hardware interface every write cycle. The command interface is now set to TOOL_CONTACT_EXECUTING when the hardware interface has confirmed it is started. Not sure if this is what was causing flakiness, but it is definitely a bug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2ce1326de2307bffdcb841152d81fd6071f7b604. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->