### PR TITLE
Fix interruptible URScript interface startup

### DIFF
--- a/ur_robot_driver/CMakeLists.txt
+++ b/ur_robot_driver/CMakeLists.txt
@@ -272,6 +272,10 @@ if(BUILD_TESTING)
     TIMEOUT
       800
   )
+  add_launch_test(test/test_urscript_interface_shutdown.py
+    TIMEOUT
+      30
+  )
 
   if(${UR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS})
     add_launch_test(test/launch_args.py

--- a/ur_robot_driver/src/urscript_interface.cpp
+++ b/ur_robot_driver/src/urscript_interface.cpp
@@ -37,7 +37,11 @@
 
 #include <ur_client_library/primary/primary_client.h>
 
+#include <atomic>
 #include <chrono>
+#include <exception>
+#include <memory>
+#include <mutex>
 #include <thread>
 
 #include <ur_msgs/action/send_script.hpp>
@@ -58,9 +62,58 @@ public:
 
     primary_client_ =
         std::make_unique<urcl::primary_interface::PrimaryClient>(this->get_parameter("robot_ip").as_string(), notif_);
+  }
 
-    primary_client_->start(10, std::chrono::seconds(10));
+  void start_primary_client_async()
+  {
+    std::lock_guard<std::mutex> lock(startup_mutex_);
+    startup_thread_ = std::thread([this]() {
+      {
+        std::lock_guard<std::mutex> lock(startup_mutex_);
+        if (startup_stop_requested_) {
+          return;
+        }
+        startup_in_progress_ = true;
+      }
 
+      try {
+        primary_client_->start(10, std::chrono::seconds(10));
+      } catch (...) {
+        std::lock_guard<std::mutex> lock(startup_mutex_);
+        startup_exception_ = std::current_exception();
+      }
+
+      std::lock_guard<std::mutex> lock(startup_mutex_);
+      startup_in_progress_ = false;
+    });
+  }
+
+  void stop_primary_client_startup()
+  {
+    bool stop_primary_client = false;
+    {
+      std::lock_guard<std::mutex> lock(startup_mutex_);
+      startup_stop_requested_ = true;
+      stop_primary_client = startup_in_progress_;
+    }
+
+    if (stop_primary_client) {
+      primary_client_->stop();
+    }
+  }
+
+  std::exception_ptr join_primary_client_startup()
+  {
+    if (startup_thread_.joinable()) {
+      startup_thread_.join();
+    }
+
+    std::lock_guard<std::mutex> lock(startup_mutex_);
+    return startup_exception_;
+  }
+
+  void initialize_interfaces()
+  {
     script_sub_ = create_subscription<std_msgs::msg::String>(
         "~/script_command", 1, std::bind(&URScriptInterface::script_callback, this, std::placeholders::_1));
 
@@ -73,6 +126,10 @@ public:
 
   ~URScriptInterface() override
   {
+    if (startup_thread_.joinable()) {
+      stop_primary_client_startup();
+      startup_thread_.join();
+    }
     if (execute_thread_.joinable()) {
       execute_thread_.join();
     }
@@ -202,13 +259,72 @@ private:
   std::unique_ptr<urcl::primary_interface::PrimaryClient> primary_client_;
   urcl::comm::INotifier notif_;
   std::atomic<bool> busy = false;
+  std::mutex startup_mutex_;
+  std::thread startup_thread_;
+  std::exception_ptr startup_exception_;
+  bool startup_stop_requested_ = false;
+  bool startup_in_progress_ = false;
   std::thread execute_thread_;
 };
 
 int main(int argc, char** argv)
 {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_unique<URScriptInterface>());
-  rclcpp::shutdown();
+
+  try {
+    auto node = std::make_shared<URScriptInterface>();
+    std::weak_ptr<URScriptInterface> weak_node = node;
+    rclcpp::on_shutdown([weak_node]() {
+      if (auto node = weak_node.lock()) {
+        node->stop_primary_client_startup();
+      }
+    });
+
+    if (!rclcpp::ok()) {
+      node->stop_primary_client_startup();
+      return 0;
+    }
+
+    node->start_primary_client_async();
+    auto startup_exception = node->join_primary_client_startup();
+
+    if (!rclcpp::ok()) {
+      return 0;
+    }
+    if (startup_exception != nullptr) {
+      std::rethrow_exception(startup_exception);
+    }
+
+    node->initialize_interfaces();
+    if (!rclcpp::ok()) {
+      return 0;
+    }
+    rclcpp::spin(node);
+  } catch (const urcl::UrException& exc) {
+    if (!rclcpp::ok()) {
+      return 0;
+    }
+    RCLCPP_FATAL(rclcpp::get_logger("urscript_interface"), "Primary client startup failed: %s", exc.what());
+    rclcpp::shutdown();
+    return 1;
+  } catch (const std::exception& exc) {
+    if (!rclcpp::ok()) {
+      return 0;
+    }
+    RCLCPP_FATAL(rclcpp::get_logger("urscript_interface"), "Unexpected startup failure: %s", exc.what());
+    rclcpp::shutdown();
+    return 1;
+  } catch (...) {
+    if (!rclcpp::ok()) {
+      return 0;
+    }
+    RCLCPP_FATAL(rclcpp::get_logger("urscript_interface"), "Unknown startup failure");
+    rclcpp::shutdown();
+    return 1;
+  }
+
+  if (rclcpp::ok()) {
+    rclcpp::shutdown();
+  }
   return 0;
 }

--- a/ur_robot_driver/test/test_urscript_interface_shutdown.py
+++ b/ur_robot_driver/test/test_urscript_interface_shutdown.py
@@ -77,6 +77,7 @@ class TestStartupShutdown(unittest.TestCase):
             proc_output.assertWaitFor(
                 "Retrying in 10 seconds",
                 process=urscript_interface,
+                stream="stdout",
                 timeout=10,
             )
 

--- a/ur_robot_driver/test/test_urscript_interface_shutdown.py
+++ b/ur_robot_driver/test/test_urscript_interface_shutdown.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# Copyright 2026, Shin
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+import signal
+import socket
+import unittest
+
+import launch
+import launch.events.process
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.markers
+import launch_ros.actions
+import pytest
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    refusing_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    refusing_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    refusing_socket.bind(("127.0.0.1", 30001))
+
+    urscript_interface = launch_ros.actions.Node(
+        package="ur_robot_driver",
+        executable="urscript_interface",
+        parameters=[{"robot_ip": "127.0.0.1"}],
+        output="screen",
+    )
+
+    return (
+        launch.LaunchDescription(
+            [
+                urscript_interface,
+                launch_testing.actions.ReadyToTest(),
+            ]
+        ),
+        {
+            "refusing_socket": refusing_socket,
+            "urscript_interface": urscript_interface,
+        },
+    )
+
+
+class TestStartupShutdown(unittest.TestCase):
+    def test_sigint_interrupts_primary_client_startup(
+        self, launch_service, proc_info, proc_output, refusing_socket, urscript_interface
+    ):
+        try:
+            proc_info.assertWaitForStartup(process=urscript_interface, timeout=5)
+            proc_output.assertWaitFor(
+                "Retrying in 10 seconds",
+                process=urscript_interface,
+                timeout=10,
+            )
+
+            launch_service.emit_event(
+                launch.events.process.SignalProcess(
+                    signal_number=signal.SIGINT,
+                    process_matcher=lambda process: process is urscript_interface,
+                )
+            )
+
+            proc_info.assertWaitForShutdown(process=urscript_interface, timeout=5)
+            launch_testing.asserts.assertExitCodes(
+                proc_info,
+                process=urscript_interface,
+                allowable_exit_codes=[0],
+            )
+        finally:
+            refusing_socket.close()


### PR DESCRIPTION
## Summary

- run `PrimaryClient::start(10, 10s)` in a joinable startup worker
- on ROS shutdown during startup, call `PrimaryClient::stop()` and join the worker
- create the existing topic and action endpoints only after startup succeeds
- report genuine startup exceptions as an orderly nonzero process exit
- add a loopback-only process regression test for SIGINT during the retry wait

This addresses #838 without changing retry conditions, URCL, topic/action contracts, controllers, motion, or safety behavior.

## Difference from URCL #519

UniversalRobots/Universal_Robots_Client_Library#519 made the lower-level reconnect path interruptible. This driver change handles the remaining ROS 2 lifecycle gap: `urscript_interface` blocks in `PrimaryClient::start()` before the executor begins, so shutdown must explicitly stop and join that startup operation and must catch startup exhaustion in `main()`.

## Reproduction

```bash
ros2 run ur_robot_driver urscript_interface --ros-args -p robot_ip:=127.0.0.1
# while it is waiting to retry, press Ctrl-C
```

The added launch test reserves loopback port 30001 without listening, waits for the 10-second retry path, sends SIGINT, and requires exit code 0 within 5 seconds.

## Tests

- Format workflow: PASS — https://github.com/shin4141/Universal_Robots_ROS2_Driver/actions/runs/33580143252
- local syntax-only C++ compile, Python compile, clang-format dry-run, and `git diff --check`: PASS
- ROS Rolling driver-local validation: PASS
  - environment: Lima 2.2.0 VM, Ubuntu 26.04 arm64, `ros:rolling-ros-base@sha256:812a4b6ab03877842545398d99cf15dc25a01ff8065e8c1e117cd3750c7ca5c8`
  - source workspace: this PR at `72390b1`; `ur_client_library` `master` at `f4f8870`; `ur_msgs` `rolling-devel` at `1dbe819`; `ur_description` `rolling` at `89bbe79`
  - ros2_control-related source repositories were omitted as suggested; required Rolling binary dependencies were installed with `rosdep`

```bash
colcon build --symlink-install \
  --packages-select ur_client_library ur_msgs ur_description ur_dashboard_msgs ur_robot_driver \
  --parallel-workers 4 \
  --cmake-args -DBUILD_TESTING=ON -DUR_ROBOT_DRIVER_BUILD_INTEGRATION_TESTS=OFF

cd build/ur_robot_driver
ctest --output-on-failure -R '^test_test_urscript_interface_shutdown.py$'
```

Build result: 5 packages finished, including `ur_robot_driver` (3 min 42 sec total). Regression result: 1/1 passed in 5.83 sec.

The Rolling run exposed that `launch_testing` searches stderr by default while the URCL retry line is emitted on stdout. The regression now specifies `stream="stdout"`; no production behavior changed.

## Maintainer direction

The proposed driver-local scope was described on #838, and @urfeex confirmed that the issue still persists and invited this approach: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/838#issuecomment-5493880410

The Rolling workspace used above follows @urfeex's validation guidance: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1951#issuecomment-5524882452

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ROS 2 node lifecycle and primary-client connection timing (interfaces appear only after connect), but scope is limited to `urscript_interface` startup/shutdown—not motion, safety, or script execution paths after spin.
> 
> **Overview**
> **`urscript_interface` no longer blocks in the constructor on `PrimaryClient::start()`**, so Ctrl-C during the URCL retry wait can exit cleanly instead of hanging before `spin()`.
> 
> Startup runs on a **background thread** with mutex-tracked state. **`rclcpp::on_shutdown`** and the destructor call **`stop_primary_client_startup()`**, which invokes **`PrimaryClient::stop()`** when a connect retry is in progress, then joins the worker. **Topic and action servers are created only after startup succeeds** via **`initialize_interfaces()`**. **`main()`** rethrows stored startup failures as fatal exits when ROS is still running, and treats shutdown during startup as **exit 0**.
> 
> A new **launch test** (`test_urscript_interface_shutdown.py`) reserves loopback port 30001, waits for the retry log on stdout, sends **SIGINT**, and asserts shutdown with exit code 0. **CMake** wires the test with a 30s timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72390b1152b3726e0575a9b9e9fb02cfce6a8b3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->