### PR TITLE
Fix flaky quintic spline test in passthrough controller

### DIFF
--- a/ur_controllers/doc/index.rst
+++ b/ur_controllers/doc/index.rst
@@ -128,6 +128,10 @@ filled with all joint names.
 A **goal time tolerance** of ``0.0`` means that no goal time tolerance is set and the action will
 not fail when execution takes too long.
 
+A goal tolerance of ``0.0`` disables the corresponding tolerance check. For example, a
+position tolerance of ``0.0`` means that the final joint position is not checked. The same
+applies to velocity and acceleration tolerances.
+
 Action interface / usage
 """"""""""""""""""""""""
 

--- a/ur_controllers/src/passthrough_trajectory_controller.cpp
+++ b/ur_controllers/src/passthrough_trajectory_controller.cpp
@@ -796,14 +796,15 @@ bool PassthroughTrajectoryController::check_goal_tolerance()
     if (!joint_pos.has_value()) {
       return false;
     }
-    if (std::abs(joint_pos.value() - setpoint) > joint_tol.position) {
+    if (joint_tol.position != 0.0 && std::abs(joint_pos.value() - setpoint) > joint_tol.position) {
       // RCLCPP_ERROR(
       // get_node()->get_logger(), "Joint %s should be at position %f, but is at position %f, where tolerance is %f",
       // joint_position_state_interface_[i].get().get_name().c_str(), setpoint, joint_pos, joint_tol.position);
       return false;
     }
 
-    if (!active_joint_traj_.points.back().velocities.empty() && !joint_velocity_state_interface_.empty()) {
+    if (joint_tol.velocity != 0.0 && !active_joint_traj_.points.back().velocities.empty() &&
+        !joint_velocity_state_interface_.empty()) {
       const auto joint_vel = joint_velocity_state_interface_[i].get().get_optional();
       if (!joint_vel.has_value()) {
         return false;
@@ -813,7 +814,8 @@ bool PassthroughTrajectoryController::check_goal_tolerance()
         return false;
       }
     }
-    if (!active_joint_traj_.points.back().accelerations.empty() && !joint_acceleration_state_interface_.empty()) {
+    if (joint_tol.acceleration != 0.0 && !active_joint_traj_.points.back().accelerations.empty() &&
+        !joint_acceleration_state_interface_.empty()) {
       const auto joint_acc = joint_acceleration_state_interface_[i].get().get_optional();
       if (!joint_acc.has_value()) {
         return false;

--- a/ur_robot_driver/test/integration_test_passthrough_controller.py
+++ b/ur_robot_driver/test/integration_test_passthrough_controller.py
@@ -231,7 +231,8 @@ class PassthroughControllerTest(unittest.TestCase):
         )
         goal_time_tolerance = Duration(sec=1, nanosec=0)
         goal_tolerance = [
-            JointTolerance(position=0.01, name=tf_prefix + joint) for joint in ROBOT_JOINTS
+            JointTolerance(position=0.01, velocity=0.01, acceleration=0.01, name=tf_prefix + joint)
+            for joint in ROBOT_JOINTS
         ]
         goal_handle = self._passthrough_forward_joint_trajectory.send_goal(
             trajectory=trajectory,

--- a/ur_robot_driver/test/integration_test_passthrough_controller.py
+++ b/ur_robot_driver/test/integration_test_passthrough_controller.py
@@ -310,3 +310,42 @@ class PassthroughControllerTest(unittest.TestCase):
                 activate_controllers=["joint_trajectory_controller"],
             ).ok
         )
+
+    def test_trajectory_with_disabled_tolerances(self, tf_prefix):
+        # Should always succeed
+        self.assertTrue(
+            self._controller_manager_interface.switch_controller(
+                strictness=SwitchController.Request.BEST_EFFORT,
+                activate_controllers=["passthrough_trajectory_controller"],
+                deactivate_controllers=["joint_trajectory_controller"],
+            ).ok
+        )
+        trajectory = JointTrajectory(
+            points=[
+                JointTrajectoryPoint(
+                    positions=pos,
+                    time_from_start=times,
+                    velocities=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                    accelerations=[0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                )
+                for (times, pos) in TEST_TRAJECTORY
+            ],
+            joint_names=[tf_prefix + joint for joint in ROBOT_JOINTS],
+        )
+        goal_time_tolerance = Duration(sec=0, nanosec=0)
+        goal_tolerance = [
+            JointTolerance(position=0.00, velocity=0.00, acceleration=0.00, name=tf_prefix + joint)
+            for joint in ROBOT_JOINTS
+        ]
+        goal_handle = self._passthrough_forward_joint_trajectory.send_goal(
+            trajectory=trajectory,
+            goal_time_tolerance=goal_time_tolerance,
+            goal_tolerance=goal_tolerance,
+        )
+
+        self.assertTrue(goal_handle.accepted)
+        if goal_handle.accepted:
+            result = self._passthrough_forward_joint_trajectory.get_result(
+                goal_handle, TIMEOUT_EXECUTE_TRAJECTORY
+            )
+            self.assertEqual(result.error_code, FollowJointTrajectory.Result.SUCCESSFUL)


### PR DESCRIPTION
Add goal tolerances to both velocities and accelerations. The default of 0.0 is most likely too tight.
Closes #1650 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes end-of-trajectory success/failure semantics for FollowJointTrajectory goals; callers who relied on implicit zero tolerances enforcing exact match may see goals succeed where they previously failed.
> 
> **Overview**
> **Passthrough trajectory controller** now treats a **0.0** position, velocity, or acceleration goal tolerance like goal time tolerance: that axis is **not** checked at the end of execution. Previously, unset/zero velocity and acceleration tolerances still ran end-state checks and could fail trajectories (e.g. flaky quintic spline integration tests).
> 
> Docs in `ur_controllers` describe this behavior. Integration tests set explicit velocity/acceleration tolerances on the quintic case and add **`test_trajectory_with_disabled_tolerances`** to assert success when all joint tolerances are zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f63939d3e061e0be4bf90e27dac27f5cdae2fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->