### PR TITLE
[RobotStateHelper] Fix worker thread lifecycle management

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -133,18 +133,27 @@ target_link_libraries(controller_stopper_node PRIVATE
 #
 # robot_state_helper
 #
-add_executable(robot_state_helper
+add_library(robot_state_helper_lib SHARED
   src/robot_state_helper.cpp
-  src/robot_state_helper_node.cpp
   src/urcl_log_handler.cpp
 )
-target_link_libraries(robot_state_helper PUBLIC
+target_include_directories(robot_state_helper_lib PUBLIC
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
+)
+target_link_libraries(robot_state_helper_lib PUBLIC
   ${std_msgs_TARGETS}
   ${std_srvs_TARGETS}
   ${ur_dashboard_msgs_TARGETS}
   rclcpp::rclcpp
   rclcpp_action::rclcpp_action
   ur_client_library::urcl
+)
+add_executable(robot_state_helper
+  src/robot_state_helper_node.cpp
+)
+target_link_libraries(robot_state_helper
+  robot_state_helper_lib
 )
 
 add_executable(urscript_interface
@@ -182,6 +191,12 @@ install(
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(
+  TARGETS robot_state_helper_lib
+  EXPORT export_${PROJECT_NAME}
+  DESTINATION lib
+)
+
 # INSTALL
 install(
   TARGETS
@@ -216,6 +231,7 @@ ament_export_dependencies(
   hardware_interface
   pluginlib
   rclcpp
+  rclcpp_action
   rclcpp_lifecycle
   controller_manager
   controller_manager_msgs

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -284,6 +284,14 @@ if(BUILD_TESTING)
     ur_robot_driver_plugin
   )
 
+  ament_add_gmock(test_robot_state_helper
+    test/test_robot_state_helper.cpp
+  )
+  target_link_libraries(test_robot_state_helper
+    robot_state_helper_lib
+    rclcpp::rclcpp
+  )
+
   add_launch_test(test/test_mock_hardware.py
     TIMEOUT
       800

--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -290,6 +290,8 @@ if(BUILD_TESTING)
   target_link_libraries(test_robot_state_helper
     robot_state_helper_lib
     rclcpp::rclcpp
+    rclcpp_action::rclcpp_action
+    ${std_srvs_TARGETS}
   )
 
   add_launch_test(test/test_mock_hardware.py

--- a/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
@@ -68,8 +68,7 @@ protected:
   }
 
 private:
-  // Grant the test wrapper access to private state (robot_mode_, safety_mode_, in_action_)
-  // and the goal callback.
+  // Grant the test wrapper access to private state and action callbacks.
   friend class RobotStateHelperTestWrapper;
 
   void robotModeCallback(ur_dashboard_msgs::msg::RobotMode::SharedPtr msg);

--- a/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
@@ -87,6 +87,7 @@ private:
                                                   std::shared_ptr<const ur_dashboard_msgs::action::SetMode::Goal> goal);
   rclcpp_action::CancelResponse setModeCancelCallback(const std::shared_ptr<SetModeGoalHandle> goal_handle);
 
+  bool shouldGoalTerminate() const;
   void setTerminalState(bool success, std::string_view message = "");
 
   void setModeExecute(const std::shared_ptr<SetModeGoalHandle> goal_handle);

--- a/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
@@ -29,6 +29,7 @@
 #ifndef UR_ROBOT_DRIVER__ROBOT_STATE_HELPER_HPP_
 #define UR_ROBOT_DRIVER__ROBOT_STATE_HELPER_HPP_
 
+#include <string_view>
 #include <optional>
 #include <string>
 #include <memory>
@@ -89,7 +90,7 @@ private:
                                                   std::shared_ptr<const ur_dashboard_msgs::action::SetMode::Goal> goal);
   rclcpp_action::CancelResponse setModeCancelCallback(const std::shared_ptr<SetModeGoalHandle> goal_handle);
 
-  void handleStopRequested();
+  void setTerminalState(bool success, std::string_view message = "");
 
   void setModeExecute(const std::shared_ptr<SetModeGoalHandle> goal_handle);
 

--- a/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
@@ -75,8 +75,6 @@ private:
   void robotModeCallback(ur_dashboard_msgs::msg::RobotMode::SharedPtr msg);
   void safetyModeCallback(ur_dashboard_msgs::msg::SafetyMode::SharedPtr msg);
 
-  void updateRobotState();
-
   bool recoverFromSafety();
   bool doTransition(const urcl::RobotMode target_mode);
   bool jumpToRobotMode(const urcl::RobotMode target_mode);

--- a/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
@@ -32,8 +32,8 @@
 #include <string>
 #include <memory>
 
-#include "rclcpp/rclcpp.hpp"
-#include "rclcpp_action/create_server.hpp"
+#include "rclcpp/node.hpp"
+#include "rclcpp_action/server.hpp"
 #include "std_msgs/msg/bool.hpp"
 #include "std_srvs/srv/trigger.hpp"
 
@@ -45,18 +45,26 @@
 
 namespace ur_robot_driver
 {
-class RobotStateHelper
+class RobotStateHelper : public rclcpp::Node
 {
 public:
   using SetModeGoalHandle = rclcpp_action::ServerGoalHandle<ur_dashboard_msgs::action::SetMode>;
 
-  explicit RobotStateHelper(const rclcpp::Node::SharedPtr& node);
-  RobotStateHelper() = delete;
-  virtual ~RobotStateHelper() = default;
+  explicit RobotStateHelper(const rclcpp::NodeOptions& options);
+  ~RobotStateHelper();
+
+protected:
+  // Constructor meant for test purposes mainly. Constructs a helper without the ROS service
+  // interfaces.
+  RobotStateHelper()
+    : rclcpp::Node("robot_state_helper")
+    , robot_mode_(urcl::RobotMode::UNKNOWN)
+    , safety_mode_(urcl::SafetyMode::UNDEFINED_SAFETY_MODE)
+    , in_action_(false)
+  {
+  }
 
 private:
-  rclcpp::Node::SharedPtr node_;
-
   void robotModeCallback(ur_dashboard_msgs::msg::RobotMode::SharedPtr msg);
   void safetyModeCallback(ur_dashboard_msgs::msg::SafetyMode::SharedPtr msg);
 

--- a/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
@@ -105,6 +105,7 @@ private:
   std::atomic<urcl::SafetyMode> safety_mode_;
   std::atomic<bool> error_ = false;
   std::atomic<bool> in_action_;
+  std::atomic<bool> goal_pending_ = false;
   std::atomic<bool> program_running_;
 
   // workers poll this to exit their wait loops and dashboard-service calls before the helper is torn down.

--- a/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
+++ b/ur_robot_driver/include/ur_robot_driver/robot_state_helper.hpp
@@ -29,8 +29,10 @@
 #ifndef UR_ROBOT_DRIVER__ROBOT_STATE_HELPER_HPP_
 #define UR_ROBOT_DRIVER__ROBOT_STATE_HELPER_HPP_
 
+#include <optional>
 #include <string>
 #include <memory>
+#include <thread>
 
 #include "rclcpp/node.hpp"
 #include "rclcpp_action/server.hpp"
@@ -65,6 +67,10 @@ protected:
   }
 
 private:
+  // Grant the test wrapper access to private state (robot_mode_, safety_mode_, in_action_)
+  // and the goal callback.
+  friend class RobotStateHelperTestWrapper;
+
   void robotModeCallback(ur_dashboard_msgs::msg::RobotMode::SharedPtr msg);
   void safetyModeCallback(ur_dashboard_msgs::msg::SafetyMode::SharedPtr msg);
 
@@ -74,7 +80,7 @@ private:
   bool doTransition(const urcl::RobotMode target_mode);
   bool jumpToRobotMode(const urcl::RobotMode target_mode);
 
-  bool safeDashboardTrigger(rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr srv);
+  std::optional<bool> safeDashboardTrigger(rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr srv);
 
   bool stopProgram();
 
@@ -82,6 +88,8 @@ private:
   rclcpp_action::GoalResponse setModeGoalCallback(const rclcpp_action::GoalUUID& uuid,
                                                   std::shared_ptr<const ur_dashboard_msgs::action::SetMode::Goal> goal);
   rclcpp_action::CancelResponse setModeCancelCallback(const std::shared_ptr<SetModeGoalHandle> goal_handle);
+
+  void handleStopRequested();
 
   void setModeExecute(const std::shared_ptr<SetModeGoalHandle> goal_handle);
 
@@ -97,6 +105,10 @@ private:
   std::atomic<bool> error_ = false;
   std::atomic<bool> in_action_;
   std::atomic<bool> program_running_;
+
+  // workers poll this to exit their wait loops and dashboard-service calls before the helper is torn down.
+  std::atomic<bool> stop_requested_ = false;
+  std::thread worker_thread_;
   std::mutex goal_mutex_;
 
   std::string robot_ip_;

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -43,6 +43,7 @@
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>rclpy</depend>
   <depend>std_msgs</depend>

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -118,7 +118,7 @@ void RobotStateHelper::robotModeCallback(ur_dashboard_msgs::msg::RobotMode::Shar
     RCLCPP_INFO_STREAM(get_logger(), "The robot is currently in mode " << robotModeString(robot_mode_) << ".");
     {
       std::scoped_lock lock(goal_mutex_);
-      if (in_action_) {
+      if (in_action_ && current_goal_handle_->is_active()) {
         feedback_->current_robot_mode =
             static_cast<ur_dashboard_msgs::action::SetMode::Feedback::_current_robot_mode_type>(robot_mode_.load());
         current_goal_handle_->publish_feedback(feedback_);
@@ -134,7 +134,7 @@ void RobotStateHelper::safetyModeCallback(ur_dashboard_msgs::msg::SafetyMode::Sh
     RCLCPP_INFO_STREAM(get_logger(), "The robot is currently in safety mode " << safetyModeString(safety_mode_) << ".");
     {
       std::scoped_lock lock(goal_mutex_);
-      if (in_action_) {
+      if (in_action_ && current_goal_handle_->is_active()) {
         feedback_->current_safety_mode =
             static_cast<ur_dashboard_msgs::action::SetMode::Feedback::_current_safety_mode_type>(safety_mode_.load());
         current_goal_handle_->publish_feedback(feedback_);

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -263,7 +263,7 @@ std::optional<bool> RobotStateHelper::safeDashboardTrigger(rclcpp::Client<std_sr
   auto future = srv->async_send_request(request);
   // Poll in short intervals so a shutdown request is honoured promptly.
   while (future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready) {
-    if (stop_requested_ || !rclcpp::ok()) {
+    if (shouldGoalTerminate()) {
       srv->remove_pending_request(future);
       return std::nullopt;
     }
@@ -317,7 +317,7 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
   const auto goal = goal_handle->get_goal();
   this->goal_ = goal;
   urcl::RobotMode target_mode;
-  if (stop_requested_ || !rclcpp::ok()) {
+  if (shouldGoalTerminate()) {
     setTerminalState(false);
     return;
   }
@@ -332,7 +332,7 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
             setTerminalState(false, "Stopping the program failed.");
             return;
           }
-          if (stop_requested_ || !rclcpp::ok()) {
+          if (shouldGoalTerminate()) {
             setTerminalState(false);
             return;
           }
@@ -340,14 +340,14 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
         if (robot_mode_ != target_mode || safety_mode_ > urcl::SafetyMode::REDUCED) {
           RCLCPP_INFO_STREAM(get_logger(), "Target mode was set to " << robotModeString(target_mode) << ".");
           if (!doTransition(target_mode)) {
-            if (stop_requested_ || !rclcpp::ok()) {
+            if (shouldGoalTerminate()) {
               setTerminalState(false);
               return;
             }
             setTerminalState(false, "Transition to target mode failed.");
             return;
           }
-          if (stop_requested_ || !rclcpp::ok()) {
+          if (shouldGoalTerminate()) {
             setTerminalState(false);
             return;
           }
@@ -375,13 +375,13 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
   }
 
   // Wait until the robot reached the target mode or something went wrong.
-  while (robot_mode_ != target_mode && !error_ && !stop_requested_ && rclcpp::ok()) {
+  while (robot_mode_ != target_mode && !error_ && !shouldGoalTerminate()) {
     RCLCPP_INFO(get_logger(), "Waiting for robot to reach target mode... Current_mode: %s",
                 robotModeString(robot_mode_).c_str());
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
 
-  if (stop_requested_ || !rclcpp::ok()) {
+  if (shouldGoalTerminate()) {
     setTerminalState(false);
     return;
   }
@@ -409,10 +409,10 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
         } else {
           // The dashboard denies playing immediately after switching the mode to RUNNING.
           // Poll so cancel/shutdown is honoured during this delay.
-          for (int i = 0; i < 10 && !stop_requested_ && rclcpp::ok(); ++i) {
+          for (int i = 0; i < 10 && !shouldGoalTerminate(); ++i) {
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
           }
-          if (stop_requested_ || !rclcpp::ok()) {
+          if (shouldGoalTerminate()) {
             setTerminalState(false);
             return;
           }
@@ -504,8 +504,12 @@ RobotStateHelper::setModeCancelCallback(const std::shared_ptr<RobotStateHelper::
     return rclcpp_action::CancelResponse::REJECT;
   }
   RCLCPP_INFO(get_logger(), "Cancelling the current SetMode action.");
-  stop_requested_ = true;
   return rclcpp_action::CancelResponse::ACCEPT;
+}
+
+bool RobotStateHelper::shouldGoalTerminate() const
+{
+  return stop_requested_ || !rclcpp::ok() || (current_goal_handle_ && current_goal_handle_->is_canceling());
 }
 
 }  // namespace ur_robot_driver

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -103,6 +103,14 @@ RobotStateHelper::RobotStateHelper(const rclcpp::NodeOptions& options)
       std::bind(&RobotStateHelper::setModeAcceptCallback, this, std::placeholders::_1));
 }
 
+RobotStateHelper::~RobotStateHelper()
+{
+  stop_requested_ = true;
+  if (worker_thread_.joinable()) {
+    worker_thread_.join();
+  }
+}
+
 void RobotStateHelper::robotModeCallback(ur_dashboard_msgs::msg::RobotMode::SharedPtr msg)
 {
   if (robot_mode_ != static_cast<urcl::RobotMode>(msg->mode)) {
@@ -151,7 +159,12 @@ bool RobotStateHelper::recoverFromSafety()
     case urcl::SafetyMode::VIOLATION:;
     case urcl::SafetyMode::FAULT:
       if (restart_safety_srv_ != nullptr) {
-        return safeDashboardTrigger(this->restart_safety_srv_);
+        auto call_result = safeDashboardTrigger(restart_safety_srv_);
+        if (!call_result.has_value()) {
+          RCLCPP_WARN_STREAM(get_logger(), "The safety restart service call was interrupted by a shutdown request.");
+          return false;
+        }
+        return call_result.value();
       } else {
         return false;
       }
@@ -239,12 +252,17 @@ bool RobotStateHelper::doTransition(const urcl::RobotMode target_mode)
   return false;
 }
 
-bool RobotStateHelper::safeDashboardTrigger(rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr srv)
+std::optional<bool> RobotStateHelper::safeDashboardTrigger(rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr srv)
 {
   assert(srv != nullptr);
   auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
   auto future = srv->async_send_request(request);
-  future.wait();
+  // Poll in short intervals so a shutdown request is honoured promptly.
+  while (future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready) {
+    if (stop_requested_) {
+      return std::nullopt;
+    }
+  }
   auto result = future.get();
   RCLCPP_INFO_STREAM(get_logger(), "Service response received: " << result->message);
   return result->success;
@@ -252,7 +270,21 @@ bool RobotStateHelper::safeDashboardTrigger(rclcpp::Client<std_srvs::srv::Trigge
 
 void RobotStateHelper::setModeAcceptCallback(const std::shared_ptr<RobotStateHelper::SetModeGoalHandle> goal_handle)
 {
-  std::thread{ std::bind(&RobotStateHelper::setModeExecute, this, std::placeholders::_1), goal_handle }.detach();
+  // Join any previously completed worker before reusing worker_thread_. The goal
+  // callback has already reserved in_action_; the previous worker cleared that
+  // flag when it left setModeExecute, so this join is non-blocking.
+  if (worker_thread_.joinable()) {
+    worker_thread_.join();
+  }
+  {
+    std::scoped_lock lock(goal_mutex_);
+    // Reset stop state and install the new handle atomically so a cancel cannot
+    // be lost to a later clear, and a stale cancel cannot latch onto this goal.
+    stop_requested_ = false;
+    current_goal_handle_ = goal_handle;
+  }
+  worker_thread_ =
+      std::thread{ std::bind(&RobotStateHelper::setModeExecute, this, std::placeholders::_1), goal_handle };
 }
 
 bool RobotStateHelper::stopProgram()
@@ -268,14 +300,23 @@ bool RobotStateHelper::stopProgram()
 
 void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::SetModeGoalHandle> goal_handle)
 {
+  // Ensure in_action_ is always cleared when this function returns, regardless
+  // of which exit path is taken.
+  struct InActionGuard
   {
-    std::scoped_lock lock(goal_mutex_);
-    current_goal_handle_ = goal_handle;
-  }
-  in_action_ = true;
+    std::atomic<bool>& flag;
+    ~InActionGuard()
+    {
+      flag = false;
+    }
+  } in_action_guard{ in_action_ };
   const auto goal = goal_handle->get_goal();
   this->goal_ = goal;
   urcl::RobotMode target_mode;
+  if (stop_requested_ || !rclcpp::ok()) {
+    handleStopRequested();
+    return;
+  }
   try {
     target_mode = static_cast<urcl::RobotMode>(goal->target_robot_mode);
     switch (target_mode) {
@@ -290,14 +331,26 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
             current_goal_handle_->abort(result_);
             return;
           }
+          if (stop_requested_ || !rclcpp::ok()) {
+            handleStopRequested();
+            return;
+          }
         }
         if (robot_mode_ != target_mode || safety_mode_ > urcl::SafetyMode::REDUCED) {
           RCLCPP_INFO_STREAM(get_logger(), "Target mode was set to " << robotModeString(target_mode) << ".");
           if (!doTransition(target_mode)) {
+            if (stop_requested_ || !rclcpp::ok()) {
+              handleStopRequested();
+              return;
+            }
             result_->message = "Transition to target mode failed.";
             result_->success = false;
             std::scoped_lock lock(goal_mutex_);
             current_goal_handle_->abort(result_);
+            return;
+          }
+          if (stop_requested_ || !rclcpp::ok()) {
+            handleStopRequested();
             return;
           }
         }
@@ -338,11 +391,16 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
     return;
   }
 
-  // Wait until the robot reached the target mode or something went wrong
-  while (robot_mode_ != target_mode && !error_) {
+  // Wait until the robot reached the target mode or something went wrong.
+  while (robot_mode_ != target_mode && !error_ && !stop_requested_ && rclcpp::ok()) {
     RCLCPP_INFO(get_logger(), "Waiting for robot to reach target mode... Current_mode: %s",
                 robotModeString(robot_mode_).c_str());
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  }
+
+  if (stop_requested_ || !rclcpp::ok()) {
+    handleStopRequested();
+    return;
   }
 
   if (robot_mode_ == target_mode) {
@@ -350,15 +408,36 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
     result_->message = "Reached target robot mode.";
     if (robot_mode_ == urcl::RobotMode::RUNNING && goal_->play_program && !program_running_) {
       if (headless_mode_) {
-        result_->success = safeDashboardTrigger(this->resend_robot_program_srv_);
+        auto call_result = safeDashboardTrigger(this->resend_robot_program_srv_);
+        if (!call_result.has_value()) {
+          handleStopRequested();
+          return;
+        } else if (!call_result.value()) {
+          result_->success = false;
+          result_->message = "Resending the robot program failed.";
+        }
       } else {
         if (play_program_srv_ == nullptr) {
           result_->success = false;
           result_->message = "Play program service not available on this robot.";
         } else {
-          // The dashboard denies playing immediately after switching the mode to RUNNING
-          std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-          result_->success = safeDashboardTrigger(this->play_program_srv_);
+          // The dashboard denies playing immediately after switching the mode to RUNNING.
+          // Poll so cancel/shutdown is honoured during this delay.
+          for (int i = 0; i < 10 && !stop_requested_ && rclcpp::ok(); ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+          }
+          if (stop_requested_ || !rclcpp::ok()) {
+            handleStopRequested();
+            return;
+          }
+          auto call_result = safeDashboardTrigger(this->play_program_srv_);
+          if (!call_result.has_value()) {
+            handleStopRequested();
+            return;
+          } else if (!call_result.value()) {
+            result_->success = false;
+            result_->message = "Starting the robot program failed.";
+          }
         }
       }
     }
@@ -381,10 +460,25 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
   }
 }
 
+void RobotStateHelper::handleStopRequested()
+{
+  std::scoped_lock lock(goal_mutex_);
+  result_->success = false;
+  if (current_goal_handle_->is_canceling()) {
+    result_->message = "SetMode action cancelled by user request.";
+    current_goal_handle_->canceled(result_);
+  } else {
+    result_->message = "SetMode action stopped.";
+    current_goal_handle_->abort(result_);
+  }
+}
+
 rclcpp_action::GoalResponse RobotStateHelper::setModeGoalCallback(
     const rclcpp_action::GoalUUID& uuid, std::shared_ptr<const ur_dashboard_msgs::action::SetMode::Goal> goal)
 {
   (void)uuid;
+  (void)goal;
+
   if (robot_mode_ == urcl::RobotMode::UNKNOWN) {
     RCLCPP_ERROR_STREAM(get_logger(), "Robot mode is unknown. Cannot accept goal, yet. Is "
                                       "the robot switched on and connected to the driver?");
@@ -396,15 +490,31 @@ rclcpp_action::GoalResponse RobotStateHelper::setModeGoalCallback(
                                       "the robot switched on and connected to the driver?");
     return rclcpp_action::GoalResponse::REJECT;
   }
+
+  {
+    // Reserve the slot before returning ACCEPT so a second goal callback cannot
+    // also accept while this goal is waiting for its accept callback to run.
+    std::scoped_lock lock(goal_mutex_);
+    if (in_action_) {
+      RCLCPP_WARN_STREAM(get_logger(), "A SetMode action is already in progress. Rejecting new goal.");
+      return rclcpp_action::GoalResponse::REJECT;
+    }
+    in_action_ = true;
+  }
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }
 
 rclcpp_action::CancelResponse
 RobotStateHelper::setModeCancelCallback(const std::shared_ptr<RobotStateHelper::SetModeGoalHandle> goal_handle)
 {
-  RCLCPP_INFO(get_logger(), "Received request to cancel goal");
-  (void)goal_handle;
-  return rclcpp_action::CancelResponse::REJECT;
+  std::scoped_lock lock(goal_mutex_);
+  if (!in_action_ || !current_goal_handle_ || goal_handle->get_goal_id() != current_goal_handle_->get_goal_id()) {
+    RCLCPP_WARN(get_logger(), "No matching SetMode action is currently running. Cannot cancel.");
+    return rclcpp_action::CancelResponse::REJECT;
+  }
+  RCLCPP_INFO(get_logger(), "Cancelling the current SetMode action.");
+  stop_requested_ = true;
+  return rclcpp_action::CancelResponse::ACCEPT;
 }
 
 }  // namespace ur_robot_driver

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -315,7 +315,7 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
   this->goal_ = goal;
   urcl::RobotMode target_mode;
   if (stop_requested_ || !rclcpp::ok()) {
-    handleStopRequested();
+    setTerminalState(false);
     return;
   }
   try {
@@ -326,14 +326,11 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
       case urcl::RobotMode::RUNNING:
         if (goal_->stop_program && program_running_) {
           if (!stopProgram()) {
-            result_->message = "Stopping the program failed.";
-            result_->success = false;
-            std::scoped_lock lock(goal_mutex_);
-            current_goal_handle_->abort(result_);
+            setTerminalState(false, "Stopping the program failed.");
             return;
           }
           if (stop_requested_ || !rclcpp::ok()) {
-            handleStopRequested();
+            setTerminalState(false);
             return;
           }
         }
@@ -341,17 +338,14 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
           RCLCPP_INFO_STREAM(get_logger(), "Target mode was set to " << robotModeString(target_mode) << ".");
           if (!doTransition(target_mode)) {
             if (stop_requested_ || !rclcpp::ok()) {
-              handleStopRequested();
+              setTerminalState(false);
               return;
             }
-            result_->message = "Transition to target mode failed.";
-            result_->success = false;
-            std::scoped_lock lock(goal_mutex_);
-            current_goal_handle_->abort(result_);
+            setTerminalState(false, "Transition to target mode failed.");
             return;
           }
           if (stop_requested_ || !rclcpp::ok()) {
-            handleStopRequested();
+            setTerminalState(false);
             return;
           }
         }
@@ -363,32 +357,17 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
       case urcl::RobotMode::POWER_ON:
       case urcl::RobotMode::BACKDRIVE:
       case urcl::RobotMode::UPDATING_FIRMWARE:
-        result_->message =
-            "Requested target mode " + robotModeString(target_mode) + " which cannot be explicitly selected.";
-        result_->success = false;
-        {
-          std::scoped_lock lock(goal_mutex_);
-          current_goal_handle_->abort(result_);
-        }
+        setTerminalState(false, "Requested target mode " + robotModeString(target_mode) +
+                                    " which cannot be explicitly selected.");
         return;
         break;
       default:
-        result_->message = "Requested illegal mode.";
-        result_->success = false;
-        {
-          std::scoped_lock lock(goal_mutex_);
-          current_goal_handle_->abort(result_);
-        }
+        setTerminalState(false, "Requested target mode " + robotModeString(target_mode) + " is not a valid mode.");
         return;
         break;
     }
   } catch (const std::invalid_argument& e) {
-    result_->message = e.what();
-    result_->success = false;
-    {
-      std::scoped_lock lock(goal_mutex_);
-      current_goal_handle_->abort(result_);
-    }
+    setTerminalState(false, e.what());
     return;
   }
 
@@ -400,27 +379,30 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
   }
 
   if (stop_requested_ || !rclcpp::ok()) {
-    handleStopRequested();
+    setTerminalState(false);
     return;
   }
 
+  std::string result_message;
+  bool result_success;
+
   if (robot_mode_ == target_mode) {
-    result_->success = true;
-    result_->message = "Reached target robot mode.";
+    result_success = true;
+    result_message = "Reached target robot mode.";
     if (robot_mode_ == urcl::RobotMode::RUNNING && goal_->play_program && !program_running_) {
       if (headless_mode_) {
         auto call_result = safeDashboardTrigger(this->resend_robot_program_srv_);
         if (!call_result.has_value()) {
-          handleStopRequested();
+          setTerminalState(false, "Resending the robot program was interrupted by a shutdown/cancel request.");
           return;
         } else if (!call_result.value()) {
-          result_->success = false;
-          result_->message = "Resending the robot program failed.";
+          result_success = false;
+          result_message = "Resending the robot program failed.";
         }
       } else {
         if (play_program_srv_ == nullptr) {
-          result_->success = false;
-          result_->message = "Play program service not available on this robot.";
+          result_success = false;
+          result_message = "Play program service not available on this robot.";
         } else {
           // The dashboard denies playing immediately after switching the mode to RUNNING.
           // Poll so cancel/shutdown is honoured during this delay.
@@ -428,48 +410,53 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
           }
           if (stop_requested_ || !rclcpp::ok()) {
-            handleStopRequested();
+            setTerminalState(false);
             return;
           }
           auto call_result = safeDashboardTrigger(this->play_program_srv_);
           if (!call_result.has_value()) {
-            handleStopRequested();
+            setTerminalState(false);
             return;
           } else if (!call_result.value()) {
-            result_->success = false;
-            result_->message = "Starting the robot program failed.";
+            result_success = false;
+            result_message = "Starting the robot program failed.";
           }
         }
       }
     }
-    if (result_->success) {
-      std::scoped_lock lock(goal_mutex_);
-      current_goal_handle_->succeed(result_);
-    } else {
-      std::scoped_lock lock(goal_mutex_);
-      current_goal_handle_->abort(result_);
-    }
   } else {
-    result_->success = false;
-    result_->message = "Robot reached higher mode than requested during recovery. This either means that something "
-                       "went wrong or that a higher mode was requested from somewhere else (e.g. the teach "
-                       "pendant.)";
-    {
-      std::scoped_lock lock(goal_mutex_);
-      current_goal_handle_->abort(result_);
-    }
+    result_success = false;
+    result_message = "Robot reached higher mode than requested during recovery. This either means that something "
+                     "went wrong or that a higher mode was requested from somewhere else (e.g. the teach "
+                     "pendant.)";
   }
+  setTerminalState(result_success, result_message);
 }
 
-void RobotStateHelper::handleStopRequested()
+void RobotStateHelper::setTerminalState(bool success, std::string_view message)
 {
   std::scoped_lock lock(goal_mutex_);
-  result_->success = false;
   if (current_goal_handle_->is_canceling()) {
-    result_->message = "SetMode action cancelled by user request.";
+    result_->success = false;
+    // Keep an explicit failure reason if we have one; otherwise use the cancel default
+    // (do not report a success message on a canceled goal).
+    if (!success && !message.empty()) {
+      result_->message = message;
+    } else {
+      result_->message = "SetMode action cancelled by user request.";
+    }
     current_goal_handle_->canceled(result_);
+  } else if (success) {
+    result_->success = true;
+    result_->message = message;
+    current_goal_handle_->succeed(result_);
   } else {
-    result_->message = "SetMode action stopped.";
+    result_->success = false;
+    if (!message.empty()) {
+      result_->message = message;
+    } else {
+      result_->message = "SetMode action stopped.";
+    }
     current_goal_handle_->abort(result_);
   }
 }

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -116,11 +116,13 @@ void RobotStateHelper::robotModeCallback(ur_dashboard_msgs::msg::RobotMode::Shar
   if (robot_mode_ != static_cast<urcl::RobotMode>(msg->mode)) {
     robot_mode_ = urcl::RobotMode(msg->mode);
     RCLCPP_INFO_STREAM(get_logger(), "The robot is currently in mode " << robotModeString(robot_mode_) << ".");
-    if (in_action_) {
+    {
       std::scoped_lock lock(goal_mutex_);
-      feedback_->current_robot_mode =
-          static_cast<ur_dashboard_msgs::action::SetMode::Feedback::_current_robot_mode_type>(robot_mode_.load());
-      current_goal_handle_->publish_feedback(feedback_);
+      if (in_action_) {
+        feedback_->current_robot_mode =
+            static_cast<ur_dashboard_msgs::action::SetMode::Feedback::_current_robot_mode_type>(robot_mode_.load());
+        current_goal_handle_->publish_feedback(feedback_);
+      }
     }
   }
 }
@@ -130,11 +132,13 @@ void RobotStateHelper::safetyModeCallback(ur_dashboard_msgs::msg::SafetyMode::Sh
   if (safety_mode_ != static_cast<urcl::SafetyMode>(msg->mode)) {
     safety_mode_ = urcl::SafetyMode(msg->mode);
     RCLCPP_INFO_STREAM(get_logger(), "The robot is currently in safety mode " << safetyModeString(safety_mode_) << ".");
-    if (in_action_) {
+    {
       std::scoped_lock lock(goal_mutex_);
-      feedback_->current_safety_mode =
-          static_cast<ur_dashboard_msgs::action::SetMode::Feedback::_current_safety_mode_type>(safety_mode_.load());
-      current_goal_handle_->publish_feedback(feedback_);
+      if (in_action_) {
+        feedback_->current_safety_mode =
+            static_cast<ur_dashboard_msgs::action::SetMode::Feedback::_current_safety_mode_type>(safety_mode_.load());
+        current_goal_handle_->publish_feedback(feedback_);
+      }
     }
   }
 }

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -165,7 +165,8 @@ bool RobotStateHelper::recoverFromSafety()
       if (restart_safety_srv_ != nullptr) {
         auto call_result = safeDashboardTrigger(restart_safety_srv_);
         if (!call_result.has_value()) {
-          RCLCPP_WARN_STREAM(get_logger(), "The safety restart service call was interrupted by a shutdown or cancellation request.");
+          RCLCPP_WARN_STREAM(get_logger(), "The safety restart service call was interrupted by a shutdown or "
+                                           "cancellation request.");
           return false;
         }
         return call_result.value();

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -260,6 +260,7 @@ std::optional<bool> RobotStateHelper::safeDashboardTrigger(rclcpp::Client<std_sr
   // Poll in short intervals so a shutdown request is honoured promptly.
   while (future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready) {
     if (stop_requested_) {
+      srv->remove_pending_request(future);
       return std::nullopt;
     }
   }

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -165,7 +165,7 @@ bool RobotStateHelper::recoverFromSafety()
       if (restart_safety_srv_ != nullptr) {
         auto call_result = safeDashboardTrigger(restart_safety_srv_);
         if (!call_result.has_value()) {
-          RCLCPP_WARN_STREAM(get_logger(), "The safety restart service call was interrupted by a shutdown request.");
+          RCLCPP_WARN_STREAM(get_logger(), "The safety restart service call was interrupted by a shutdown or cancellation request.");
           return false;
         }
         return call_result.value();

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -271,9 +271,6 @@ std::optional<bool> RobotStateHelper::safeDashboardTrigger(rclcpp::Client<std_sr
 
 void RobotStateHelper::setModeAcceptCallback(const std::shared_ptr<RobotStateHelper::SetModeGoalHandle> goal_handle)
 {
-  // Join any previously completed worker before reusing worker_thread_. The goal
-  // callback has already reserved in_action_; the previous worker cleared that
-  // flag when it left setModeExecute, so this join is non-blocking.
   if (worker_thread_.joinable()) {
     worker_thread_.join();
   }
@@ -282,6 +279,8 @@ void RobotStateHelper::setModeAcceptCallback(const std::shared_ptr<RobotStateHel
     // Reset stop state and install the new handle atomically so a cancel cannot
     // be lost to a later clear, and a stale cancel cannot latch onto this goal.
     stop_requested_ = false;
+    in_action_ = true;
+    goal_pending_ = false;
     current_goal_handle_ = goal_handle;
   }
   worker_thread_ =
@@ -483,11 +482,11 @@ rclcpp_action::GoalResponse RobotStateHelper::setModeGoalCallback(
     // Reserve the slot before returning ACCEPT so a second goal callback cannot
     // also accept while this goal is waiting for its accept callback to run.
     std::scoped_lock lock(goal_mutex_);
-    if (in_action_) {
+    if (in_action_ || goal_pending_) {
       RCLCPP_WARN_STREAM(get_logger(), "A SetMode action is already in progress. Rejecting new goal.");
       return rclcpp_action::GoalResponse::REJECT;
     }
-    in_action_ = true;
+    goal_pending_ = true;
   }
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
 }

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -42,34 +42,34 @@
 
 namespace ur_robot_driver
 {
-RobotStateHelper::RobotStateHelper(const rclcpp::Node::SharedPtr& node)
-  : node_(node)
+RobotStateHelper::RobotStateHelper(const rclcpp::NodeOptions& options)
+  : rclcpp::Node("robot_state_helper", options)
   , robot_mode_(urcl::RobotMode::UNKNOWN)
   , safety_mode_(urcl::SafetyMode::UNDEFINED_SAFETY_MODE)
   , in_action_(false)
 {
-  robot_mode_sub_cb_ = node_->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-  rclcpp::SubscriptionOptions options;
-  options.callback_group = robot_mode_sub_cb_;
+  robot_mode_sub_cb_ = create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+  rclcpp::SubscriptionOptions sub_options;
+  sub_options.callback_group = robot_mode_sub_cb_;
   // Topic on which the robot_mode is published by the driver
-  robot_mode_sub_ = node_->create_subscription<ur_dashboard_msgs::msg::RobotMode>(
+  robot_mode_sub_ = create_subscription<ur_dashboard_msgs::msg::RobotMode>(
       "io_and_status_controller/robot_mode", rclcpp::SensorDataQoS(),
-      std::bind(&RobotStateHelper::robotModeCallback, this, std::placeholders::_1), options);
+      std::bind(&RobotStateHelper::robotModeCallback, this, std::placeholders::_1), sub_options);
   // Topic on which the safety is published by the driver
-  safety_mode_sub_ = node_->create_subscription<ur_dashboard_msgs::msg::SafetyMode>(
+  safety_mode_sub_ = create_subscription<ur_dashboard_msgs::msg::SafetyMode>(
       "io_and_status_controller/safety_mode", 1,
       std::bind(&RobotStateHelper::safetyModeCallback, this, std::placeholders::_1));
-  program_running_sub = node_->create_subscription<std_msgs::msg::Bool>(
+  program_running_sub = create_subscription<std_msgs::msg::Bool>(
       "io_and_status_controller/robot_program_running", 1,
       [this](std_msgs::msg::Bool::UniquePtr msg) -> void { program_running_ = msg->data; });
 
-  service_cb_grp_ = node_->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+  service_cb_grp_ = create_callback_group(rclcpp::CallbackGroupType::Reentrant);
 
-  node->declare_parameter("headless_mode", false);
-  headless_mode_ = node->get_parameter("headless_mode").as_bool();
+  declare_parameter("headless_mode", false);
+  headless_mode_ = get_parameter("headless_mode").as_bool();
 
-  node->declare_parameter("robot_ip", "192.168.56.101");
-  robot_ip_ = node->get_parameter("robot_ip").as_string();
+  declare_parameter("robot_ip", "192.168.56.101");
+  robot_ip_ = get_parameter("robot_ip").as_string();
 
   primary_client_ = std::make_shared<urcl::primary_interface::PrimaryClient>(robot_ip_, notifier_);
 
@@ -77,27 +77,27 @@ RobotStateHelper::RobotStateHelper(const rclcpp::Node::SharedPtr& node)
   auto robot_version = primary_client_->getRobotVersion();
 
   if (robot_version->major > 5) {
-    RCLCPP_WARN(rclcpp::get_logger("robot_state_helper"), "Running on a PolyScopeX robot. The dashboard server is not "
-                                                          "available, therefore the robot_state_helper cannot start "
-                                                          "PolyScope programs and restart the safety.");
+    RCLCPP_WARN(get_logger(), "Running on a PolyScopeX robot. The dashboard server is not "
+                              "available, therefore the robot_state_helper cannot start "
+                              "PolyScope programs and restart the safety.");
   } else {
     // Service to restart safety
-    restart_safety_srv_ = node_->create_client<std_srvs::srv::Trigger>(
-        "dashboard_client/restart_safety", rclcpp::QoS(rclcpp::KeepLast(10)), service_cb_grp_);
+    restart_safety_srv_ = create_client<std_srvs::srv::Trigger>("dashboard_client/restart_safety",
+                                                                rclcpp::QoS(rclcpp::KeepLast(10)), service_cb_grp_);
     // Service to start UR program execution on the robot
-    play_program_srv_ = node_->create_client<std_srvs::srv::Trigger>(
-        "dashboard_client/play", rclcpp::QoS(rclcpp::KeepLast(10)), service_cb_grp_);
+    play_program_srv_ = create_client<std_srvs::srv::Trigger>("dashboard_client/play",
+                                                              rclcpp::QoS(rclcpp::KeepLast(10)), service_cb_grp_);
     play_program_srv_->wait_for_service();
   }
 
-  resend_robot_program_srv_ = node_->create_client<std_srvs::srv::Trigger>(
-      "io_and_status_controller/resend_robot_program", rclcpp::QoS(rclcpp::KeepLast(10)), service_cb_grp_);
+  resend_robot_program_srv_ = create_client<std_srvs::srv::Trigger>("io_and_status_controller/resend_robot_program",
+                                                                    rclcpp::QoS(rclcpp::KeepLast(10)), service_cb_grp_);
   resend_robot_program_srv_->wait_for_service();
 
   feedback_ = std::make_shared<ur_dashboard_msgs::action::SetMode::Feedback>();
   result_ = std::make_shared<ur_dashboard_msgs::action::SetMode::Result>();
   set_mode_as_ = rclcpp_action::create_server<ur_dashboard_msgs::action::SetMode>(
-      node_, "~/set_mode",
+      this, "~/set_mode",
       std::bind(&RobotStateHelper::setModeGoalCallback, this, std::placeholders::_1, std::placeholders::_2),
       std::bind(&RobotStateHelper::setModeCancelCallback, this, std::placeholders::_1),
       std::bind(&RobotStateHelper::setModeAcceptCallback, this, std::placeholders::_1));
@@ -107,8 +107,7 @@ void RobotStateHelper::robotModeCallback(ur_dashboard_msgs::msg::RobotMode::Shar
 {
   if (robot_mode_ != static_cast<urcl::RobotMode>(msg->mode)) {
     robot_mode_ = urcl::RobotMode(msg->mode);
-    RCLCPP_INFO_STREAM(rclcpp::get_logger("robot_state_helper"),
-                       "The robot is currently in mode " << robotModeString(robot_mode_) << ".");
+    RCLCPP_INFO_STREAM(get_logger(), "The robot is currently in mode " << robotModeString(robot_mode_) << ".");
     if (in_action_) {
       std::scoped_lock lock(goal_mutex_);
       feedback_->current_robot_mode =
@@ -122,8 +121,7 @@ void RobotStateHelper::safetyModeCallback(ur_dashboard_msgs::msg::SafetyMode::Sh
 {
   if (safety_mode_ != static_cast<urcl::SafetyMode>(msg->mode)) {
     safety_mode_ = urcl::SafetyMode(msg->mode);
-    RCLCPP_INFO_STREAM(rclcpp::get_logger("robot_state_helper"),
-                       "The robot is currently in safety mode " << safetyModeString(safety_mode_) << ".");
+    RCLCPP_INFO_STREAM(get_logger(), "The robot is currently in safety mode " << safetyModeString(safety_mode_) << ".");
     if (in_action_) {
       std::scoped_lock lock(goal_mutex_);
       feedback_->current_safety_mode =
@@ -140,15 +138,15 @@ bool RobotStateHelper::recoverFromSafety()
       try {
         primary_client_->commandUnlockProtectiveStop();
       } catch (const urcl::UrException& e) {
-        RCLCPP_WARN_STREAM(rclcpp::get_logger("robot_state_helper"), e.what());
+        RCLCPP_WARN_STREAM(get_logger(), e.what());
         return false;
       }
       return true;
     case urcl::SafetyMode::SYSTEM_EMERGENCY_STOP:;
     case urcl::SafetyMode::ROBOT_EMERGENCY_STOP:
-      RCLCPP_WARN_STREAM(rclcpp::get_logger("robot_state_helper"), "The robot is currently in safety mode."
-                                                                       << safetyModeString(safety_mode_)
-                                                                       << ". Please release the EM-Stop to proceed.");
+      RCLCPP_WARN_STREAM(get_logger(), "The robot is currently in safety mode." << safetyModeString(safety_mode_)
+                                                                                << ". Please release the EM-Stop to "
+                                                                                   "proceed.");
       return false;
     case urcl::SafetyMode::VIOLATION:;
     case urcl::SafetyMode::FAULT:
@@ -159,7 +157,7 @@ bool RobotStateHelper::recoverFromSafety()
       }
     default:
       // nothing to do
-      RCLCPP_DEBUG_STREAM(rclcpp::get_logger("robot_state_helper"), "No safety recovery needed.");
+      RCLCPP_DEBUG_STREAM(get_logger(), "No safety recovery needed.");
   }
   return true;
 }
@@ -178,10 +176,10 @@ bool RobotStateHelper::jumpToRobotMode(const urcl::RobotMode target_mode)
         primary_client_->commandBrakeRelease();
         return true;
       default:
-        RCLCPP_ERROR_STREAM(rclcpp::get_logger("robot_state_helper"), "Unreachable target robot mode.");
+        RCLCPP_ERROR_STREAM(get_logger(), "Unreachable target robot mode.");
     }
   } catch (const urcl::UrException& e) {
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger("robot_state_helper"), e.what());
+    RCLCPP_ERROR_STREAM(get_logger(), e.what());
   }
   return false;
 }
@@ -193,38 +191,34 @@ bool RobotStateHelper::doTransition(const urcl::RobotMode target_mode)
   }
   switch (robot_mode_) {
     case urcl::RobotMode::CONFIRM_SAFETY:
-      RCLCPP_WARN_STREAM(rclcpp::get_logger("robot_state_helper"), "The robot is currently in mode "
-                                                                       << robotModeString(robot_mode_)
-                                                                       << ". It is required to interact with "
-                                                                          "the "
-                                                                          "teach pendant at this point.");
+      RCLCPP_WARN_STREAM(get_logger(), "The robot is currently in mode " << robotModeString(robot_mode_)
+                                                                         << ". It is required to interact with "
+                                                                            "the "
+                                                                            "teach pendant at this point.");
       break;
     case urcl::RobotMode::BOOTING:
-      RCLCPP_INFO_STREAM(rclcpp::get_logger("robot_state_helper"), "The robot is currently in mode "
-                                                                       << robotModeString(robot_mode_)
-                                                                       << ". Please wait until the robot is "
-                                                                          "booted up...");
+      RCLCPP_INFO_STREAM(get_logger(), "The robot is currently in mode " << robotModeString(robot_mode_)
+                                                                         << ". Please wait until the robot is "
+                                                                            "booted up...");
       break;
     case urcl::RobotMode::POWER_OFF:
       return jumpToRobotMode(target_mode);
     case urcl::RobotMode::POWER_ON:
-      RCLCPP_INFO_STREAM(rclcpp::get_logger("robot_state_helper"), "The robot is currently in mode "
-                                                                       << robotModeString(robot_mode_)
-                                                                       << ". Please wait until the robot is in "
-                                                                          "mode "
-                                                                       << robotModeString(urcl::RobotMode::IDLE));
+      RCLCPP_INFO_STREAM(get_logger(), "The robot is currently in mode " << robotModeString(robot_mode_)
+                                                                         << ". Please wait until the robot is in "
+                                                                            "mode "
+                                                                         << robotModeString(urcl::RobotMode::IDLE));
       break;
     case urcl::RobotMode::IDLE:
       return jumpToRobotMode(target_mode);
       break;
     case urcl::RobotMode::BACKDRIVE:
-      RCLCPP_INFO_STREAM(rclcpp::get_logger("robot_state_helper"), "The robot is currently in mode "
-                                                                       << robotModeString(robot_mode_)
-                                                                       << ". It will automatically return to "
-                                                                          "mode "
-                                                                       << robotModeString(urcl::RobotMode::IDLE)
-                                                                       << " once the teach button is "
-                                                                          "released.");
+      RCLCPP_INFO_STREAM(get_logger(), "The robot is currently in mode " << robotModeString(robot_mode_)
+                                                                         << ". It will automatically return to "
+                                                                            "mode "
+                                                                         << robotModeString(urcl::RobotMode::IDLE)
+                                                                         << " once the teach button is "
+                                                                            "released.");
       break;
     case urcl::RobotMode::RUNNING:
       if (target_mode == urcl::RobotMode::IDLE) {
@@ -234,15 +228,13 @@ bool RobotStateHelper::doTransition(const urcl::RobotMode target_mode)
         }
       }
       return jumpToRobotMode(target_mode);
-      RCLCPP_INFO_STREAM(rclcpp::get_logger("robot_state_helper"),
-                         "The robot has reached operational mode " << robotModeString(robot_mode_));
+      RCLCPP_INFO_STREAM(get_logger(), "The robot has reached operational mode " << robotModeString(robot_mode_));
       break;
     default:
-      RCLCPP_WARN_STREAM(rclcpp::get_logger("robot_state_helper"), "The robot is currently in mode "
-                                                                       << robotModeString(robot_mode_)
-                                                                       << ". This won't be handled by this "
-                                                                          "helper. Please resolve this "
-                                                                          "manually.");
+      RCLCPP_WARN_STREAM(get_logger(), "The robot is currently in mode " << robotModeString(robot_mode_)
+                                                                         << ". This won't be handled by this "
+                                                                            "helper. Please resolve this "
+                                                                            "manually.");
   }
   return false;
 }
@@ -254,7 +246,7 @@ bool RobotStateHelper::safeDashboardTrigger(rclcpp::Client<std_srvs::srv::Trigge
   auto future = srv->async_send_request(request);
   future.wait();
   auto result = future.get();
-  RCLCPP_INFO_STREAM(rclcpp::get_logger("robot_state_helper"), "Service response received: " << result->message);
+  RCLCPP_INFO_STREAM(get_logger(), "Service response received: " << result->message);
   return result->success;
 }
 
@@ -268,7 +260,7 @@ bool RobotStateHelper::stopProgram()
   try {
     primary_client_->commandStop();
   } catch (const urcl::UrException& e) {
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger("robot_state_helper"), e.what());
+    RCLCPP_ERROR_STREAM(get_logger(), e.what());
     return false;
   }
   return true;
@@ -300,8 +292,7 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
           }
         }
         if (robot_mode_ != target_mode || safety_mode_ > urcl::SafetyMode::REDUCED) {
-          RCLCPP_INFO_STREAM(rclcpp::get_logger("robot_state_helper"),
-                             "Target mode was set to " << robotModeString(target_mode) << ".");
+          RCLCPP_INFO_STREAM(get_logger(), "Target mode was set to " << robotModeString(target_mode) << ".");
           if (!doTransition(target_mode)) {
             result_->message = "Transition to target mode failed.";
             result_->success = false;
@@ -349,7 +340,7 @@ void RobotStateHelper::setModeExecute(const std::shared_ptr<RobotStateHelper::Se
 
   // Wait until the robot reached the target mode or something went wrong
   while (robot_mode_ != target_mode && !error_) {
-    RCLCPP_INFO(rclcpp::get_logger("robot_state_helper"), "Waiting for robot to reach target mode... Current_mode: %s",
+    RCLCPP_INFO(get_logger(), "Waiting for robot to reach target mode... Current_mode: %s",
                 robotModeString(robot_mode_).c_str());
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
   }
@@ -395,14 +386,14 @@ rclcpp_action::GoalResponse RobotStateHelper::setModeGoalCallback(
 {
   (void)uuid;
   if (robot_mode_ == urcl::RobotMode::UNKNOWN) {
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger("robot_state_helper"), "Robot mode is unknown. Cannot accept goal, yet. Is "
-                                                                  "the robot switched on and connected to the driver?");
+    RCLCPP_ERROR_STREAM(get_logger(), "Robot mode is unknown. Cannot accept goal, yet. Is "
+                                      "the robot switched on and connected to the driver?");
     return rclcpp_action::GoalResponse::REJECT;
   }
 
   if (safety_mode_ == urcl::SafetyMode::UNDEFINED_SAFETY_MODE) {
-    RCLCPP_ERROR_STREAM(rclcpp::get_logger("robot_state_helper"), "Safety mode is unknown. Cannot accept goal, yet. Is "
-                                                                  "the robot switched on and connected to the driver?");
+    RCLCPP_ERROR_STREAM(get_logger(), "Safety mode is unknown. Cannot accept goal, yet. Is "
+                                      "the robot switched on and connected to the driver?");
     return rclcpp_action::GoalResponse::REJECT;
   }
   return rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
@@ -411,7 +402,7 @@ rclcpp_action::GoalResponse RobotStateHelper::setModeGoalCallback(
 rclcpp_action::CancelResponse
 RobotStateHelper::setModeCancelCallback(const std::shared_ptr<RobotStateHelper::SetModeGoalHandle> goal_handle)
 {
-  RCLCPP_INFO(rclcpp::get_logger("robot_state_helper"), "Received request to cancel goal");
+  RCLCPP_INFO(get_logger(), "Received request to cancel goal");
   (void)goal_handle;
   return rclcpp_action::CancelResponse::REJECT;
 }

--- a/ur_robot_driver/src/robot_state_helper.cpp
+++ b/ur_robot_driver/src/robot_state_helper.cpp
@@ -263,7 +263,7 @@ std::optional<bool> RobotStateHelper::safeDashboardTrigger(rclcpp::Client<std_sr
   auto future = srv->async_send_request(request);
   // Poll in short intervals so a shutdown request is honoured promptly.
   while (future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready) {
-    if (stop_requested_) {
+    if (stop_requested_ || !rclcpp::ok()) {
       srv->remove_pending_request(future);
       return std::nullopt;
     }

--- a/ur_robot_driver/src/robot_state_helper_node.cpp
+++ b/ur_robot_driver/src/robot_state_helper_node.cpp
@@ -26,23 +26,30 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include <memory>
+
+#include <rclcpp/utilities.hpp>
+#include <rclcpp/executors/multi_threaded_executor.hpp>
+
+#include "ur_client_library/exceptions.h"
 #include "ur_robot_driver/robot_state_helper.hpp"
 #include "ur_robot_driver/urcl_log_handler.hpp"
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  rclcpp::Node::SharedPtr node = rclcpp::Node::make_shared("robot_state_helper");
   ur_robot_driver::registerUrclLogHandler("");  // Set empty tf_prefix at the moment
+
   std::shared_ptr<ur_robot_driver::RobotStateHelper> robot_state_helper;
   try {
-    robot_state_helper = std::make_shared<ur_robot_driver::RobotStateHelper>(node);
+    robot_state_helper = std::make_shared<ur_robot_driver::RobotStateHelper>(rclcpp::NodeOptions());
   } catch (const urcl::UrException& e) {
     RCLCPP_ERROR(rclcpp::get_logger("robot_state_helper"), "%s", e.what());
+    return 1;
   }
 
   rclcpp::executors::MultiThreadedExecutor executor;
-  executor.add_node(node);
+  executor.add_node(robot_state_helper);
   executor.spin();
 
   return 0;

--- a/ur_robot_driver/test/test_robot_state_helper.cpp
+++ b/ur_robot_driver/test/test_robot_state_helper.cpp
@@ -1,0 +1,185 @@
+// Copyright 2026 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Tests for the concurrency and lifetime bugs reported in
+// https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1943
+//
+// These tests exercise only the goal-callback decision logic through the
+// protected default constructor. rclcpp::init() is required because
+// RobotStateHelper now inherits from rclcpp::Node.
+
+// cppcheck-suppress-file syntaxError
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_action/types.hpp"
+#include "ur_client_library/ur/datatypes.h"
+#include "ur_dashboard_msgs/action/set_mode.hpp"
+#include "ur_robot_driver/robot_state_helper.hpp"
+
+namespace ur_robot_driver
+{
+
+// Thin wrapper that uses the protected default constructor and exposes the
+// internal state and goal callback needed by the tests.
+class RobotStateHelperTestWrapper : public RobotStateHelper
+{
+public:
+  RobotStateHelperTestWrapper() : RobotStateHelper()
+  {
+  }
+
+  void setRobotMode(urcl::RobotMode mode)
+  {
+    robot_mode_ = mode;
+  }
+  void setSafetyMode(urcl::SafetyMode mode)
+  {
+    safety_mode_ = mode;
+  }
+  void setInAction(bool val)
+  {
+    in_action_ = val;
+  }
+  bool isInAction() const
+  {
+    return in_action_;
+  }
+
+  rclcpp_action::GoalResponse callGoalCallback(const rclcpp_action::GoalUUID& uuid,
+                                               std::shared_ptr<const ur_dashboard_msgs::action::SetMode::Goal> goal)
+  {
+    return setModeGoalCallback(uuid, goal);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Helper factories
+// ---------------------------------------------------------------------------
+
+static rclcpp_action::GoalUUID makeUuid()
+{
+  rclcpp_action::GoalUUID uuid{};
+  uuid.fill(0);
+  return uuid;
+}
+
+static std::shared_ptr<const ur_dashboard_msgs::action::SetMode::Goal> makeGoal(int mode = 7 /* RUNNING */)
+{
+  auto g = std::make_shared<ur_dashboard_msgs::action::SetMode::Goal>();
+  g->target_robot_mode = mode;
+  return g;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Regression for issue #1943: the goal callback must reject a new goal while
+// a SetMode action is already in progress.  Before the fix, in_action_ was
+// never checked and a second goal was silently accepted, leading to shared-
+// state corruption.
+TEST(RobotStateHelperGoalCallback, RejectsGoalWhenInAction)
+{
+  RobotStateHelperTestWrapper helper;
+  helper.setRobotMode(urcl::RobotMode::RUNNING);
+  helper.setSafetyMode(urcl::SafetyMode::NORMAL);
+  helper.setInAction(true);
+
+  const auto response = helper.callGoalCallback(makeUuid(), makeGoal());
+
+  // cppcheck-suppress knownConditionTrueFalse
+  const rclcpp_action::GoalResponse expected = rclcpp_action::GoalResponse::REJECT;
+  EXPECT_EQ(response, expected);
+}
+
+// Baseline: a goal must be accepted when the robot mode and safety mode are
+// known and no action is currently running.
+TEST(RobotStateHelperGoalCallback, AcceptsGoalWhenModesKnownAndIdle)
+{
+  RobotStateHelperTestWrapper helper;
+  helper.setRobotMode(urcl::RobotMode::POWER_OFF);
+  helper.setSafetyMode(urcl::SafetyMode::NORMAL);
+  helper.setInAction(false);
+
+  const auto response = helper.callGoalCallback(makeUuid(), makeGoal());
+
+  const rclcpp_action::GoalResponse expected = rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
+  EXPECT_EQ(response, expected);
+}
+
+// Regression: the goal callback must reject when robot mode is still UNKNOWN
+// (robot not yet connected), regardless of in_action_.
+TEST(RobotStateHelperGoalCallback, RejectsGoalWhenRobotModeUnknown)
+{
+  RobotStateHelperTestWrapper helper;
+  // robot_mode_ stays UNKNOWN
+  helper.setSafetyMode(urcl::SafetyMode::NORMAL);
+  helper.setInAction(false);
+
+  const auto response = helper.callGoalCallback(makeUuid(), makeGoal());
+
+  const rclcpp_action::GoalResponse expected = rclcpp_action::GoalResponse::REJECT;
+  EXPECT_EQ(response, expected);
+}
+
+// Regression: the goal callback must reject when safety mode is still
+// UNDEFINED, regardless of in_action_.
+TEST(RobotStateHelperGoalCallback, RejectsGoalWhenSafetyModeUndefined)
+{
+  RobotStateHelperTestWrapper helper;
+  helper.setRobotMode(urcl::RobotMode::RUNNING);
+  // safety_mode_ stays UNDEFINED_SAFETY_MODE
+  helper.setInAction(false);
+
+  const auto response = helper.callGoalCallback(makeUuid(), makeGoal());
+
+  const rclcpp_action::GoalResponse expected = rclcpp_action::GoalResponse::REJECT;
+  EXPECT_EQ(response, expected);
+}
+
+// Verify that in_action_ is initially false so a fresh helper is immediately
+// ready to accept a goal.
+TEST(RobotStateHelperGoalCallback, InActionFalseOnConstruction)
+{
+  RobotStateHelperTestWrapper helper;
+  EXPECT_FALSE(helper.isInAction());
+}
+
+}  // namespace ur_robot_driver
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  ::testing::InitGoogleMock(&argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}

--- a/ur_robot_driver/test/test_robot_state_helper.cpp
+++ b/ur_robot_driver/test/test_robot_state_helper.cpp
@@ -29,31 +29,47 @@
 // Tests for the concurrency and lifetime bugs reported in
 // https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1943
 //
-// These tests exercise only the goal-callback decision logic through the
-// protected default constructor. rclcpp::init() is required because
-// RobotStateHelper now inherits from rclcpp::Node.
+// Goal-callback tests use the protected default constructor. Lifecycle tests
+// exercise worker join, cancel, and interruptible dashboard waits through a
+// real action server/client pair without contacting robot hardware.
+// rclcpp::init() is required because RobotStateHelper inherits from rclcpp::Node.
 
 // cppcheck-suppress-file syntaxError
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <future>
+#include <memory>
+#include <thread>
+
 #include "rclcpp/rclcpp.hpp"
-#include "rclcpp_action/types.hpp"
+#include "rclcpp_action/rclcpp_action.hpp"
+#include "std_srvs/srv/trigger.hpp"
 #include "ur_client_library/ur/datatypes.h"
 #include "ur_dashboard_msgs/action/set_mode.hpp"
 #include "ur_robot_driver/robot_state_helper.hpp"
 
+using namespace std::chrono_literals;
+
 namespace ur_robot_driver
 {
+using SetMode = ur_dashboard_msgs::action::SetMode;
 
 // Thin wrapper that uses the protected default constructor and exposes the
-// internal state and goal callback needed by the tests.
+// internal state and callbacks needed by the tests.
 class RobotStateHelperTestWrapper : public RobotStateHelper
 {
 public:
   RobotStateHelperTestWrapper() : RobotStateHelper()
   {
+    result_ = std::make_shared<SetMode::Result>();
+    feedback_ = std::make_shared<SetMode::Feedback>();
+    headless_mode_ = false;
+    program_running_ = false;
   }
 
   void setRobotMode(urcl::RobotMode mode)
@@ -72,11 +88,69 @@ public:
   {
     return in_action_;
   }
+  bool isGoalPending() const
+  {
+    return goal_pending_;
+  }
+  bool isStopRequested() const
+  {
+    return stop_requested_;
+  }
+  bool isWorkerJoinable() const
+  {
+    return worker_thread_.joinable();
+  }
+
+  void setHeadlessMode(bool val)
+  {
+    headless_mode_ = val;
+  }
+  void setProgramRunning(bool val)
+  {
+    program_running_ = val;
+  }
+  void setResendRobotProgramClient(const rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr& client)
+  {
+    resend_robot_program_srv_ = client;
+  }
+
+  // Simulate a worker stuck in a poll loop, as setModeExecute does while waiting.
+  void startBlockingWorker()
+  {
+    stop_requested_ = false;
+    in_action_ = true;
+    worker_thread_ = std::thread([this]() {
+      while (!stop_requested_ && rclcpp::ok()) {
+        std::this_thread::sleep_for(10ms);
+      }
+      in_action_ = false;
+    });
+  }
 
   rclcpp_action::GoalResponse callGoalCallback(const rclcpp_action::GoalUUID& uuid,
-                                               std::shared_ptr<const ur_dashboard_msgs::action::SetMode::Goal> goal)
+                                               std::shared_ptr<const SetMode::Goal> goal)
   {
     return setModeGoalCallback(uuid, goal);
+  }
+
+  rclcpp_action::CancelResponse callCancelCallback(const std::shared_ptr<SetModeGoalHandle> goal_handle)
+  {
+    return setModeCancelCallback(goal_handle);
+  }
+
+  void callAcceptCallback(const std::shared_ptr<SetModeGoalHandle> goal_handle)
+  {
+    setModeAcceptCallback(goal_handle);
+  }
+
+  std::optional<bool> callSafeDashboardTrigger(const rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr& srv)
+  {
+    return safeDashboardTrigger(srv);
+  }
+
+  void requestStop()
+  {
+    stop_requested_ = true;
   }
 };
 
@@ -84,22 +158,36 @@ public:
 // Helper factories
 // ---------------------------------------------------------------------------
 
-static rclcpp_action::GoalUUID makeUuid()
+static rclcpp_action::GoalUUID makeUuid(uint8_t fill = 0)
 {
   rclcpp_action::GoalUUID uuid{};
-  uuid.fill(0);
+  uuid.fill(fill);
   return uuid;
 }
 
-static std::shared_ptr<const ur_dashboard_msgs::action::SetMode::Goal> makeGoal(int mode = 7 /* RUNNING */)
+static std::shared_ptr<SetMode::Goal> makeGoal(int mode = 7 /* RUNNING */, bool play_program = false)
 {
-  auto g = std::make_shared<ur_dashboard_msgs::action::SetMode::Goal>();
+  auto g = std::make_shared<SetMode::Goal>();
   g->target_robot_mode = mode;
+  g->play_program = play_program;
+  g->stop_program = false;
   return g;
 }
 
+static bool waitFor(const std::function<bool()>& predicate, std::chrono::milliseconds timeout = 2s)
+{
+  const auto deadline = std::chrono::steady_clock::now() + timeout;
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (predicate()) {
+      return true;
+    }
+    std::this_thread::sleep_for(10ms);
+  }
+  return predicate();
+}
+
 // ---------------------------------------------------------------------------
-// Tests
+// Goal-callback tests
 // ---------------------------------------------------------------------------
 
 // Regression for issue #1943: the goal callback must reject a new goal while
@@ -133,6 +221,20 @@ TEST(RobotStateHelperGoalCallback, AcceptsGoalWhenModesKnownAndIdle)
 
   const rclcpp_action::GoalResponse expected = rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE;
   EXPECT_EQ(response, expected);
+  EXPECT_TRUE(helper.isGoalPending());
+}
+
+// Regression: once a goal is pending acceptance, a second goal must be rejected
+// before the accept callback clears goal_pending_.
+TEST(RobotStateHelperGoalCallback, RejectsGoalWhenGoalPending)
+{
+  RobotStateHelperTestWrapper helper;
+  helper.setRobotMode(urcl::RobotMode::RUNNING);
+  helper.setSafetyMode(urcl::SafetyMode::NORMAL);
+
+  EXPECT_EQ(helper.callGoalCallback(makeUuid(1), makeGoal()), rclcpp_action::GoalResponse::ACCEPT_AND_EXECUTE);
+  EXPECT_TRUE(helper.isGoalPending());
+  EXPECT_EQ(helper.callGoalCallback(makeUuid(2), makeGoal()), rclcpp_action::GoalResponse::REJECT);
 }
 
 // Regression: the goal callback must reject when robot mode is still UNKNOWN
@@ -171,6 +273,200 @@ TEST(RobotStateHelperGoalCallback, InActionFalseOnConstruction)
 {
   RobotStateHelperTestWrapper helper;
   EXPECT_FALSE(helper.isInAction());
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle / interruptibility tests
+// ---------------------------------------------------------------------------
+
+TEST(RobotStateHelperLifecycle, DestructorJoinsBlockingWorker)
+{
+  auto helper = std::make_unique<RobotStateHelperTestWrapper>();
+  helper->startBlockingWorker();
+  ASSERT_TRUE(helper->isWorkerJoinable());
+  ASSERT_TRUE(helper->isInAction());
+
+  const auto start = std::chrono::steady_clock::now();
+  helper.reset();  // ~RobotStateHelper sets stop_requested_ and joins.
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+
+  EXPECT_LT(elapsed, 1s);
+}
+
+TEST(RobotStateHelperLifecycle, CancelRejectsWhenNotRunning)
+{
+  RobotStateHelperTestWrapper helper;
+  // Short-circuit on !in_action_ before dereferencing the handle.
+  EXPECT_EQ(helper.callCancelCallback(nullptr), rclcpp_action::CancelResponse::REJECT);
+  EXPECT_FALSE(helper.isStopRequested());
+}
+
+TEST(RobotStateHelperLifecycle, SafeDashboardTriggerInterruptedByStopRequest)
+{
+  auto helper = std::make_shared<RobotStateHelperTestWrapper>();
+  auto service_node = std::make_shared<rclcpp::Node>("hanging_trigger_server");
+  std::atomic<bool> keep_hanging{ true };
+  // Block until the test clears keep_hanging so the client poll loop can be interrupted.
+  auto service = service_node->create_service<std_srvs::srv::Trigger>(
+      "hanging_trigger", [&keep_hanging](const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                         std::shared_ptr<std_srvs::srv::Trigger::Response> /*response*/) {
+        while (keep_hanging && rclcpp::ok()) {
+          std::this_thread::sleep_for(100ms);
+        }
+      });
+
+  auto client = helper->create_client<std_srvs::srv::Trigger>("hanging_trigger");
+
+  rclcpp::executors::MultiThreadedExecutor executor;
+  executor.add_node(helper);
+  executor.add_node(service_node);
+  std::thread spin_thread([&executor]() { executor.spin(); });
+
+  ASSERT_TRUE(client->wait_for_service(2s));
+
+  std::promise<std::optional<bool>> promise;
+  auto future = promise.get_future();
+  std::thread call_thread(
+      [helper, client, &promise]() { promise.set_value(helper->callSafeDashboardTrigger(client)); });
+
+  // Give the poll loop time to start, then interrupt it.
+  std::this_thread::sleep_for(200ms);
+  ASSERT_NE(future.wait_for(0s), std::future_status::ready);
+  helper->requestStop();
+
+  ASSERT_EQ(future.wait_for(2s), std::future_status::ready);
+  EXPECT_EQ(future.get(), std::nullopt);
+
+  call_thread.join();
+  keep_hanging = false;
+  executor.cancel();
+  spin_thread.join();
+}
+
+// Action server/client fixture that drives the real accept/execute/cancel path
+// without hardware by blocking on a never-responding Trigger service.
+class RobotStateHelperActionFixture : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    helper_ = std::make_shared<RobotStateHelperTestWrapper>();
+    helper_->setRobotMode(urcl::RobotMode::RUNNING);
+    helper_->setSafetyMode(urcl::SafetyMode::NORMAL);
+    helper_->setHeadlessMode(true);
+    helper_->setProgramRunning(false);
+
+    keep_hanging_ = true;
+    service_node_ = std::make_shared<rclcpp::Node>("hanging_resend_server");
+    hanging_service_ = service_node_->create_service<std_srvs::srv::Trigger>(
+        "hanging_resend_robot_program", [this](const std::shared_ptr<std_srvs::srv::Trigger::Request> /*request*/,
+                                               std::shared_ptr<std_srvs::srv::Trigger::Response> /*response*/) {
+          while (keep_hanging_ && rclcpp::ok()) {
+            std::this_thread::sleep_for(100ms);
+          }
+        });
+
+    helper_->setResendRobotProgramClient(helper_->create_client<std_srvs::srv::Trigger>("hanging_resend_robot_"
+                                                                                        "program"));
+
+    // Use the production goal/cancel/accept callbacks so worker lifecycle is real.
+    action_server_ = rclcpp_action::create_server<SetMode>(
+        helper_, "~/set_mode",
+        [this](const rclcpp_action::GoalUUID& uuid, std::shared_ptr<const SetMode::Goal> goal) {
+          return helper_->callGoalCallback(uuid, goal);
+        },
+        [this](const std::shared_ptr<RobotStateHelper::SetModeGoalHandle> goal_handle) {
+          return helper_->callCancelCallback(goal_handle);
+        },
+        [this](const std::shared_ptr<RobotStateHelper::SetModeGoalHandle> goal_handle) {
+          // Invoke the real accept callback (starts setModeExecute on a worker).
+          helper_->callAcceptCallback(goal_handle);
+        });
+
+    client_node_ = std::make_shared<rclcpp::Node>("set_mode_test_client");
+    action_client_ = rclcpp_action::create_client<SetMode>(client_node_, "/robot_state_helper/set_mode");
+
+    executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+    executor_->add_node(helper_);
+    executor_->add_node(service_node_);
+    executor_->add_node(client_node_);
+    spin_thread_ = std::thread([this]() { executor_->spin(); });
+
+    ASSERT_TRUE(action_client_->wait_for_action_server(5s));
+    ASSERT_TRUE(helper_->create_client<std_srvs::srv::Trigger>("hanging_resend_robot_program")->wait_for_service(2s));
+  }
+
+  void TearDown() override
+  {
+    keep_hanging_ = false;
+    if (executor_) {
+      executor_->cancel();
+    }
+    if (spin_thread_.joinable()) {
+      spin_thread_.join();
+    }
+    action_client_.reset();
+    action_server_.reset();
+    helper_.reset();
+    service_node_.reset();
+    client_node_.reset();
+    hanging_service_.reset();
+    executor_.reset();
+  }
+
+  std::atomic<bool> keep_hanging_{ true };
+  std::shared_ptr<RobotStateHelperTestWrapper> helper_;
+  std::shared_ptr<rclcpp::Node> service_node_;
+  std::shared_ptr<rclcpp::Node> client_node_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr hanging_service_;
+  rclcpp_action::Server<SetMode>::SharedPtr action_server_;
+  rclcpp_action::Client<SetMode>::SharedPtr action_client_;
+  std::shared_ptr<rclcpp::executors::MultiThreadedExecutor> executor_;
+  std::thread spin_thread_;
+};
+
+TEST_F(RobotStateHelperActionFixture, CancelInterruptsBlockingExecuteAndJoinsWorker)
+{
+  auto goal = makeGoal(static_cast<int>(urcl::RobotMode::RUNNING), /*play_program=*/true);
+  auto goal_future = action_client_->async_send_goal(*goal);
+  ASSERT_EQ(goal_future.wait_for(5s), std::future_status::ready);
+  auto goal_handle = goal_future.get();
+  ASSERT_NE(goal_handle, nullptr);
+
+  ASSERT_TRUE(waitFor([this]() { return helper_->isInAction() && helper_->isWorkerJoinable(); }, 5s));
+
+  auto cancel_future = action_client_->async_cancel_goal(goal_handle);
+  ASSERT_EQ(cancel_future.wait_for(5s), std::future_status::ready);
+
+  auto result_future = action_client_->async_get_result(goal_handle);
+  ASSERT_EQ(result_future.wait_for(5s), std::future_status::ready);
+  auto wrapped = result_future.get();
+
+  EXPECT_EQ(wrapped.code, rclcpp_action::ResultCode::CANCELED);
+  ASSERT_NE(wrapped.result, nullptr);
+  EXPECT_FALSE(wrapped.result->success);
+
+  ASSERT_TRUE(waitFor([this]() { return !helper_->isInAction(); }, 2s));
+}
+
+TEST_F(RobotStateHelperActionFixture, DestructorJoinsWorkerBlockedInDashboardTrigger)
+{
+  auto goal = makeGoal(static_cast<int>(urcl::RobotMode::RUNNING), /*play_program=*/true);
+  auto goal_future = action_client_->async_send_goal(*goal);
+  ASSERT_EQ(goal_future.wait_for(5s), std::future_status::ready);
+  ASSERT_NE(goal_future.get(), nullptr);
+
+  ASSERT_TRUE(waitFor([this]() { return helper_->isInAction() && helper_->isWorkerJoinable(); }, 5s));
+
+  // Drop action endpoints before destroying the helper so teardown is orderly.
+  action_client_.reset();
+  action_server_.reset();
+  executor_->remove_node(helper_);
+
+  const auto start = std::chrono::steady_clock::now();
+  helper_.reset();  // Sets stop_requested_ and joins the worker blocked in safeDashboardTrigger.
+  const auto elapsed = std::chrono::steady_clock::now() - start;
+  EXPECT_LT(elapsed, 2s);
 }
 
 }  // namespace ur_robot_driver


### PR DESCRIPTION
This fixes #1943.

The concept for addressing the issues:
- Do not detach from worker thread, but track it.
- When a new goal is accepted, join the current worker thread before starting a new one.
- When a goal comes in, while there is already one active, reject it.
- When a goal is canceled, make the worker thread stop properly.
- On destruction stop and join the worker thread.
- In the worker thread check also for `rclcpp::ok()`.
- Make the blocking service calls interruptible by checking if stop is requested regularly.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes robot mode transitions, safety recovery, and program start/cancel paths; fixes race/use-after-free risks but alters long-standing SetMode cancel behavior and timing of dashboard calls.
> 
> **Overview**
> Fixes **#1943** by making `SetMode` action execution safe under concurrency, cancellation, and node shutdown.
> 
> **`RobotStateHelper`** is now an **`rclcpp::Node`** (not a helper around a separate node). The implementation is split into **`robot_state_helper_lib`** plus a thin node executable, with new **gmock tests** linked against the library.
> 
> **Worker thread:** detached threads are replaced with a **joined** `worker_thread_`. The destructor sets **`stop_requested_`** and joins. Accepting a new goal joins any prior worker first. **`setModeExecute`** uses **`shouldGoalTerminate()`** (`stop_requested_`, `!rclcpp::ok()`, cancel) at waits and transitions; **`safeDashboardTrigger`** polls service futures and returns **`std::nullopt`** on interrupt. **`setTerminalState`** centralizes succeed / abort / **canceled** outcomes.
> 
> **Action API:** overlapping goals are **rejected** via **`in_action_`** / **`goal_pending_`**; cancel is **accepted** only for the active goal (previously always rejected). Mode/safety feedback is published only when the goal handle is **active**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b3ca15f753fb912906b12064c752ad465c9d7ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->