### PR TITLE
Fix links to ROS 2 documentation

### DIFF
--- a/ur_robot_driver/doc/installation/installation.rst
+++ b/ur_robot_driver/doc/installation/installation.rst
@@ -18,7 +18,7 @@ recommend a binary package installation unless you want to join development and 
 Install from binary packages
 ----------------------------
 
-1. `Install ROS2 <https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html>`_. This
+1. `Install ROS2 <https://docs.ros.org/en/rolling/Get-Started/Installation/Ubuntu-Install-Debs.html>`_. This
    branch supports only ROS2 Rolling. For other ROS2 versions, please see the respective branches.
 2. Install the driver using
 
@@ -38,10 +38,10 @@ require upstream repositories to be present in a certain version as otherwise bu
 Starting from scratch following exactly the steps below should always work, but simply pulling and
 building might fail occasionally.
 
-1. `Install ROS2 <https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html>`_. This
+1. `Install ROS2 <https://docs.ros.org/en/rolling/Get-Started/Installation/Ubuntu-Install-Debs.html>`_. This
    branch supports only ROS2 Rolling. For other ROS2 versions, please see the respective branches.
 
-   Once installed, please make sure to actually `source ROS2 <https://docs.ros.org/en/rolling/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files>`_ before proceeding.
+   Once installed, please make sure to actually `source ROS2 <https://docs.ros.org/en/rolling/Get-Started/Configuring-ROS2-Environment.html#source-the-setup-files>`_ before proceeding.
 
 3. Make sure that ``colcon``, its extensions and ``vcs`` are installed:
 


### PR DESCRIPTION
Apparently, they have been moved upstream. It finally pays off that we drag this link checker along :-)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link fixes with no runtime, build, or security impact.
> 
> **Overview**
> Updates broken outbound links in the **ur_robot_driver** installation guide after ROS 2 moved its docs under `Get-Started/`.
> 
> The **Install ROS2** steps (binary and from-source) now point to `Get-Started/Installation/Ubuntu-Install-Debs.html` instead of the old `Installation/Ubuntu-Install-Debians.html` path. The **source ROS2** note uses `Get-Started/Configuring-ROS2-Environment.html` instead of the former `Tutorials/Beginner-CLI-Tools/...` URL; anchor text and install steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17a7994fd17d7aebae1c30631d8da565127d9ae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->