### PR TITLE
Use `MotionTarget` in motion primitive handling

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -318,6 +318,10 @@ if(BUILD_TESTING)
       TIMEOUT
         800
     )
+    add_launch_test(test/integration_test_motion_primitives.py
+      TIMEOUT
+        800
+    )
     add_launch_test(test/integration_test_io_controller.py
       TIMEOUT
         800

--- a/ur_robot_driver/config/ur_controllers.yaml
+++ b/ur_robot_driver/config/ur_controllers.yaml
@@ -200,6 +200,7 @@ tool_contact_controller:
 motion_primitive_forward_controller:
   ros__parameters:
     tf_prefix: "$(var tf_prefix)"
+    hardware_solves_kinematics: true
 
 gravity_update_controller:
   ros__parameters:

--- a/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/hardware_interface.hpp
@@ -352,6 +352,10 @@ protected:
   bool getMoprimVelAndAcc(const std::array<double, 25>& command, double& velocity, double& acceleration,
                           double& move_time);
   void quaternionToRotVec(double qx, double qy, double qz, double qw, double& rx, double& ry, double& rz);
+  std::vector<double> getCommandSlice(const std::array<double, 25>& command, size_t start, size_t end);
+  urcl::vector6d_t vector6dFromCommand(const std::array<double, 25>& command);
+  urcl::Pose poseFromCommand(const std::array<double, 25>& command);
+  urcl::Pose viaPoseFromCommand(const std::array<double, 25>& command);
 
   const std::string HW_IF_MOTION_PRIMITIVES = "motion_primitive";
   //*************** End Motion primitives stuff ***************

--- a/ur_robot_driver/src/hardware_interface.cpp
+++ b/ur_robot_driver/src/hardware_interface.cpp
@@ -49,6 +49,7 @@
 #include "ur_client_library/ur/tool_communication.h"
 #include "ur_client_library/ur/version_information.h"
 #include "ur_client_library/ur/robot_receive_timeout.h"
+#include "ur_client_library/helpers.h"
 
 #include <rclcpp/logging.hpp>
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
@@ -1868,6 +1869,42 @@ void URPositionHardwareInterface::asyncMoprimCmdThread()
   RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"), "[asyncMoprimCmdThread] Exiting");
 }
 
+std::vector<double> URPositionHardwareInterface::getCommandSlice(const std::array<double, 25>& command, size_t start,
+                                                                 size_t end)
+{
+  std::vector<double> slice;
+  slice.reserve(end - start + 1);
+  for (size_t i = start; i <= end; ++i) {
+    slice.push_back(command[i]);
+  }
+  return slice;
+}
+
+urcl::vector6d_t URPositionHardwareInterface::vector6dFromCommand(const std::array<double, 25>& command)
+{
+  return urcl::vector6d_t{ command[1], command[2], command[3], command[4], command[5], command[6] };
+}
+
+urcl::Pose URPositionHardwareInterface::poseFromCommand(const std::array<double, 25>& command)
+{
+  double rx, ry, rz;
+  quaternionToRotVec(command[10], command[11], command[12], command[13], rx, ry, rz);
+  return urcl::Pose(command[7], command[8], command[9], rx, ry, rz);
+}
+
+urcl::Pose URPositionHardwareInterface::viaPoseFromCommand(const std::array<double, 25>& command)
+{
+  double via_rx, via_ry, via_rz;
+  quaternionToRotVec(command[17], command[18], command[19], command[20], via_rx, via_ry, via_rz);
+  return urcl::Pose(command[14], command[15], command[16], via_rx, via_ry, via_rz);
+}
+
+template <typename Range>
+bool hasNoNaN(const Range& range)
+{
+  return std::none_of(range.begin(), range.end(), [](double i) { return std::isnan(i); });
+}
+
 void URPositionHardwareInterface::processMoprimMotionCmd(const std::array<double, 25>& command)
 {
   if (std::isnan(command[0])) {
@@ -1876,6 +1913,54 @@ void URPositionHardwareInterface::processMoprimMotionCmd(const std::array<double
   double velocity, acceleration, move_time;
   double motion_type = command[0];
   double blend_radius = command[21];
+
+  urcl::MotionTarget target_command = urcl::Pose();
+  urcl::MotionTarget via_command = urcl::Pose();
+
+  bool joints_valid = false;
+  bool pose_valid = false;
+  bool via_valid = false;
+
+  // Check if joint angles in command are valid
+  const auto joint_angles = vector6dFromCommand(command);
+  if (hasNoNaN(joint_angles)) {
+    joints_valid = true;
+    target_command = urcl::Q(joint_angles);
+  }
+
+  // Check if pose in command is valid
+  const auto pose_slice = getCommandSlice(command, 7, 13);
+  if (hasNoNaN(pose_slice)) {
+    pose_valid = true;
+    target_command = poseFromCommand(command);
+  }
+
+  // Check if via pose in command is valid
+  const auto via_slice = getCommandSlice(command, 14, 20);
+  if (hasNoNaN(via_slice)) {
+    via_valid = true;
+    via_command = viaPoseFromCommand(command);
+  }
+
+  // Not a control message
+  if (static_cast<uint8_t>(motion_type) != static_cast<uint8_t>(MoprimMotionHelperType::MOTION_SEQUENCE_END) &&
+      static_cast<uint8_t>(motion_type) != static_cast<uint8_t>(MoprimMotionHelperType::MOTION_SEQUENCE_START)) {
+    // If neither pose nor joints are valid, something is wrong
+    if (!pose_valid && !joints_valid) {
+      RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Invalid motion command: both joint positions "
+                                                                      "and pose contain NaN values");
+      current_moprim_execution_status_ = MoprimExecutionState::ERROR;
+      return;
+    }
+    // Same if both are valid
+    if (pose_valid && joints_valid) {
+      RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Invalid motion command: both joint positions "
+                                                                      "and pose contain non-NaN values. Command is "
+                                                                      "ambiguous, only one should be defined");
+      current_moprim_execution_status_ = MoprimExecutionState::ERROR;
+      return;
+    }
+  }
 
   try {
     switch (static_cast<uint8_t>(motion_type)) {
@@ -1905,17 +1990,6 @@ void URPositionHardwareInterface::processMoprimMotionCmd(const std::array<double
 
       case MoprimMotionType::LINEAR_JOINT:
       {  // moveJ
-        // Check if joint positions are valid
-        for (int i = 1; i <= 6; ++i) {
-          if (std::isnan(command[i])) {
-            RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Invalid motion command: joint positions "
-                                                                            "contain NaN values");
-            current_moprim_execution_status_ = MoprimExecutionState::ERROR;
-            return;
-          }
-        }
-        urcl::vector6d_t joint_positions = { command[1], command[2], command[3], command[4], command[5], command[6] };
-
         // Get move_time OR (velocity AND acceleration)
         if (!getMoprimTimeOrVelAndAcc(command, velocity, acceleration, move_time)) {
           RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Invalid move_time, velocity or acceleration "
@@ -1927,22 +2001,23 @@ void URPositionHardwareInterface::processMoprimMotionCmd(const std::array<double
         // Check if the command is part of a motion sequence or a single command
         if (build_moprim_sequence_) {  // Add command to motion sequence
           moprim_sequence_.emplace_back(std::make_shared<urcl::control::MoveJPrimitive>(
-              joint_positions, blend_radius, std::chrono::milliseconds(static_cast<int>(move_time * 1000)),
-              acceleration, velocity));
+              target_command, blend_radius, std::chrono::milliseconds(static_cast<int>(move_time * 1000)), acceleration,
+              velocity));
+
           RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"),
-                      "Added moveJ to motion sequence with joint positions: [%f, %f, %f, %f, %f, %f], "
+                      "Added moveJ to motion sequence with: %s, "
                       "velocity: %f, acceleration: %f, move_time: %f, blend_radius: %f",
-                      joint_positions[0], joint_positions[1], joint_positions[2], joint_positions[3],
-                      joint_positions[4], joint_positions[5], velocity, acceleration, move_time, blend_radius);
+                      stringFromMotionTarget(target_command).c_str(), velocity, acceleration, move_time, blend_radius);
           return;
         } else {  // execute single primitive directly
           current_moprim_execution_status_ = MoprimExecutionState::EXECUTING;
+
           RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"),
-                      "Executing moveJ with joint positions: [%f, %f, %f, %f, %f, %f], "
+                      "Executing moveJ with: %s, "
                       "velocity: %f, acceleration: %f, move_time: %f, blend_radius: %f",
-                      joint_positions[0], joint_positions[1], joint_positions[2], joint_positions[3],
-                      joint_positions[4], joint_positions[5], velocity, acceleration, move_time, blend_radius);
-          bool success = instruction_executor_->moveJ(joint_positions, acceleration, velocity, move_time, blend_radius);
+                      stringFromMotionTarget(target_command).c_str(), velocity, acceleration, move_time, blend_radius);
+
+          bool success = instruction_executor_->moveJ(target_command, acceleration, velocity, move_time, blend_radius);
           if (success) {
             current_moprim_execution_status_ = MoprimExecutionState::SUCCESS;
           }
@@ -1953,19 +2028,6 @@ void URPositionHardwareInterface::processMoprimMotionCmd(const std::array<double
 
       case MoprimMotionType::LINEAR_CARTESIAN:
       {  // moveL
-        // Check if pose values (position and quaternion) are valid
-        for (int i = 7; i <= 13; ++i) {
-          if (std::isnan(command[i])) {
-            RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Invalid motion command: pose contains NaN "
-                                                                            "values");
-            current_moprim_execution_status_ = MoprimExecutionState::ERROR;
-            return;
-          }
-        }
-        double rx, ry, rz;
-        quaternionToRotVec(command[10], command[11], command[12], command[13], rx, ry, rz);
-        urcl::Pose pose = { command[7], command[8], command[9], rx, ry, rz };
-
         // Get move_time OR (velocity AND acceleration)
         if (!getMoprimTimeOrVelAndAcc(command, velocity, acceleration, move_time)) {
           RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Invalid move_time, velocity or acceleration "
@@ -1977,22 +2039,21 @@ void URPositionHardwareInterface::processMoprimMotionCmd(const std::array<double
         // Check if the command is part of a motion sequence or a single command
         if (build_moprim_sequence_) {  // Add command to motion sequence
           moprim_sequence_.emplace_back(std::make_shared<urcl::control::MoveLPrimitive>(
-              pose, blend_radius, std::chrono::milliseconds(static_cast<int>(move_time * 1000)), acceleration,
+              target_command, blend_radius, std::chrono::milliseconds(static_cast<int>(move_time * 1000)), acceleration,
               velocity));
+
           RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"),
-                      "Added  moveL to motion sequence with pose: [%f, %f, %f, %f, %f, %f], "
+                      "Added  moveL to motion sequence with: %s, "
                       "velocity: %f, acceleration: %f, move_time: %f, blend_radius: %f",
-                      pose.x, pose.y, pose.z, pose.rx, pose.ry, pose.rz, velocity, acceleration, move_time,
-                      blend_radius);
+                      stringFromMotionTarget(target_command).c_str(), velocity, acceleration, move_time, blend_radius);
           return;
         } else {  // execute single primitive directly
           current_moprim_execution_status_ = MoprimExecutionState::EXECUTING;
           RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"),
-                      "Executing moveL with pose: [%f, %f, %f, %f, %f, %f], "
+                      "Executing moveL with: %s, "
                       "velocity: %f, acceleration: %f, move_time: %f, blend_radius: %f",
-                      pose.x, pose.y, pose.z, pose.rx, pose.ry, pose.rz, velocity, acceleration, move_time,
-                      blend_radius);
-          bool success = instruction_executor_->moveL(pose, acceleration, velocity, move_time, blend_radius);
+                      stringFromMotionTarget(target_command).c_str(), velocity, acceleration, move_time, blend_radius);
+          bool success = instruction_executor_->moveL(target_command, acceleration, velocity, move_time, blend_radius);
           if (success) {
             current_moprim_execution_status_ = MoprimExecutionState::SUCCESS;
           }
@@ -2004,56 +2065,47 @@ void URPositionHardwareInterface::processMoprimMotionCmd(const std::array<double
       case MoprimMotionType::CIRCULAR_CARTESIAN:
       {  // CIRC
         // Check if pose values (position and quaternion) are valid
-        for (int i = 7; i <= 20; ++i) {
-          if (std::isnan(command[i])) {
-            RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Invalid motion command: pose contains NaN "
-                                                                            "values");
-            current_moprim_execution_status_ = MoprimExecutionState::ERROR;
-            return;
-          }
+        if (!(pose_valid && via_valid)) {
+          RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Invalid motion command: goal pose or via "
+                                                                          "pose contains NaN "
+                                                                          "values");
+          current_moprim_execution_status_ = MoprimExecutionState::ERROR;
+          return;
+        }
+
+        // Get velocity and acceleration
+        if (!getMoprimVelAndAcc(command, velocity, acceleration, move_time)) {
+          RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Invalid velocity or acceleration "
+                                                                          "values");
+          current_moprim_execution_status_ = MoprimExecutionState::ERROR;
+          return;
         }
 
         // 0: Unconstrained mode, 1: Fixed mode
         // (https://www.universal-robots.com/manuals/EN/HTML/SW5_22/Content/prod-scriptmanual/all_scripts/movec_pose_via_pose_toa1.htm)
         int32_t mode = 0;
 
-        // Get velocity and acceleration)
-        if (!getMoprimVelAndAcc(command, velocity, acceleration, move_time)) {
-          RCLCPP_ERROR(rclcpp::get_logger("URPositionHardwareInterface"), "Invalid velocity or acceleration values");
-          current_moprim_execution_status_ = MoprimExecutionState::ERROR;
-          return;
-        }
-
-        double via_rx, via_ry, via_rz;
-        quaternionToRotVec(command[17], command[18], command[19], command[20], via_rx, via_ry, via_rz);
-        urcl::Pose via_pose = { command[14], command[15], command[16], via_rx, via_ry, via_rz };
-
-        double goal_rx, goal_ry, goal_rz;
-        quaternionToRotVec(command[10], command[11], command[12], command[13], goal_rx, goal_ry, goal_rz);
-        urcl::Pose goal_pose = { command[7], command[8], command[9], goal_rx, goal_ry, goal_rz };
-
         // Check if the command is part of a motion sequence or a single command
         if (build_moprim_sequence_) {  // Add command to motion sequence
           moprim_sequence_.emplace_back(std::make_shared<urcl::control::MoveCPrimitive>(
-              via_pose, goal_pose, blend_radius, acceleration, velocity, mode));
+              via_command, target_command, blend_radius, acceleration, velocity, mode));
           RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"),
-                      "Added  moveC to motion sequence with via_pose: [%f, %f, %f, %f, %f, %f], "
-                      "goal_pose: [%f, %f, %f, %f, %f, %f], velocity: %f,"
+                      "Added  moveC to motion sequence with via_pose: %s, "
+                      "goal_pose: %s, velocity: %f,"
                       "acceleration: %f, blend_radius: %f, mode: %d",
-                      via_pose.x, via_pose.y, via_pose.z, via_pose.rx, via_pose.ry, via_pose.rz, goal_pose.x,
-                      goal_pose.y, goal_pose.z, goal_pose.rx, goal_pose.ry, goal_pose.rz, velocity, acceleration,
-                      blend_radius, mode);
+                      stringFromMotionTarget(via_command).c_str(), stringFromMotionTarget(target_command).c_str(),
+                      velocity, acceleration, blend_radius, mode);
           return;
         } else {  // execute single primitive directly
           current_moprim_execution_status_ = MoprimExecutionState::EXECUTING;
           RCLCPP_INFO(rclcpp::get_logger("URPositionHardwareInterface"),
-                      "Executing moveC with via_pose: [%f, %f, %f, %f, %f, %f], "
-                      "goal_pose: [%f, %f, %f, %f, %f, %f], velocity: %f,"
+                      "Executing moveC with via_pose: %s, "
+                      "goal_pose: %s, velocity: %f,"
                       "acceleration: %f, blend_radius: %f, mode: %d",
-                      via_pose.x, via_pose.y, via_pose.z, via_pose.rx, via_pose.ry, via_pose.rz, goal_pose.x,
-                      goal_pose.y, goal_pose.z, goal_pose.rx, goal_pose.ry, goal_pose.rz, velocity, acceleration,
-                      blend_radius, mode);
-          bool success = instruction_executor_->moveC(via_pose, goal_pose, acceleration, velocity, blend_radius, mode);
+                      stringFromMotionTarget(via_command).c_str(), stringFromMotionTarget(target_command).c_str(),
+                      velocity, acceleration, blend_radius, mode);
+          bool success =
+              instruction_executor_->moveC(via_command, target_command, acceleration, velocity, blend_radius, mode);
           if (success) {
             current_moprim_execution_status_ = MoprimExecutionState::SUCCESS;
           }

--- a/ur_robot_driver/test/integration_test_motion_primitives.py
+++ b/ur_robot_driver/test/integration_test_motion_primitives.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+# Copyright 2026, Universal Robots A/S
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import sys
+import time
+import unittest
+
+import launch_testing
+import pytest
+import rclpy
+from control_msgs.action import ExecuteMotionPrimitiveSequence
+from control_msgs.msg import MotionArgument, MotionPrimitive, MotionPrimitiveSequence
+from controller_manager_msgs.srv import SwitchController
+from geometry_msgs.msg import PoseStamped
+from rclpy.node import Node
+
+sys.path.append(os.path.dirname(__file__))
+from test_common import (  # noqa: E402
+    ActionInterface,
+    ControllerManagerInterface,
+    DashboardInterface,
+    IoStatusInterface,
+    generate_driver_test_description,
+    wait_for_robot_program_state,
+)
+
+MOTION_PRIMITIVE_CONTROLLER = "motion_primitive_forward_controller"
+ALL_MOTION_CONTROLLERS = [
+    "joint_trajectory_controller",
+    "forward_position_controller",
+    "forward_velocity_controller",
+    "passthrough_trajectory_controller",
+    "force_mode_controller",
+    "freedrive_mode_controller",
+    MOTION_PRIMITIVE_CONTROLLER,
+    "twist_controller",
+]
+TIMEOUT_EXECUTE_MOTION_PRIMITIVE = 60
+
+
+@pytest.mark.launch_test
+@launch_testing.parametrize("tf_prefix", [(""), ("my_ur_")])
+def generate_test_description(tf_prefix):
+    return generate_driver_test_description(tf_prefix=tf_prefix)
+
+
+def make_motion_argument(name, value):
+    return MotionArgument(name=name, value=value)
+
+
+def make_pose(x, y, z, qx=1.0, qy=0.0, qz=0.0, qw=0.0):
+    pose = PoseStamped()
+    pose.pose.position.x = x
+    pose.pose.position.y = y
+    pose.pose.position.z = z
+    pose.pose.orientation.x = qx
+    pose.pose.orientation.y = qy
+    pose.pose.orientation.z = qz
+    pose.pose.orientation.w = qw
+    return pose
+
+
+def make_primitive(
+    motion_type, joint_positions=None, poses=None, move_time=2.0, vel=0.0, acc=0.0, blend_radius=0.0
+):
+    primitive = MotionPrimitive()
+    primitive.type = motion_type
+    primitive.blend_radius = blend_radius
+    primitive.additional_arguments = [
+        make_motion_argument("move_time", move_time),
+        make_motion_argument("velocity", vel),
+        make_motion_argument("acceleration", acc),
+    ]
+
+    if joint_positions is not None:
+        primitive.joint_positions = joint_positions
+    if poses is not None:
+        primitive.poses = poses
+
+    return primitive
+
+
+class MotionPrimitivesControllerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+        cls.node = Node("motion_primitives_controller_test")
+        time.sleep(1)
+        cls.init_robot()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.node.destroy_node()
+        rclpy.shutdown()
+
+    @classmethod
+    def init_robot(cls):
+        cls._dashboard_interface = DashboardInterface(cls.node)
+        cls._controller_manager_interface = ControllerManagerInterface(cls.node)
+        cls._io_status_controller_interface = IoStatusInterface(cls.node)
+        cls._motion_sequence = ActionInterface(
+            cls.node,
+            f"/{MOTION_PRIMITIVE_CONTROLLER}/motion_sequence",
+            ExecuteMotionPrimitiveSequence,
+        )
+
+        for controller in ALL_MOTION_CONTROLLERS:
+            cls._controller_manager_interface.wait_for_controller(controller)
+
+    def setUp(self):
+        self._dashboard_interface.start_robot()
+        time.sleep(1)
+        resend_robot_program = getattr(self._io_status_controller_interface, "resend_robot_program")
+        self.assertTrue(resend_robot_program().success)
+        program_state = wait_for_robot_program_state(self.node, True, 10.0)
+        self.assertEqual(program_state, True)
+        switch_controller = getattr(self._controller_manager_interface, "switch_controller")
+        self.assertTrue(
+            switch_controller(
+                strictness=SwitchController.Request.BEST_EFFORT,
+                deactivate_controllers=ALL_MOTION_CONTROLLERS,
+            ).ok
+        )
+        self.assertTrue(
+            switch_controller(
+                strictness=SwitchController.Request.STRICT,
+                activate_controllers=[MOTION_PRIMITIVE_CONTROLLER],
+            ).ok
+        )
+
+    def execute_motion_sequence(self, motions):
+        goal_handle = self._motion_sequence.send_goal(
+            trajectory=MotionPrimitiveSequence(motions=motions)
+        )
+        assert goal_handle is not None
+        self.assertTrue(goal_handle.accepted)
+        result = self._motion_sequence.get_result(goal_handle, TIMEOUT_EXECUTE_MOTION_PRIMITIVE)
+        self.assertEqual(result.error_code, ExecuteMotionPrimitiveSequence.Result.SUCCESSFUL)
+
+    def test_linear_joint_accepts_pose_target(self):
+        self.execute_motion_sequence(
+            [
+                make_primitive(
+                    MotionPrimitive.LINEAR_JOINT,
+                    poses=[make_pose(0.174, -0.3, 0.3)],
+                )
+            ]
+        )
+
+    def test_linear_cartesian_accepts_joint_target(self):
+        self.execute_motion_sequence(
+            [
+                make_primitive(
+                    MotionPrimitive.LINEAR_CARTESIAN,
+                    joint_positions=[0.9, -1.57, 1.57, -1.57, -1.57, -1.57],
+                ),
+            ]
+        )
+
+    def test_circular_cartesian_uses_goal_and_via_pose(self):
+        self.execute_motion_sequence(
+            [
+                make_primitive(
+                    MotionPrimitive.CIRCULAR_CARTESIAN,
+                    poses=[
+                        make_pose(0.3, -0.3, 0.1),
+                        make_pose(0.174, -0.4, 0.1),
+                    ],
+                    vel=0.5,
+                    acc=0.5,
+                ),
+            ]
+        )
+
+    def test_ambiguous_joint_and_pose_target_is_rejected(self):
+        goal_handle = self._motion_sequence.send_goal(
+            trajectory=MotionPrimitiveSequence(
+                motions=[
+                    make_primitive(
+                        MotionPrimitive.LINEAR_JOINT,
+                        joint_positions=[1.57, -1.57, 1.57, -1.57, -1.57, -1.57],
+                        poses=[make_pose(0.174, -0.3, 0.3)],
+                    )
+                ]
+            )
+        )
+
+        assert goal_handle is not None
+        self.assertFalse(goal_handle.accepted)


### PR DESCRIPTION
This is in preparation for the controller being able to send joint angles with `LINEAR_CARTESIAN` commands, and poses with `LINEAR_JOINT` commands. It refactors some of the checks out to happen before the command type is known, and uses `urcl::MotionTarget`s for all `move*` commands, and adds some helpers to extract information out of the `command` parameter.

The whole PR is dependent on this [URCL PR](https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/558) for logging purposes

The two last commits (adding parameter to controllers YAML and tests) are dependent on this [ROS2_Control PR](https://github.com/ros-controls/ros2_controllers/pull/2575), for the existence of the parameter, and being able to send mixed motion primitive commands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real robot motion command parsing and execution paths; incorrect target selection or validation could cause failed or unintended moves, though new integration tests cover the main cases.
> 
> **Overview**
> Refactors motion primitive handling in the UR hardware interface so **moveJ**, **moveL**, and **moveC** take a unified `urcl::MotionTarget` (joint `Q` or Cartesian `Pose`) instead of hard-coding joint vs pose per primitive type. Joint and pose fields are parsed and validated **before** the motion-type switch; commands with neither target, or with **both** joint and pose set, are rejected with an error state.
> 
> This supports **cross-type targets** (e.g. `LINEAR_JOINT` with a pose, `LINEAR_CARTESIAN` with joints) when the forward controller has **`hardware_solves_kinematics: true`** in `ur_controllers.yaml`. Logging uses `stringFromMotionTarget` from URCL helpers.
> 
> Adds launch integration tests for mixed targets, circular motion, and ambiguous-goal rejection, and registers the test in **CMakeLists.txt**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 375351d966b9f298ae7afbb5f6d30d7518e91f5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->