### PR TITLE
Update dashboard client for 10.14.0

### DIFF
--- a/ur_dashboard_msgs/CMakeLists.txt
+++ b/ur_dashboard_msgs/CMakeLists.txt
@@ -20,6 +20,7 @@ set(msg_files
 set(srv_files
   srv/AddToLog.srv
   srv/DownloadProgram.srv
+  srv/DownloadSupportFile.srv
   srv/GetLoadedProgram.srv
   srv/GetPrograms.srv
   srv/GetProgramState.srv

--- a/ur_dashboard_msgs/srv/DownloadSupportFile.srv
+++ b/ur_dashboard_msgs/srv/DownloadSupportFile.srv
@@ -4,3 +4,4 @@ string target_path
 ---
 string answer
 bool success
+bool support_files_present

--- a/ur_dashboard_msgs/srv/DownloadSupportFile.srv
+++ b/ur_dashboard_msgs/srv/DownloadSupportFile.srv
@@ -1,0 +1,6 @@
+# Local path where the support file archive (zip) should be stored.
+# Only available on PolyScope X >= 10.14.0.
+string target_path
+---
+string answer
+bool success

--- a/ur_dashboard_msgs/srv/Popup.srv
+++ b/ur_dashboard_msgs/srv/Popup.srv
@@ -1,4 +1,6 @@
 string message
+# Optional popup title. Used on PolyScope X; ignored on PolyScope 5 / CB3.
+string title
 ---
 string answer
 bool success

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -237,6 +237,7 @@ install(PROGRAMS
   scripts/wait_for_robot_description
   scripts/example_move.py
   scripts/start_ursim.sh
+  scripts/wait_robot_booted.py
   examples/examples.py
   examples/force_mode.py
   examples/send_dummy_motion_primitives_ur10e.py

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -285,7 +285,7 @@ if(BUILD_TESTING)
     )
     add_launch_test(test/dashboard_client.py
       TIMEOUT
-        180
+        800 # Booting the simulators can take quite some time. Increasing this timeout to avoid spurious failures.
     )
     add_launch_test(test/example_move.py
       TIMEOUT

--- a/ur_robot_driver/doc/dashboard_client.rst
+++ b/ur_robot_driver/doc/dashboard_client.rst
@@ -11,7 +11,7 @@ Advertised Services
 add_to_log (`ur_dashboard_msgs/AddToLog <http://docs.ros.org/en/rolling/p/ur_dashboard_msgs/srv/AddToLog.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Service to add a message to the robot's log
+Service to add a message to the robot's log. On PolyScope X this requires version >= 10.14.0.
 
 brake_release (`std_srvs/Trigger <http://docs.ros.org/en/rolling/p/std_srvs/srv/Trigger.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -26,12 +26,12 @@ If this service is called the operational mode can again be changed from PolySco
 close_popup (`std_srvs/Trigger <http://docs.ros.org/en/rolling/p/std_srvs/srv/Trigger.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Close a (non-safety) popup on the teach pendant.
+Close a (non-safety) popup on the teach pendant. On PolyScope X this requires version >= 10.14.0.
 
 close_safety_popup (`std_srvs/Trigger <http://docs.ros.org/en/rolling/p/std_srvs/srv/Trigger.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Close a safety popup on the teach pendant.
+Close a safety popup on the teach pendant. On PolyScope X this requires version >= 10.14.0.
 
 connect (`std_srvs/Trigger <http://docs.ros.org/en/rolling/p/std_srvs/srv/Trigger.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -97,7 +97,8 @@ Start execution of a previously loaded program
 popup (`ur_dashboard_msgs/Popup <http://docs.ros.org/en/rolling/p/ur_dashboard_msgs/srv/Popup.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Service to show a popup on the UR Teach pendant.
+Service to show a popup on the UR Teach pendant. On PolyScope X (>= 10.14.0) an optional ``title``
+can be provided; on PolyScope 5 / CB3 the title is ignored.
 
 power_off (`std_srvs/Trigger <http://docs.ros.org/en/rolling/p/std_srvs/srv/Trigger.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -148,7 +149,7 @@ robot with version >= 10.11.0.
 shutdown (`std_srvs/Trigger <http://docs.ros.org/en/rolling/p/std_srvs/srv/Trigger.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Shutdown the robot controller
+Shutdown the robot controller. On PolyScope X this requires version >= 10.14.0.
 
 stop (`std_srvs/Trigger <http://docs.ros.org/en/rolling/p/std_srvs/srv/Trigger.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -178,12 +179,12 @@ version >= 10.12.0.
 get_polyscope_version (`ur_dashboard_msgs/GetPolyScopeVersion <http://docs.ros.org/en/rolling/p/ur_dashboard_msgs/srv/GetPolyScopeVersion.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**CB3 | PolyScope 5** Get polyScope version of robot
+**CB3 | PolyScope 5 | PolyScope X >= 10.14.0** Get PolyScope version of the robot
 
 get_serial_number (`ur_dashboard_msgs/GetSerialNumber <http://docs.ros.org/en/rolling/p/ur_dashboard_msgs/srv/GetSerialNumber.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**CB3 | PolyScope 5** Get serial number of robot
+**CB3 | PolyScope 5 | PolyScope X >= 10.14.0** Get serial number of robot
 
 get_user_role (`ur_dashboard_msgs/GetUserRole <http://docs.ros.org/en/rolling/p/ur_dashboard_msgs/srv/GetUserRole.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -208,7 +209,7 @@ set_operational_mode (`ur_dashboard_msgs/SetOperationalMode <http://docs.ros.org
 get_robot_model (`ur_dashboard_msgs/GetRobotModel <http://docs.ros.org/en/rolling/p/ur_dashboard_msgs/srv/GetRobotModel.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**CB3 | PolyScope 5** Get the robot model, in the format URx. It should be noted this call does not differentiate between e-series and CB3, so UR5 and UR5e will both report as UR5
+**CB3 | PolyScope 5 | PolyScope X >= 10.14.0** Get the robot model, in the format URx. It should be noted this call does not differentiate between e-series and CB3, so UR5 and UR5e will both report as UR5
 
 get_safety_status (`ur_dashboard_msgs/GetSafetyStatus <http://docs.ros.org/en/rolling/p/ur_dashboard_msgs/srv/GetSafetyStatus.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -218,14 +219,20 @@ get_safety_status (`ur_dashboard_msgs/GetSafetyStatus <http://docs.ros.org/en/ro
 generate_flight_report (`ur_dashboard_msgs/GenerateFlightReport <http://docs.ros.org/en/rolling/p/ur_dashboard_msgs/srv/GenerateFlightReport.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**CB3 | PolyScope 5** Generate flight report of the chosen type, defaults to SYSTEM. It is required to wait at least 30 seconds between triggering software or controller reports.
+**CB3 | PolyScope 5 | PolyScope X >= 10.14.0** Generate flight report of the chosen type, defaults to SYSTEM. On PolyScope 5 / CB3 it is required to wait at least 30 seconds between triggering software or controller reports. On PolyScope X the ``report_type`` argument is ignored.
 
 generate_support_file (`ur_dashboard_msgs/GenerateSupportFile <http://docs.ros.org/en/rolling/p/ur_dashboard_msgs/srv/GenerateSupportFile.html>`_)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **CB3 | PolyScope 5** Generate a support file a the specified location. Location is relative to the programs folder, if saving to a subfolder it must exist prior to the service call.
-Defaults to saving to the programs folder
+Defaults to saving to the programs folder. On PolyScope X use :ref:`download_support_file <dashboard_download_support_file>` instead.
 
+.. _dashboard_download_support_file:
+
+download_support_file (`ur_dashboard_msgs/DownloadSupportFile <http://docs.ros.org/en/rolling/p/ur_dashboard_msgs/srv/DownloadSupportFile.html>`_)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**PolyScope X only (>= 10.14.0)**: Download the robot's support files as a zip archive to ``target_path`` on the machine running the dashboard client.
 
 Parameters
 ----------

--- a/ur_robot_driver/include/ur_robot_driver/dashboard_client_ros.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/dashboard_client_ros.hpp
@@ -66,6 +66,7 @@
 #include "ur_dashboard_msgs/srv/is_in_remote_control.hpp"
 #include "ur_dashboard_msgs/srv/get_programs.hpp"
 #include "ur_dashboard_msgs/srv/download_program.hpp"
+#include "ur_dashboard_msgs/srv/download_support_file.hpp"
 #include "ur_dashboard_msgs/srv/upload_program.hpp"
 #include "ur_dashboard_msgs/srv/get_poly_scope_version.hpp"
 #include "ur_dashboard_msgs/srv/get_serial_number.hpp"
@@ -233,6 +234,7 @@ private:
   rclcpp::Service<ur_dashboard_msgs::srv::SetOperationalMode>::SharedPtr set_operational_mode_service_;
   rclcpp::Service<ur_dashboard_msgs::srv::GenerateFlightReport>::SharedPtr generate_flight_report_service_;
   rclcpp::Service<ur_dashboard_msgs::srv::GenerateSupportFile>::SharedPtr generate_support_file_service_;
+  rclcpp::Service<ur_dashboard_msgs::srv::DownloadSupportFile>::SharedPtr download_support_file_service_;
 
   // Query services
   rclcpp::Service<ur_dashboard_msgs::srv::IsProgramRunning>::SharedPtr running_service_;

--- a/ur_robot_driver/scripts/wait_robot_booted.py
+++ b/ur_robot_driver/scripts/wait_robot_booted.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# Copyright 2026 Universal Robots A/S
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Wait until a UR controller/URSim instance is reachable after boot."""
+
+import argparse
+import socket
+import sys
+import time
+import urllib.error
+import urllib.request
+
+DASHBOARD_PORT = 29999
+ROBOT_API_OPENAPI_PATH = "/universal-robots/robot-api/openapi.json"
+
+
+def dashboard_reachable(robot_ip: str, timeout: float) -> bool:
+    """Return True if the dashboard server accepts a TCP connection."""
+    try:
+        with socket.create_connection((robot_ip, DASHBOARD_PORT), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
+def robot_api_reachable(robot_ip: str, timeout: float) -> bool:
+    """Return True if the PolyScope X Robot API openapi endpoint responds with HTTP 200."""
+    url = f"http://{robot_ip}{ROBOT_API_OPENAPI_PATH}"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            return response.status == 200
+    except (urllib.error.URLError, TimeoutError, ValueError):
+        return False
+
+
+def probe_robot(robot_ip: str, probe_timeout: float) -> str | None:
+    """Probe dashboard and Robot API; return a short description of the first hit."""
+    if dashboard_reachable(robot_ip, probe_timeout):
+        return f"dashboard server at {robot_ip}:{DASHBOARD_PORT}"
+    if robot_api_reachable(robot_ip, probe_timeout):
+        return f"Robot API at http://{robot_ip}{ROBOT_API_OPENAPI_PATH}"
+    return None
+
+
+def wait_for_robot(
+    robot_ip: str,
+    timeout: float,
+    interval: float,
+    probe_timeout: float,
+) -> bool:
+    """Poll until the dashboard or Robot API is reachable, or ``timeout`` elapses."""
+    deadline = time.monotonic() + timeout
+    print(
+        f"Waiting for robot at {robot_ip} "
+        f"(dashboard :{DASHBOARD_PORT} or Robot API {ROBOT_API_OPENAPI_PATH})...",
+        flush=True,
+    )
+    while time.monotonic() < deadline:
+        found = probe_robot(robot_ip, probe_timeout)
+        if found is not None:
+            print(f"Robot is reachable via {found}.", flush=True)
+            return True
+        remaining = max(0.0, deadline - time.monotonic())
+        print(
+            f"Robot not ready yet; retrying in {interval:.1f}s ({remaining:.1f}s left)...",
+            flush=True,
+        )
+        time.sleep(min(interval, remaining) if remaining > 0 else interval)
+        if time.monotonic() >= deadline:
+            break
+    print(
+        f"Timed out after {timeout:.1f}s waiting for robot at {robot_ip}.",
+        file=sys.stderr,
+        flush=True,
+    )
+    return False
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "robot_ip",
+        help="IP address of the robot / URSim instance",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=120.0,
+        help="Overall time to wait in seconds (default: 120)",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=3.0,
+        help="Delay between connection attempts in seconds (default: 3)",
+    )
+    parser.add_argument(
+        "--probe-timeout",
+        type=float,
+        default=2.0,
+        help="Timeout for a single connection attempt in seconds (default: 2)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+    if args.timeout <= 0 or args.interval <= 0 or args.probe_timeout <= 0:
+        print("timeout, interval and probe-timeout must be positive", file=sys.stderr)
+        return 2
+
+    ok = wait_for_robot(
+        args.robot_ip,
+        args.timeout,
+        args.interval,
+        args.probe_timeout,
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ur_robot_driver/scripts/wait_robot_booted.py
+++ b/ur_robot_driver/scripts/wait_robot_booted.py
@@ -111,8 +111,8 @@ def parse_args(argv=None):
     parser.add_argument(
         "--timeout",
         type=float,
-        default=120.0,
-        help="Overall time to wait in seconds (default: 120)",
+        default=180.0,
+        help="Overall time to wait in seconds (default: 180)",
     )
     parser.add_argument(
         "--interval",

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -260,8 +260,8 @@ void DashboardClientROS::initServices(urcl::DashboardClient::ClientPolicy dashbo
   popup_service_ = node_->create_service<ur_dashboard_msgs::srv::Popup>(
       "~/popup", [&](ur_dashboard_msgs::srv::Popup::Request::SharedPtr req,
                      ur_dashboard_msgs::srv::Popup::Response::SharedPtr resp) {
-        auto dashboard_response =
-            dashboardCallWithChecks([this, req]() { return client_->commandPopupWithResponse(req->message); }, resp);
+        auto dashboard_response = dashboardCallWithChecks(
+            [this, req]() { return client_->commandPopupWithResponse(req->message, req->title); }, resp);
 
         return true;
       });
@@ -524,6 +524,15 @@ void DashboardClientROS::initServices(urcl::DashboardClient::ClientPolicy dashbo
         }
         return true;
       });
+
+  // PolyScope X only: download support files as a zip archive to a local path
+  download_support_file_service_ = node_->create_service<ur_dashboard_msgs::srv::DownloadSupportFile>(
+      "~/download_support_file", [&](const ur_dashboard_msgs::srv::DownloadSupportFile::Request::SharedPtr req,
+                                     ur_dashboard_msgs::srv::DownloadSupportFile::Response::SharedPtr resp) {
+        dashboardCallWithChecks(
+            [this, req]() { return client_->commandDownloadSupportFilesWithResponse(req->target_path); }, resp);
+        return true;
+      });
 }
 
 bool DashboardClientROS::handleRunningQuery(const ur_dashboard_msgs::srv::IsProgramRunning::Request::SharedPtr req,
@@ -715,7 +724,8 @@ bool DashboardClientROS::handleGetPolyScopeVersionQuery(
         [dashboard_response, resp]() {
           std::string version_string = std::get<std::string>(dashboard_response.data.at("polyscope_version"));
 
-          std::regex version_regex(R"([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)");
+          // Accept 2-4 numeric components (e.g. "10.14.0" on PolyScope X, "5.21.0.12345" on PolyScope 5)
+          std::regex version_regex(R"([0-9]+(?:\.[0-9]+){1,3})");
           std::smatch version_match;
           if (std::regex_search(version_string, version_match, version_regex)) {
             int num = 0;
@@ -735,7 +745,13 @@ bool DashboardClientROS::handleGetPolyScopeVersionQuery(
                 num = 0;
               }
             }
-            resp->version.build = num;
+            if (counter == 1) {
+              resp->version.minor = num;
+            } else if (counter == 2) {
+              resp->version.bugfix = num;
+            } else if (counter == 3) {
+              resp->version.build = num;
+            }
           }
         },
         resp, dashboard_response);

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -529,8 +529,22 @@ void DashboardClientROS::initServices(urcl::DashboardClient::ClientPolicy dashbo
   download_support_file_service_ = node_->create_service<ur_dashboard_msgs::srv::DownloadSupportFile>(
       "~/download_support_file", [&](const ur_dashboard_msgs::srv::DownloadSupportFile::Request::SharedPtr req,
                                      ur_dashboard_msgs::srv::DownloadSupportFile::Response::SharedPtr resp) {
-        dashboardCallWithChecks(
+        auto dashboard_response = dashboardCallWithChecks(
             [this, req]() { return client_->commandDownloadSupportFilesWithResponse(req->target_path); }, resp);
+        if (resp->success) {
+          resp->support_files_present = true;
+          handleDashboardResponseData(
+              [dashboard_response, resp]() {
+                static constexpr std::string key = "status_code";
+                if (dashboard_response.data.find(key) != dashboard_response.data.end()) {
+                  const int status_code = std::get<int>(dashboard_response.data.at(key));
+                  if (status_code == 204) {
+                    resp->support_files_present = false;
+                  }
+                }
+              },
+              resp, dashboard_response);
+        }
         return true;
       });
 }

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -535,7 +535,7 @@ void DashboardClientROS::initServices(urcl::DashboardClient::ClientPolicy dashbo
           resp->support_files_present = true;
           handleDashboardResponseData(
               [dashboard_response, resp]() {
-                static constexpr std::string key = "status_code";
+                const std::string key = "status_code";
                 if (dashboard_response.data.find(key) != dashboard_response.data.end()) {
                   const int status_code = std::get<int>(dashboard_response.data.at(key));
                   if (status_code == 204) {

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -526,27 +526,29 @@ void DashboardClientROS::initServices(urcl::DashboardClient::ClientPolicy dashbo
       });
 
   // PolyScope X only: download support files as a zip archive to a local path
-  download_support_file_service_ = node_->create_service<ur_dashboard_msgs::srv::DownloadSupportFile>(
-      "~/download_support_file", [&](const ur_dashboard_msgs::srv::DownloadSupportFile::Request::SharedPtr req,
-                                     ur_dashboard_msgs::srv::DownloadSupportFile::Response::SharedPtr resp) {
-        auto dashboard_response = dashboardCallWithChecks(
-            [this, req]() { return client_->commandDownloadSupportFilesWithResponse(req->target_path); }, resp);
-        if (resp->success) {
-          resp->support_files_present = true;
-          handleDashboardResponseData(
-              [dashboard_response, resp]() {
-                const std::string key = "status_code";
-                if (dashboard_response.data.find(key) != dashboard_response.data.end()) {
-                  const int status_code = std::get<int>(dashboard_response.data.at(key));
-                  if (status_code == 204) {
-                    resp->support_files_present = false;
+  if (dashboard_policy == urcl::DashboardClient::ClientPolicy::POLYSCOPE_X) {
+    download_support_file_service_ = node_->create_service<ur_dashboard_msgs::srv::DownloadSupportFile>(
+        "~/download_support_file", [&](const ur_dashboard_msgs::srv::DownloadSupportFile::Request::SharedPtr req,
+                                       ur_dashboard_msgs::srv::DownloadSupportFile::Response::SharedPtr resp) {
+          auto dashboard_response = dashboardCallWithChecks(
+              [this, req]() { return client_->commandDownloadSupportFilesWithResponse(req->target_path); }, resp);
+          if (resp->success) {
+            resp->support_files_present = true;
+            handleDashboardResponseData(
+                [dashboard_response, resp]() {
+                  const std::string key = "status_code";
+                  if (dashboard_response.data.find(key) != dashboard_response.data.end()) {
+                    const int status_code = std::get<int>(dashboard_response.data.at(key));
+                    if (status_code == 204) {
+                      resp->support_files_present = false;
+                    }
                   }
-                }
-              },
-              resp, dashboard_response);
-        }
-        return true;
-      });
+                },
+                resp, dashboard_response);
+          }
+          return true;
+        });
+  }
 }
 
 bool DashboardClientROS::handleRunningQuery(const ur_dashboard_msgs::srv::IsProgramRunning::Request::SharedPtr req,

--- a/ur_robot_driver/src/dashboard_client_ros.cpp
+++ b/ur_robot_driver/src/dashboard_client_ros.cpp
@@ -526,29 +526,27 @@ void DashboardClientROS::initServices(urcl::DashboardClient::ClientPolicy dashbo
       });
 
   // PolyScope X only: download support files as a zip archive to a local path
-  if (dashboard_policy == urcl::DashboardClient::ClientPolicy::POLYSCOPE_X) {
-    download_support_file_service_ = node_->create_service<ur_dashboard_msgs::srv::DownloadSupportFile>(
-        "~/download_support_file", [&](const ur_dashboard_msgs::srv::DownloadSupportFile::Request::SharedPtr req,
-                                       ur_dashboard_msgs::srv::DownloadSupportFile::Response::SharedPtr resp) {
-          auto dashboard_response = dashboardCallWithChecks(
-              [this, req]() { return client_->commandDownloadSupportFilesWithResponse(req->target_path); }, resp);
-          if (resp->success) {
-            resp->support_files_present = true;
-            handleDashboardResponseData(
-                [dashboard_response, resp]() {
-                  const std::string key = "status_code";
-                  if (dashboard_response.data.find(key) != dashboard_response.data.end()) {
-                    const int status_code = std::get<int>(dashboard_response.data.at(key));
-                    if (status_code == 204) {
-                      resp->support_files_present = false;
-                    }
+  download_support_file_service_ = node_->create_service<ur_dashboard_msgs::srv::DownloadSupportFile>(
+      "~/download_support_file", [&](const ur_dashboard_msgs::srv::DownloadSupportFile::Request::SharedPtr req,
+                                     ur_dashboard_msgs::srv::DownloadSupportFile::Response::SharedPtr resp) {
+        auto dashboard_response = dashboardCallWithChecks(
+            [this, req]() { return client_->commandDownloadSupportFilesWithResponse(req->target_path); }, resp);
+        if (resp->success) {
+          resp->support_files_present = true;
+          handleDashboardResponseData(
+              [dashboard_response, resp]() {
+                const std::string key = "status_code";
+                if (dashboard_response.data.find(key) != dashboard_response.data.end()) {
+                  const int status_code = std::get<int>(dashboard_response.data.at(key));
+                  if (status_code == 204) {
+                    resp->support_files_present = false;
                   }
-                },
-                resp, dashboard_response);
-          }
-          return true;
-        });
-  }
+                }
+              },
+              resp, dashboard_response);
+        }
+        return true;
+      });
 }
 
 bool DashboardClientROS::handleRunningQuery(const ur_dashboard_msgs::srv::IsProgramRunning::Request::SharedPtr req,

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -186,8 +186,6 @@ class DashboardClientTest(unittest.TestCase):
         if _is_older_polyscope_x(ursim_version, "10.14.0"):
             self.skipTest("Getting polyscope version requires PolyScope X >= 10.14.0")
         resp = self._dashboard_interface.get_polyscope_version()
-        if not resp.success and "Not implemented" in resp.answer:
-            self.skipTest("Getting polyscope version requires PolyScope X >= 10.14.0")
         self.assertTrue(resp.success)
         if ursim_version != "latest":
             self.assertEqual(resp.version.major, _version_tuple(ursim_version)[0])
@@ -198,8 +196,6 @@ class DashboardClientTest(unittest.TestCase):
         if _is_older_polyscope_x(ursim_version, "10.14.0"):
             self.skipTest("Getting serial number requires PolyScope X >= 10.14.0")
         resp = self._dashboard_interface.get_serial_number()
-        if not resp.success and "Not implemented" in resp.answer:
-            self.skipTest("Getting serial number requires PolyScope X >= 10.14.0")
         self.assertTrue(resp.success)
         self.assertNotEqual(resp.serial_number, 0)
 
@@ -249,8 +245,6 @@ class DashboardClientTest(unittest.TestCase):
         if _is_older_polyscope_x(ursim_version, "10.14.0"):
             self.skipTest("Getting robot model requires PolyScope X >= 10.14.0")
         resp = self._dashboard_interface.get_robot_model()
-        if not resp.success and "Not implemented" in resp.answer:
-            self.skipTest("Getting robot model requires PolyScope X >= 10.14.0")
         self.assertTrue(resp.success)
         self.assertTrue("UR" in resp.robot_model)
 
@@ -265,8 +259,6 @@ class DashboardClientTest(unittest.TestCase):
         if _is_older_polyscope_x(ursim_version, "10.14.0"):
             self.skipTest("Generating flight report requires PolyScope X >= 10.14.0")
         resp = self._dashboard_interface.generate_flight_report()
-        if not resp.success and "Not implemented" in resp.answer:
-            self.skipTest("Generating flight report requires PolyScope X >= 10.14.0")
         # PolyScope X requires remote control for this endpoint.
         if not resp.success and "Forbidden" in resp.answer:
             self.skipTest("Generating flight report requires remote control on PolyScope X")
@@ -283,14 +275,12 @@ class DashboardClientTest(unittest.TestCase):
         self.assertNotEqual(resp.generated_file_name, "")
 
     def test_download_support_file(self, ursim_version):
-        if not _is_polyscope_x_at_least(ursim_version, "10.14.0"):
+        if not _is_polyscope_x_at_least(ursim_version, "10.14.0") or ursim_version.startswith("5."):
             self.skipTest("Downloading support files requires PolyScope X >= 10.14.0")
         target_path = "/tmp/ur_dashboard_support_files.zip"
         if os.path.exists(target_path):
             os.remove(target_path)
         resp = self._dashboard_interface.download_support_file(target_path=target_path)
-        if not resp.success and "Not implemented" in resp.answer:
-            self.skipTest("Downloading support files requires PolyScope X >= 10.14.0")
         self.assertTrue(resp.success)
         self.assertTrue(os.path.isfile(target_path))
         self.assertGreater(os.path.getsize(target_path), 0)
@@ -299,8 +289,6 @@ class DashboardClientTest(unittest.TestCase):
         if _is_older_polyscope_x(ursim_version, "10.14.0"):
             self.skipTest("Popup / add_to_log require PolyScope X >= 10.14.0")
         popup_resp = self._dashboard_interface.popup(message="ROS2 dashboard test", title="Test")
-        if not popup_resp.success and "Not implemented" in popup_resp.answer:
-            self.skipTest("Popup / add_to_log require PolyScope X >= 10.14.0")
         # PolyScope X requires remote control for popup / log endpoints.
         if not popup_resp.success and "Forbidden" in popup_resp.answer:
             self.skipTest("Popup / add_to_log require remote control on PolyScope X")

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -75,6 +75,7 @@ def _is_older_polyscope_x(ursim_version, min_version):
     "ursim_version, ur_type, autoconnect",
     [
         ("latest", "ur30", "false"),
+        ("10.14.0", "ur15", "true"),
         ("10.12.0", "ur15", "true"),
         ("3.15.8", "ur10", "true"),
     ],
@@ -188,7 +189,10 @@ class DashboardClientTest(unittest.TestCase):
         if not resp.success and "Not implemented" in resp.answer:
             self.skipTest("Getting polyscope version requires PolyScope X >= 10.14.0")
         self.assertTrue(resp.success)
-        self.assertNotEqual(resp.version.major, 0)
+        if ursim_version != "latest":
+            self.assertEqual(resp.version.major, _version_tuple(ursim_version)[0])
+            self.assertEqual(resp.version.minor, _version_tuple(ursim_version)[1])
+            self.assertEqual(resp.version.patch, _version_tuple(ursim_version)[2])
 
     def test_get_serial_number(self, ursim_version):
         if _is_older_polyscope_x(ursim_version, "10.14.0"):

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -283,7 +283,8 @@ class DashboardClientTest(unittest.TestCase):
         resp = self._dashboard_interface.download_support_file(target_path=target_path)
         self.assertTrue(resp.success)
         self.assertTrue(os.path.isfile(target_path))
-        self.assertGreater(os.path.getsize(target_path), 0)
+        if resp.support_files_present:
+            self.assertGreater(os.path.getsize(target_path), 0)
 
     def test_popup_and_add_to_log(self, ursim_version):
         if _is_older_polyscope_x(ursim_version, "10.14.0"):

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -262,11 +262,11 @@ class DashboardClientTest(unittest.TestCase):
             self.skipTest("Generating flight report requires remote control on PolyScope X")
         self.assertTrue(resp.success)
         # PolyScope 5 / CB3 return a report id; PolyScope X currently does not.
-        if not ursim_version.startswith("10.") and ursim_version != "latest":
+        if not ursim_version.startswith("10."):
             self.assertNotEqual(resp.report_id, "")
 
     def test_generate_support_file(self, ursim_version):
-        if ursim_version.startswith("10.") or ursim_version == "latest":
+        if ursim_version.startswith("10."):
             self.skipTest("Generating support file is not supported on PolyScope X")
         resp = self._dashboard_interface.generate_support_file()
         self.assertTrue(resp.success)

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -273,7 +273,7 @@ class DashboardClientTest(unittest.TestCase):
         self.assertNotEqual(resp.generated_file_name, "")
 
     def test_download_support_file(self, ursim_version):
-        if not _is_polyscope_x_at_least(ursim_version, "10.14.0") or ursim_version.startswith("5."):
+        if not _is_polyscope_x_at_least(ursim_version, "10.14.0"):
             self.skipTest("Downloading support files requires PolyScope X >= 10.14.0")
         target_path = "/tmp/ur_dashboard_support_files.zip"
         if os.path.exists(target_path):

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -53,11 +53,9 @@ def _is_polyscope_x_at_least(ursim_version, min_version):
     """
     Return True if ursim_version is PolyScope X >= min_version.
 
-    ``latest`` is treated as the newest PolyScope X image. Numbered 10.x tags are compared
+    ``latest`` is treated as the newest PolyScope 5 image therefore the result will be False. Numbered 10.x tags are compared
     numerically. CB3 / PolyScope 5 tags return False.
     """
-    if ursim_version == "latest":
-        return True
     if not ursim_version.startswith("10."):
         return False
     return _version_tuple(ursim_version) >= _version_tuple(min_version)

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -273,16 +273,18 @@ class DashboardClientTest(unittest.TestCase):
         self.assertNotEqual(resp.generated_file_name, "")
 
     def test_download_support_file(self, ursim_version):
-        if not _is_polyscope_x_at_least(ursim_version, "10.14.0"):
-            self.skipTest("Downloading support files requires PolyScope X >= 10.14.0")
         target_path = "/tmp/ur_dashboard_support_files.zip"
         if os.path.exists(target_path):
             os.remove(target_path)
         resp = self._dashboard_interface.download_support_file(target_path=target_path)
-        self.assertTrue(resp.success)
-        self.assertTrue(os.path.isfile(target_path))
-        if resp.support_files_present:
-            self.assertGreater(os.path.getsize(target_path), 0)
+        if _is_polyscope_x_at_least(ursim_version, "10.14.0"):
+            self.assertTrue(resp.success)
+            self.assertTrue(os.path.isfile(target_path))
+            if resp.support_files_present:
+                self.assertGreater(os.path.getsize(target_path), 0)
+        else:
+            self.assertFalse(resp.success)
+            self.assertFalse(os.path.isfile(target_path))
 
     def test_popup_and_add_to_log(self, ursim_version):
         if _is_older_polyscope_x(ursim_version, "10.14.0"):

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -192,7 +192,7 @@ class DashboardClientTest(unittest.TestCase):
         if ursim_version != "latest":
             self.assertEqual(resp.version.major, _version_tuple(ursim_version)[0])
             self.assertEqual(resp.version.minor, _version_tuple(ursim_version)[1])
-            self.assertEqual(resp.version.patch, _version_tuple(ursim_version)[2])
+            self.assertEqual(resp.version.bugfix, _version_tuple(ursim_version)[2])
 
     def test_get_serial_number(self, ursim_version):
         if _is_older_polyscope_x(ursim_version, "10.14.0"):

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -45,6 +45,31 @@ from test_common import (  # noqa: E402
 )
 
 
+def _version_tuple(version_str):
+    return tuple(int(part) for part in version_str.split(".")[:3])
+
+
+def _is_polyscope_x_at_least(ursim_version, min_version):
+    """
+    Return True if ursim_version is PolyScope X >= min_version.
+
+    ``latest`` is treated as the newest PolyScope X image. Numbered 10.x tags are compared
+    numerically. CB3 / PolyScope 5 tags return False.
+    """
+    if ursim_version == "latest":
+        return True
+    if not ursim_version.startswith("10."):
+        return False
+    return _version_tuple(ursim_version) >= _version_tuple(min_version)
+
+
+def _is_older_polyscope_x(ursim_version, min_version):
+    """Return True for numbered PolyScope X tags older than min_version."""
+    return ursim_version.startswith("10.") and not _is_polyscope_x_at_least(
+        ursim_version, min_version
+    )
+
+
 @pytest.mark.launch_test
 @launch_testing.parametrize(
     "ursim_version, ur_type, autoconnect",
@@ -157,16 +182,20 @@ class DashboardClientTest(unittest.TestCase):
         self.assertTrue(result.success)
 
     def test_get_polyscope_version(self, ursim_version):
-        if ursim_version.startswith("10."):
-            self.skipTest("Getting polyscope version is not supported on PolyScope X")
+        if _is_older_polyscope_x(ursim_version, "10.14.0"):
+            self.skipTest("Getting polyscope version requires PolyScope X >= 10.14.0")
         resp = self._dashboard_interface.get_polyscope_version()
+        if not resp.success and "Not implemented" in resp.answer:
+            self.skipTest("Getting polyscope version requires PolyScope X >= 10.14.0")
         self.assertTrue(resp.success)
         self.assertNotEqual(resp.version.major, 0)
 
     def test_get_serial_number(self, ursim_version):
-        if ursim_version.startswith("10."):
-            self.skipTest("Getting serial number is not supported on PolyScope X")
+        if _is_older_polyscope_x(ursim_version, "10.14.0"):
+            self.skipTest("Getting serial number requires PolyScope X >= 10.14.0")
         resp = self._dashboard_interface.get_serial_number()
+        if not resp.success and "Not implemented" in resp.answer:
+            self.skipTest("Getting serial number requires PolyScope X >= 10.14.0")
         self.assertTrue(resp.success)
         self.assertNotEqual(resp.serial_number, 0)
 
@@ -213,9 +242,11 @@ class DashboardClientTest(unittest.TestCase):
         self.assertIn(resp.operational_mode.mode, ["MANUAL", "AUTOMATIC"])
 
     def test_get_robot_model(self, ursim_version):
-        if ursim_version.startswith("10."):
-            self.skipTest("Getting robot model not supported on PolyScope X, skipping tests")
+        if _is_older_polyscope_x(ursim_version, "10.14.0"):
+            self.skipTest("Getting robot model requires PolyScope X >= 10.14.0")
         resp = self._dashboard_interface.get_robot_model()
+        if not resp.success and "Not implemented" in resp.answer:
+            self.skipTest("Getting robot model requires PolyScope X >= 10.14.0")
         self.assertTrue(resp.success)
         self.assertTrue("UR" in resp.robot_model)
 
@@ -227,15 +258,52 @@ class DashboardClientTest(unittest.TestCase):
         self.assertEqual(resp.safety_status.status, SafetyStatus.NORMAL)
 
     def test_generate_flight_report(self, ursim_version):
-        if ursim_version.startswith("10."):
-            self.skipTest("Generating flight report not supported on PolyScope X, skipping tests")
+        if _is_older_polyscope_x(ursim_version, "10.14.0"):
+            self.skipTest("Generating flight report requires PolyScope X >= 10.14.0")
         resp = self._dashboard_interface.generate_flight_report()
+        if not resp.success and "Not implemented" in resp.answer:
+            self.skipTest("Generating flight report requires PolyScope X >= 10.14.0")
+        # PolyScope X requires remote control for this endpoint.
+        if not resp.success and "Forbidden" in resp.answer:
+            self.skipTest("Generating flight report requires remote control on PolyScope X")
         self.assertTrue(resp.success)
-        self.assertNotEqual(resp.report_id, "")
+        # PolyScope 5 / CB3 return a report id; PolyScope X currently does not.
+        if not ursim_version.startswith("10.") and ursim_version != "latest":
+            self.assertNotEqual(resp.report_id, "")
 
     def test_generate_support_file(self, ursim_version):
-        if ursim_version.startswith("10."):
-            self.skipTest("Generating support file not supported on PolyScope X, skipping tests")
+        if ursim_version.startswith("10.") or ursim_version == "latest":
+            self.skipTest("Generating support file is not supported on PolyScope X")
         resp = self._dashboard_interface.generate_support_file()
         self.assertTrue(resp.success)
         self.assertNotEqual(resp.generated_file_name, "")
+
+    def test_download_support_file(self, ursim_version):
+        if not _is_polyscope_x_at_least(ursim_version, "10.14.0"):
+            self.skipTest("Downloading support files requires PolyScope X >= 10.14.0")
+        target_path = "/tmp/ur_dashboard_support_files.zip"
+        if os.path.exists(target_path):
+            os.remove(target_path)
+        resp = self._dashboard_interface.download_support_file(target_path=target_path)
+        if not resp.success and "Not implemented" in resp.answer:
+            self.skipTest("Downloading support files requires PolyScope X >= 10.14.0")
+        self.assertTrue(resp.success)
+        self.assertTrue(os.path.isfile(target_path))
+        self.assertGreater(os.path.getsize(target_path), 0)
+
+    def test_popup_and_add_to_log(self, ursim_version):
+        if _is_older_polyscope_x(ursim_version, "10.14.0"):
+            self.skipTest("Popup / add_to_log require PolyScope X >= 10.14.0")
+        popup_resp = self._dashboard_interface.popup(message="ROS2 dashboard test", title="Test")
+        if not popup_resp.success and "Not implemented" in popup_resp.answer:
+            self.skipTest("Popup / add_to_log require PolyScope X >= 10.14.0")
+        # PolyScope X requires remote control for popup / log endpoints.
+        if not popup_resp.success and "Forbidden" in popup_resp.answer:
+            self.skipTest("Popup / add_to_log require remote control on PolyScope X")
+        self.assertTrue(popup_resp.success)
+        self.assertTrue(self._dashboard_interface.close_popup().success)
+
+        log_resp = self._dashboard_interface.add_to_log(message="ROS2 dashboard test log")
+        if not log_resp.success and "Forbidden" in log_resp.answer:
+            self.skipTest("add_to_log requires remote control on PolyScope X")
+        self.assertTrue(log_resp.success)

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -79,6 +79,9 @@ def _is_older_polyscope_x(ursim_version, min_version):
         ("3.15.8", "ur10", "true"),
     ],
 )
+@launch_testing.ready_to_test_action_timeout(
+    130
+)  # seconds. We wait for a booted robot for 120 secs
 def generate_test_description(ursim_version, ur_type, autoconnect):
     return generate_dashboard_test_description(ursim_version, ur_type, autoconnect)
 

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -32,6 +32,7 @@ import time
 import unittest
 
 import launch_testing
+import launch_testing.asserts
 import pytest
 import rclpy
 from rclpy.node import Node
@@ -80,6 +81,14 @@ def _is_older_polyscope_x(ursim_version, min_version):
 )
 def generate_test_description(ursim_version, ur_type, autoconnect):
     return generate_dashboard_test_description(ursim_version, ur_type, autoconnect)
+
+
+@launch_testing.post_shutdown_test()
+class TestWaitRobotBootedExitCode(unittest.TestCase):
+    def test_exit_code(self, proc_info, wait_robot_booted):
+        launch_testing.asserts.assertExitCodes(
+            proc_info, process=wait_robot_booted, allowable_exit_codes=[0]
+        )
 
 
 class DashboardClientTest(unittest.TestCase):

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -80,8 +80,8 @@ def _is_older_polyscope_x(ursim_version, min_version):
     ],
 )
 @launch_testing.ready_to_test_action_timeout(
-    130
-)  # seconds. We wait for a booted robot for 120 secs
+    190
+)  # seconds. We wait for a booted robot for 180 secs
 def generate_test_description(ursim_version, ur_type, autoconnect):
     return generate_dashboard_test_description(ursim_version, ur_type, autoconnect)
 

--- a/ur_robot_driver/test/dashboard_client.py
+++ b/ur_robot_driver/test/dashboard_client.py
@@ -290,10 +290,13 @@ class DashboardClientTest(unittest.TestCase):
             os.remove(target_path)
         resp = self._dashboard_interface.download_support_file(target_path=target_path)
         if _is_polyscope_x_at_least(ursim_version, "10.14.0"):
-            self.assertTrue(resp.success)
-            self.assertTrue(os.path.isfile(target_path))
-            if resp.support_files_present:
-                self.assertGreater(os.path.getsize(target_path), 0)
+            # On a simulator that results in a 404 error.
+            if not resp.success:
+                self.assertIn("404", resp.answer)
+            elif resp.support_files_present:
+                self.assertTrue(os.path.isfile(target_path))
+                if resp.support_files_present:
+                    self.assertGreater(os.path.getsize(target_path), 0)
         else:
             self.assertFalse(resp.success)
             self.assertFalse(os.path.isfile(target_path))

--- a/ur_robot_driver/test/test_common.py
+++ b/ur_robot_driver/test/test_common.py
@@ -56,6 +56,7 @@ from std_srvs.srv import Trigger
 from ur_dashboard_msgs.msg import RobotMode
 from ur_dashboard_msgs.srv import (
     DownloadProgram,
+    DownloadSupportFile,
     GetLoadedProgram,
     GetProgramState,
     GetPrograms,
@@ -74,6 +75,8 @@ from ur_dashboard_msgs.srv import (
     GetSafetyStatus,
     SetOperationalMode,
     SetUserRole,
+    AddToLog,
+    Popup,
 )
 from ur_msgs.srv import (
     SetIO,
@@ -301,6 +304,7 @@ class DashboardInterface(
         "upload_program": UploadProgram,
         "update_program": UploadProgram,
         "download_program": DownloadProgram,
+        "download_support_file": DownloadSupportFile,
         "clear_operational_mode": Trigger,
         "generate_flight_report": GenerateFlightReport,
         "generate_support_file": GenerateSupportFile,
@@ -312,6 +316,9 @@ class DashboardInterface(
         "get_user_role": GetUserRole,
         "set_operational_mode": SetOperationalMode,
         "set_user_role": SetUserRole,
+        "add_to_log": AddToLog,
+        "popup": Popup,
+        "shutdown": Trigger,
     },
 ):
     def start_robot(self):

--- a/ur_robot_driver/test/test_common.py
+++ b/ur_robot_driver/test/test_common.py
@@ -594,9 +594,12 @@ def generate_dashboard_test_description(ursim_version="latest", ur_type="ur5e", 
         OnProcessExit(target_action=wait_robot_booted, on_exit=[ReadyToTest(), dashboard_client])
     )
 
-    return LaunchDescription(
-        _declare_launch_arguments()
-        + [wait_robot_booted, starter, _ursim_action(ursim_version, ur_type)]
+    return (
+        LaunchDescription(
+            _declare_launch_arguments()
+            + [wait_robot_booted, starter, _ursim_action(ursim_version, ur_type)]
+        ),
+        {"wait_robot_booted": wait_robot_booted},
     )
 
 

--- a/ur_robot_driver/test/test_common.py
+++ b/ur_robot_driver/test/test_common.py
@@ -519,6 +519,25 @@ def _declare_launch_arguments():
     return declared_arguments
 
 
+def _wait_robot_booted_action():
+    """Wait until dashboard or Robot API is reachable. Not a ROS node."""
+    return ExecuteProcess(
+        cmd=[
+            PathJoinSubstitution(
+                [
+                    FindPackagePrefix("ur_robot_driver"),
+                    "lib",
+                    "ur_robot_driver",
+                    "wait_robot_booted.py",
+                ]
+            ),
+            "192.168.56.101",
+        ],
+        name="wait_robot_booted",
+        output="screen",
+    )
+
+
 def _ursim_action(
     ursim_version="latest",
     ur_type="ur5e",
@@ -569,10 +588,15 @@ def generate_dashboard_test_description(ursim_version="latest", ur_type="ur5e", 
             "autoconnect": autoconnect,
         }.items(),
     )
+    wait_robot_booted = _wait_robot_booted_action()
+
+    starter = RegisterEventHandler(
+        OnProcessExit(target_action=wait_robot_booted, on_exit=[ReadyToTest(), dashboard_client])
+    )
 
     return LaunchDescription(
         _declare_launch_arguments()
-        + [ReadyToTest(), dashboard_client, _ursim_action(ursim_version, ur_type)]
+        + [wait_robot_booted, starter, _ursim_action(ursim_version, ur_type)]
     )
 
 


### PR DESCRIPTION
Add Dashboard Client (RobotAPI) support for new calls in PolyScope X 10.14.0.

This requires https://github.com/UniversalRobots/Universal_Robots_Client_Library/pull/549

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches robot control/dashboard surfaces (popup, shutdown, support download, version parsing) and depends on a new client-library release; integration test timing changes could mask or expose flaky CI.
> 
> **Overview**
> Adds **PolyScope X 10.14.0** dashboard/Robot API coverage in the ROS driver: new **`DownloadSupportFile`** service (zip to a local `target_path`, with `support_files_present` when the API returns 204), **`Popup`** extended with an optional **`title`**, and **`get_polyscope_version`** parsing updated for shorter version strings (e.g. `10.14.0`).
> 
> The dashboard client forwards popup title and download-support-file calls to **ur_client_library** (depends on the matching client-library PR). Docs now mark which services need **>= 10.14.0** on PolyScope X and point PolyScope X users at download instead of generate for support files.
> 
> Integration tests gain **`wait_robot_booted.py`** (dashboard port or Robot API OpenAPI), launch ordering so the dashboard starts after the sim is up, a **10.14.0** URSim matrix entry, longer dashboard test timeouts, and version-gated tests for the new/expanded APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec1d02590d424595d03c7ab8ba85649f1b70bde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->