### PR TITLE
Update links to ROS installation documentation

### DIFF
--- a/ur_robot_driver/doc/installation/installation.rst
+++ b/ur_robot_driver/doc/installation/installation.rst
@@ -18,8 +18,8 @@ recommend a binary package installation unless you want to join development and 
 Install from binary packages
 ----------------------------
 
-1. `Install ROS2 <https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html>`_. This
-   branch supports only ROS2 Rolling. For other ROS2 versions, please see the respective branches.
+1. `Install ROS2 <https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html>`_. This
+   branch supports only ROS2 Jazzy. For other ROS2 versions, please see the respective branches.
 2. Install the driver using
 
    .. code-block:: bash
@@ -38,10 +38,10 @@ require upstream repositories to be present in a certain version as otherwise bu
 Starting from scratch following exactly the steps below should always work, but simply pulling and
 building might fail occasionally.
 
-1. `Install ROS2 <https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html>`_. This
-   branch supports only ROS2 Rolling. For other ROS2 versions, please see the respective branches.
+1. `Install ROS2 <https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html>`_. This
+   branch supports only ROS2 Jazzy. For other ROS2 versions, please see the respective branches.
 
-   Once installed, please make sure to actually `source ROS2 <https://docs.ros.org/en/rolling/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files>`_ before proceeding.
+   Once installed, please make sure to actually `source ROS2 <https://docs.ros.org/en/jazzy/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files>`_ before proceeding.
 
 3. Make sure that ``colcon``, its extensions and ``vcs`` are installed:
 
@@ -57,7 +57,7 @@ building might fail occasionally.
      export COLCON_WS=~/workspace/ros_ur_driver
      mkdir -p $COLCON_WS/src
 
-5. Clone relevant packages (replace ``<branch>`` with ``humble``, ``iron`` or ``main`` for rolling), install dependencies, compile, and source the workspace by using:
+5. Clone relevant packages (replace ``<branch>`` with the correct one as listed on the `README <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver#release-status>`_), install dependencies, compile, and source the workspace by using:
 
    .. code-block:: bash
 


### PR DESCRIPTION
Same as #1958 but for Jazzy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and wording changes with no runtime or build logic impact.
> 
> **Overview**
> Updates the **ur_robot_driver** installation guide so it matches **ROS 2 Jazzy** instead of Rolling.
> 
> Binary and source install steps now link to Jazzy install and “source ROS” tutorial URLs, and the text states this branch targets Jazzy only. The clone step no longer lists `humble` / `iron` / `main`; it directs readers to the README **release status** section for the correct branch name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c155bdf9a2b97d07be386171c3abdfda01cefa5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->