### PR TITLE
Fix tool contact controller

### DIFF
--- a/ur_controllers/CMakeLists.txt
+++ b/ur_controllers/CMakeLists.txt
@@ -217,6 +217,13 @@ if(BUILD_TESTING)
     controller_manager::controller_manager
     ros2_control_test_assets::ros2_control_test_assets
   )
+  ament_add_gmock(test_tool_contact_controller
+    test/test_tool_contact_controller.cpp
+  )
+  target_link_libraries(test_tool_contact_controller
+    ${PROJECT_NAME}
+    hardware_interface::hardware_interface
+  )
 endif()
 
 ament_package()

--- a/ur_controllers/include/ur_controllers/tool_contact_controller.hpp
+++ b/ur_controllers/include/ur_controllers/tool_contact_controller.hpp
@@ -60,6 +60,9 @@
 #include <ur_msgs/action/tool_contact.hpp>
 #include "ur_controllers/tool_contact_controller_parameters.hpp"
 
+// Forward declaration for unit-test friend (defined in test_tool_contact_controller.cpp).
+class ToolContactControllerTest;
+
 namespace ur_controllers
 {
 class ToolContactController : public controller_interface::ControllerInterface
@@ -132,6 +135,9 @@ private:
   static constexpr double TOOL_CONTACT_WAITING_END = 5.0;
   static constexpr double TOOL_CONTACT_SUCCESS_END = 6.0;
   static constexpr double TOOL_CONTACT_FAILURE_END = 7.0;
+
+  // Grant unit tests access to private state for update()-path regression checks.
+  friend class ::ToolContactControllerTest;
 };
 }  // namespace ur_controllers
 

--- a/ur_controllers/src/tool_contact_controller.cpp
+++ b/ur_controllers/src/tool_contact_controller.cpp
@@ -297,31 +297,60 @@ rclcpp_action::CancelResponse ToolContactController::goal_canceled_callback(
 controller_interface::return_type ToolContactController::update(const rclcpp::Time& /* time */,
                                                                 const rclcpp::Duration& /* period */)
 {
-  static bool write_success = true;
+  bool write_success = true;
+
+  auto exit_success_if_write_success = [&write_success](const char* msg) {
+    if (!write_success) {
+      RCLCPP_FATAL(rclcpp::get_logger("ToolContactController"), "%s", msg);
+      return controller_interface::return_type::ERROR;
+    }
+    return controller_interface::return_type::OK;
+  };
 
   // Abort takes priority
   if (tool_contact_abort_) {
     tool_contact_abort_ = false;
     tool_contact_enable_ = false;
     write_success &= tool_contact_set_state_interface_->get().set_value(TOOL_CONTACT_WAITING_END);
+    return exit_success_if_write_success("Controller failed to update command interface.");
   } else if (tool_contact_enable_) {
     tool_contact_enable_ = false;
     write_success &= tool_contact_set_state_interface_->get().set_value(TOOL_CONTACT_WAITING_BEGIN);
+    return exit_success_if_write_success("Controller failed to update command interface.");
   }
 
-  RealtimeGoalHandlePtr active_goal;
-  if (!rt_active_goal_.try_get([&active_goal](const RealtimeGoalHandlePtr& goal) { active_goal = goal; })) {
-    RCLCPP_ERROR(get_node()->get_logger(), "Failed to read active goal, skipping update cycle.");
-    return controller_interface::return_type::OK;
-  }
-
+  // Read hardware state before the goal box so the start handshake can still be
+  // acknowledged if obtaining the goal handle fails due to contention.
   std::optional<double> state_optional = tool_contact_state_interface_->get().get_optional();
-
   if (!state_optional) {
     RCLCPP_FATAL(get_node()->get_logger(), "Controller failed to read state interface, aborting.");
     return controller_interface::return_type::ERROR;
   }
   const int state = static_cast<int>(state_optional.value());
+
+  RealtimeGoalHandlePtr active_goal;
+  if (!rt_active_goal_.try_get([&active_goal](const RealtimeGoalHandlePtr& goal) { active_goal = goal; })) {
+    RCLCPP_ERROR(get_node()->get_logger(), "Failed to read active goal, skipping goal handling this cycle.");
+
+    // Still acknowledge EXECUTING so startToolContact is not retriggered.
+    // Terminal result handling is deferred until a cycle where the goal is available.
+    if (state == static_cast<int>(TOOL_CONTACT_EXECUTING)) {
+      std::optional<double> result = tool_contact_result_interface_->get().get_optional();
+      if (!result) {
+        RCLCPP_FATAL(get_node()->get_logger(), "Controller failed to read result interface, aborting.");
+        return controller_interface::return_type::ERROR;
+      }
+      if (result.value() != 0.0 && result.value() != 1.0) {
+        tool_contact_active_ = true;
+        if (!logged_once_) {
+          RCLCPP_INFO(get_node()->get_logger(), "Tool contact enabled successfully.");
+          logged_once_ = true;
+        }
+        write_success &= tool_contact_set_state_interface_->get().set_value(TOOL_CONTACT_EXECUTING);
+      }
+    }
+    return exit_success_if_write_success("Controller failed to update command interface.");
+  }
 
   switch (state) {
     case static_cast<int>(TOOL_CONTACT_EXECUTING):
@@ -380,9 +409,8 @@ controller_interface::return_type ToolContactController::update(const rclcpp::Ti
       if (tool_contact_active_) {
         RCLCPP_INFO(get_node()->get_logger(), "Tool contact disabled successfully.");
         tool_contact_active_ = false;
-
-        write_success &= tool_contact_set_state_interface_->get().set_value(TOOL_CONTACT_STANDBY);
       }
+      write_success &= tool_contact_set_state_interface_->get().set_value(TOOL_CONTACT_STANDBY);
     } break;
 
     case static_cast<int>(TOOL_CONTACT_FAILURE_END):
@@ -407,11 +435,7 @@ controller_interface::return_type ToolContactController::update(const rclcpp::Ti
     active_goal->setFeedback(feedback_);
   }
 
-  if (!write_success) {
-    RCLCPP_FATAL(get_node()->get_logger(), "Controller failed to update or read command/state interface.");
-    return controller_interface::return_type::ERROR;
-  }
-  return controller_interface::return_type::OK;
+  return exit_success_if_write_success("Controller failed to update or read command/state interface.");
 }
 
 std::optional<ToolContactController::RealtimeGoalHandlePtr> ToolContactController::get_rt_goal_from_non_rt()

--- a/ur_controllers/src/tool_contact_controller.cpp
+++ b/ur_controllers/src/tool_contact_controller.cpp
@@ -346,8 +346,8 @@ controller_interface::return_type ToolContactController::update(const rclcpp::Ti
           RCLCPP_INFO(get_node()->get_logger(), "Tool contact enabled successfully.");
           logged_once_ = true;
         }
-        write_success &= tool_contact_set_state_interface_->get().set_value(TOOL_CONTACT_EXECUTING);
       }
+      write_success &= tool_contact_set_state_interface_->get().set_value(TOOL_CONTACT_EXECUTING);
     }
     return exit_success_if_write_success("Controller failed to update command interface.");
   }

--- a/ur_controllers/test/test_tool_contact_controller.cpp
+++ b/ur_controllers/test/test_tool_contact_controller.cpp
@@ -184,7 +184,11 @@ protected:
     while (!lock_held.load() && std::chrono::steady_clock::now() < deadline) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    ASSERT_TRUE(lock_held.load()) << "Timed out waiting to hold the goal box mutex.";
+if (!lock_held.load()) {
+      release_lock = true;
+      holder.join();
+      FAIL() << "Timed out waiting to hold the goal box mutex.";
+    }
 
     std::forward<Fn>(fn)();
 

--- a/ur_controllers/test/test_tool_contact_controller.cpp
+++ b/ur_controllers/test/test_tool_contact_controller.cpp
@@ -184,7 +184,7 @@ protected:
     while (!lock_held.load() && std::chrono::steady_clock::now() < deadline) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-if (!lock_held.load()) {
+    if (!lock_held.load()) {
       release_lock = true;
       holder.join();
       FAIL() << "Timed out waiting to hold the goal box mutex.";

--- a/ur_controllers/test/test_tool_contact_controller.cpp
+++ b/ur_controllers/test/test_tool_contact_controller.cpp
@@ -29,8 +29,13 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <atomic>
+#include <chrono>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
+#include <utility>
 
 #include "controller_interface/controller_interface_params.hpp"
 #include "hardware_interface/loaned_command_interface.hpp"
@@ -161,6 +166,32 @@ protected:
     return controller_.update(rclcpp::Time(0, 0, RCL_ROS_TIME), rclcpp::Duration::from_seconds(0.01));
   }
 
+  // Hold rt_active_goal_'s mutex so update()'s try_get fails (contention path).
+  template <typename Fn>
+  void with_goal_box_contended(Fn&& fn)
+  {
+    std::atomic<bool> lock_held{ false };
+    std::atomic<bool> release_lock{ false };
+    std::thread holder([this, &lock_held, &release_lock]() {
+      std::unique_lock lock(controller_.rt_active_goal_.get_mutex());
+      lock_held = true;
+      while (!release_lock.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+    });
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (!lock_held.load() && std::chrono::steady_clock::now() < deadline) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    ASSERT_TRUE(lock_held.load()) << "Timed out waiting to hold the goal box mutex.";
+
+    std::forward<Fn>(fn)();
+
+    release_lock = true;
+    holder.join();
+  }
+
   ur_controllers::ToolContactController controller_;
   double set_state_value_{};
   double state_value_{};
@@ -266,6 +297,79 @@ TEST_F(ToolContactControllerTest, ExecutingHardwareAbortResultSetsStandby)
   EXPECT_EQ(run_update(), controller_interface::return_type::OK);
   EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_STANDBY);
   EXPECT_FALSE(is_active());
+}
+
+// ---------------------------------------------------------------------------
+// Goal-box contention: try_get fails while another thread holds the mutex
+// ---------------------------------------------------------------------------
+
+TEST_F(ToolContactControllerTest, ContendedGoalBoxExecutingNonTerminalAcknowledgesExecuting)
+{
+  // Non-terminal EXECUTING must still be acknowledged so startToolContact is
+  // not retriggered, even when the goal handle cannot be read this cycle.
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_WAITING_BEGIN;
+  set_hw_state(TOOL_CONTACT_EXECUTING, 3.0);
+  set_logged_once(false);
+
+  with_goal_box_contended([this]() {
+    EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+    EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_EXECUTING);
+    EXPECT_TRUE(is_active());
+    EXPECT_TRUE(logged_once());
+    EXPECT_FALSE(should_reset_goal());
+  });
+}
+
+TEST_F(ToolContactControllerTest, ContendedGoalBoxExecutingSuccessDefersTerminalHandling)
+{
+  // Terminal success must NOT write WAITING_END while the goal box is
+  // contended; goal/result handling is deferred to a later cycle.
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_EXECUTING;
+  set_hw_state(TOOL_CONTACT_EXECUTING, 0.0);
+  set_active(true);
+  set_logged_once(true);
+
+  with_goal_box_contended([this]() {
+    EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+    EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_EXECUTING);
+    EXPECT_TRUE(is_active());
+    EXPECT_FALSE(should_reset_goal());
+  });
+}
+
+TEST_F(ToolContactControllerTest, ContendedGoalBoxExecutingHardwareAbortDefersTerminalHandling)
+{
+  // Terminal hardware abort must NOT write STANDBY while the goal box is
+  // contended; goal/result handling is deferred to a later cycle.
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_EXECUTING;
+  set_hw_state(TOOL_CONTACT_EXECUTING, 1.0);
+  set_active(true);
+  set_logged_once(true);
+
+  with_goal_box_contended([this]() {
+    EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+    EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_EXECUTING);
+    EXPECT_TRUE(is_active());
+    EXPECT_FALSE(should_reset_goal());
+  });
+}
+
+TEST_F(ToolContactControllerTest, ContendedGoalBoxNonExecutingLeavesCommandUnchanged)
+{
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_STANDBY;
+  set_hw_state(TOOL_CONTACT_STANDBY);
+  set_logged_once(true);
+
+  with_goal_box_contended([this]() {
+    EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+    EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_STANDBY);
+    // STANDBY logging clear only runs in the uncontended switch.
+    EXPECT_TRUE(logged_once());
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/ur_controllers/test/test_tool_contact_controller.cpp
+++ b/ur_controllers/test/test_tool_contact_controller.cpp
@@ -1,0 +1,405 @@
+// Copyright 2026 Universal Robots A/S
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//    * Redistributions of source code must retain the above copyright
+//      notice, this list of conditions and the following disclaimer.
+//
+//    * Redistributions in binary form must reproduce the above copyright
+//      notice, this list of conditions and the following disclaimer in the
+//      documentation and/or other materials provided with the distribution.
+//
+//    * Neither the name of the {copyright_holder} nor the names of its
+//      contributors may be used to endorse or promote products derived from
+//      this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+
+#include "controller_interface/controller_interface_params.hpp"
+#include "hardware_interface/loaned_command_interface.hpp"
+#include "hardware_interface/loaned_state_interface.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp/utilities.hpp"
+#include "ur_controllers/tool_contact_controller.hpp"
+
+// Unit tests for ToolContactController::update() state/command interactions.
+// Includes the #1939 regression: abort must not be overwritten by EXECUTING.
+
+class ToolContactControllerTest : public ::testing::Test
+{
+public:
+  static constexpr double TOOL_CONTACT_STANDBY = 1.0;
+  static constexpr double TOOL_CONTACT_WAITING_BEGIN = 2.0;
+  static constexpr double TOOL_CONTACT_EXECUTING = 3.0;
+  static constexpr double TOOL_CONTACT_FAILURE_BEGIN = 4.0;
+  static constexpr double TOOL_CONTACT_WAITING_END = 5.0;
+  static constexpr double TOOL_CONTACT_SUCCESS_END = 6.0;
+  static constexpr double TOOL_CONTACT_FAILURE_END = 7.0;
+
+protected:
+  void SetUp() override
+  {
+    controller_interface::ControllerInterfaceParams params;
+    params.controller_name = "tool_contact_controller_test";
+    params.robot_description = "";
+    params.update_rate = 500;
+    params.controller_manager_update_rate = 500;
+    params.node_namespace = "";
+    params.node_options = controller_.define_custom_node_options();
+    ASSERT_EQ(controller_.init(params), controller_interface::return_type::OK);
+
+    set_state_value_ = TOOL_CONTACT_STANDBY;
+    state_value_ = TOOL_CONTACT_STANDBY;
+    result_value_ = 3.0;
+
+    command_interface_ = std::make_shared<hardware_interface::CommandInterface>(
+        "tool_contact", "tool_contact_set_state", &set_state_value_);
+    state_interface_ =
+        std::make_shared<hardware_interface::StateInterface>("tool_contact", "tool_contact_state", &state_value_);
+    result_interface_ =
+        std::make_shared<hardware_interface::StateInterface>("tool_contact", "tool_contact_result", &result_value_);
+
+    loaned_command_ = std::make_unique<hardware_interface::LoanedCommandInterface>(command_interface_);
+    loaned_state_ = std::make_unique<hardware_interface::LoanedStateInterface>(state_interface_);
+    loaned_result_ = std::make_unique<hardware_interface::LoanedStateInterface>(result_interface_);
+
+    controller_.tool_contact_set_state_interface_ = *loaned_command_;
+    controller_.tool_contact_state_interface_ = *loaned_state_;
+    controller_.tool_contact_result_interface_ = *loaned_result_;
+
+    // No active goal; try_get succeeds and yields nullptr.
+    ASSERT_TRUE(controller_.set_rt_goal_from_non_rt(nullptr));
+  }
+
+  void TearDown() override
+  {
+    if (controller_.get_node()) {
+      controller_.get_node()->shutdown();
+    }
+  }
+
+  void request_abort()
+  {
+    controller_.tool_contact_abort_ = true;
+    controller_.tool_contact_enable_ = false;
+  }
+
+  void request_enable()
+  {
+    controller_.tool_contact_abort_ = false;
+    controller_.tool_contact_enable_ = true;
+  }
+
+  void request_abort_and_enable()
+  {
+    controller_.tool_contact_abort_ = true;
+    controller_.tool_contact_enable_ = true;
+  }
+
+  void clear_requests()
+  {
+    controller_.tool_contact_abort_ = false;
+    controller_.tool_contact_enable_ = false;
+  }
+
+  void set_hw_state(double state, double result = 3.0)
+  {
+    state_value_ = state;
+    result_value_ = result;
+  }
+
+  void set_active(bool active)
+  {
+    controller_.tool_contact_active_ = active;
+  }
+
+  void set_logged_once(bool logged)
+  {
+    controller_.logged_once_ = logged;
+  }
+
+  bool abort_requested() const
+  {
+    return controller_.tool_contact_abort_;
+  }
+  bool enable_requested() const
+  {
+    return controller_.tool_contact_enable_;
+  }
+  bool is_active() const
+  {
+    return controller_.tool_contact_active_;
+  }
+  bool logged_once() const
+  {
+    return controller_.logged_once_;
+  }
+  bool should_reset_goal() const
+  {
+    return controller_.should_reset_goal;
+  }
+
+  controller_interface::return_type run_update()
+  {
+    return controller_.update(rclcpp::Time(0, 0, RCL_ROS_TIME), rclcpp::Duration::from_seconds(0.01));
+  }
+
+  ur_controllers::ToolContactController controller_;
+  double set_state_value_{};
+  double state_value_{};
+  double result_value_{};
+  std::shared_ptr<hardware_interface::CommandInterface> command_interface_;
+  std::shared_ptr<hardware_interface::StateInterface> state_interface_;
+  std::shared_ptr<hardware_interface::StateInterface> result_interface_;
+  std::unique_ptr<hardware_interface::LoanedCommandInterface> loaned_command_;
+  std::unique_ptr<hardware_interface::LoanedStateInterface> loaned_state_;
+  std::unique_ptr<hardware_interface::LoanedStateInterface> loaned_result_;
+};
+
+// ---------------------------------------------------------------------------
+// Early-exit command requests
+// ---------------------------------------------------------------------------
+
+TEST_F(ToolContactControllerTest, AbortWhileExecutingKeepsWaitingEndCommand)
+{
+  // Regression (#1939): abort must not be overwritten by the EXECUTING branch.
+  request_abort();
+  set_state_value_ = TOOL_CONTACT_EXECUTING;
+  set_hw_state(TOOL_CONTACT_EXECUTING, 3.0);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_WAITING_END);
+  EXPECT_FALSE(abort_requested());
+  EXPECT_FALSE(enable_requested());
+}
+
+TEST_F(ToolContactControllerTest, EnableWhileIdleSetsWaitingBeginAndReturns)
+{
+  request_enable();
+  set_state_value_ = TOOL_CONTACT_STANDBY;
+  set_hw_state(TOOL_CONTACT_STANDBY);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_WAITING_BEGIN);
+  EXPECT_FALSE(enable_requested());
+}
+
+TEST_F(ToolContactControllerTest, AbortTakesPriorityOverEnable)
+{
+  request_abort_and_enable();
+  set_state_value_ = TOOL_CONTACT_EXECUTING;
+  set_hw_state(TOOL_CONTACT_EXECUTING, 3.0);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_WAITING_END);
+  EXPECT_FALSE(abort_requested());
+  EXPECT_FALSE(enable_requested());
+}
+
+TEST_F(ToolContactControllerTest, AbortDoesNotFallThroughToStateMachine)
+{
+  // Even when HW reports SUCCESS_END, abort must win and leave WAITING_END.
+  request_abort();
+  set_state_value_ = TOOL_CONTACT_EXECUTING;
+  set_hw_state(TOOL_CONTACT_SUCCESS_END);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_WAITING_END);
+}
+
+// ---------------------------------------------------------------------------
+// TOOL_CONTACT_EXECUTING
+// ---------------------------------------------------------------------------
+
+TEST_F(ToolContactControllerTest, ExecutingNonTerminalResultAcknowledgesExecuting)
+{
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_WAITING_BEGIN;
+  set_hw_state(TOOL_CONTACT_EXECUTING, 3.0);
+  set_logged_once(false);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_EXECUTING);
+  EXPECT_TRUE(is_active());
+  EXPECT_TRUE(logged_once());
+  EXPECT_FALSE(should_reset_goal());
+}
+
+TEST_F(ToolContactControllerTest, ExecutingSuccessResultRequestsWaitingEnd)
+{
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_EXECUTING;
+  set_hw_state(TOOL_CONTACT_EXECUTING, 0.0);
+  set_active(true);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_WAITING_END);
+  EXPECT_FALSE(is_active());
+  // No active goal handle, so should_reset_goal stays false.
+  EXPECT_FALSE(should_reset_goal());
+}
+
+TEST_F(ToolContactControllerTest, ExecutingHardwareAbortResultSetsStandby)
+{
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_EXECUTING;
+  set_hw_state(TOOL_CONTACT_EXECUTING, 1.0);
+  set_active(true);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_STANDBY);
+  EXPECT_FALSE(is_active());
+}
+
+// ---------------------------------------------------------------------------
+// TOOL_CONTACT_FAILURE_BEGIN / SUCCESS_END / FAILURE_END / STANDBY
+// ---------------------------------------------------------------------------
+
+TEST_F(ToolContactControllerTest, FailureBeginSetsStandbyAndClearsActive)
+{
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_WAITING_BEGIN;
+  set_hw_state(TOOL_CONTACT_FAILURE_BEGIN);
+  set_active(true);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_STANDBY);
+  EXPECT_FALSE(is_active());
+}
+
+TEST_F(ToolContactControllerTest, SuccessEndSetsStandbyAndClearsActive)
+{
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_WAITING_END;
+  set_hw_state(TOOL_CONTACT_SUCCESS_END);
+  set_active(true);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_STANDBY);
+  EXPECT_FALSE(is_active());
+}
+
+TEST_F(ToolContactControllerTest, SuccessEndAlwaysWritesStandbyEvenIfAlreadyInactive)
+{
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_WAITING_END;
+  set_hw_state(TOOL_CONTACT_SUCCESS_END);
+  set_active(false);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_STANDBY);
+  EXPECT_FALSE(is_active());
+}
+
+TEST_F(ToolContactControllerTest, FailureEndSetsStandby)
+{
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_WAITING_END;
+  set_hw_state(TOOL_CONTACT_FAILURE_END);
+  set_active(true);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_STANDBY);
+}
+
+TEST_F(ToolContactControllerTest, StandbyClearsLoggedOnceWithoutChangingCommand)
+{
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_STANDBY;
+  set_hw_state(TOOL_CONTACT_STANDBY);
+  set_logged_once(true);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_STANDBY);
+  EXPECT_FALSE(logged_once());
+}
+
+TEST_F(ToolContactControllerTest, WaitingBeginStateIsPassthroughDefault)
+{
+  // Intermediate HW states fall through the default branch; command is unchanged.
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_WAITING_BEGIN;
+  set_hw_state(TOOL_CONTACT_WAITING_BEGIN);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_WAITING_BEGIN);
+}
+
+TEST_F(ToolContactControllerTest, WaitingEndStateIsPassthroughDefault)
+{
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_WAITING_END;
+  set_hw_state(TOOL_CONTACT_WAITING_END);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_WAITING_END);
+}
+
+TEST_F(ToolContactControllerTest, UnknownStateLeavesCommandUnchanged)
+{
+  clear_requests();
+  set_state_value_ = TOOL_CONTACT_STANDBY;
+  set_hw_state(99.0);
+
+  EXPECT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_STANDBY);
+}
+
+// ---------------------------------------------------------------------------
+// Enable then progress through a happy-path handshake without abort
+// ---------------------------------------------------------------------------
+
+TEST_F(ToolContactControllerTest, EnableThenExecutingHandshakeSequence)
+{
+  // 1) Enable request -> WAITING_BEGIN
+  request_enable();
+  set_state_value_ = TOOL_CONTACT_STANDBY;
+  set_hw_state(TOOL_CONTACT_STANDBY);
+  ASSERT_EQ(run_update(), controller_interface::return_type::OK);
+  ASSERT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_WAITING_BEGIN);
+
+  // 2) HW reports EXECUTING with non-terminal result -> acknowledge EXECUTING
+  clear_requests();
+  set_hw_state(TOOL_CONTACT_EXECUTING, 3.0);
+  ASSERT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_EXECUTING);
+  EXPECT_TRUE(is_active());
+
+  // 3) Abort while still executing -> WAITING_END (regression path)
+  request_abort();
+  ASSERT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_WAITING_END);
+
+  // 4) HW reports SUCCESS_END -> STANDBY
+  clear_requests();
+  set_hw_state(TOOL_CONTACT_SUCCESS_END);
+  ASSERT_EQ(run_update(), controller_interface::return_type::OK);
+  EXPECT_DOUBLE_EQ(set_state_value_, TOOL_CONTACT_STANDBY);
+  EXPECT_FALSE(is_active());
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleMock(&argc, argv);
+  rclcpp::init(argc, argv);
+  const int result = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return result;
+}


### PR DESCRIPTION
When merging #1939 we introduced a regression, that this PR fixes. I've added unit tests for the tool_contact_controller that should find such regressions in the future.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes realtime control logic for tool contact hardware commands and action goal completion timing; mistakes could affect safe disable or duplicate start commands, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes a **#1939 regression** in `ToolContactController::update()` where abort/enable handling no longer returned early, so an in-flight abort could be overwritten when hardware was in `EXECUTING`.
> 
> **`update()` behavior changes:** abort and enable requests now **return immediately** after writing `WAITING_END` or `WAITING_BEGIN`. Hardware state is read **before** the realtime goal handle; if `try_get` fails on contention, non-terminal `EXECUTING` still gets acknowledged (avoids retriggering `startToolContact`) while terminal success/abort goal handling waits for a later cycle. `SUCCESS_END` always commands `STANDBY`, not only when `tool_contact_active_` was true. Per-cycle `write_success` replaces a `static` flag.
> 
> Adds **gmock unit tests** (`test_tool_contact_controller`) with a test `friend` on the controller, covering abort priority, state machine transitions, goal-box contention, and an enable→execute→abort→success sequence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5880c7d5aebc5797196d14e1ad7e215c305b0d1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->