### PR TITLE
[Docs] Update links to ROS installation documentation

### DIFF
--- a/ur_robot_driver/doc/installation/installation.rst
+++ b/ur_robot_driver/doc/installation/installation.rst
@@ -7,8 +7,8 @@ recommend a binary package installation unless you want to join development and 
 Install from binary packages
 ----------------------------
 
-1. `Install ROS2 <https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html>`_. This
-   branch supports only ROS2 Rolling. For other ROS2 versions, please see the respective branches.
+1. `Install ROS2 <https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html>`_. This
+   branch supports only ROS2 Humble. For other ROS2 versions, please see the respective branches.
 2. Install the driver using
 
    .. code-block:: bash
@@ -27,10 +27,10 @@ require upstream repositories to be present in a certain version as otherwise bu
 Starting from scratch following exactly the steps below should always work, but simply pulling and
 building might fail occasionally.
 
-1. `Install ROS2 <https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html>`_. This
-   branch supports only ROS2 Rolling. For other ROS2 versions, please see the respective branches.
+1. `Install ROS2 <https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html>`_. This
+   branch supports only ROS2 Humble. For other ROS2 versions, please see the respective branches.
 
-   Once installed, please make sure to actually `source ROS2 <https://docs.ros.org/en/rolling/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files>`_ before proceeding.
+   Once installed, please make sure to actually `source ROS2 <https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html#source-the-setup-files>`_ before proceeding.
 
 3. Make sure that ``colcon``, its extensions and ``vcs`` are installed:
 
@@ -46,7 +46,7 @@ building might fail occasionally.
      export COLCON_WS=~/workspace/ros_ur_driver
      mkdir -p $COLCON_WS/src
 
-5. Clone relevant packages (replace ``<branch>`` with ``humble``, ``iron`` or ``main`` for rolling), install dependencies, compile, and source the workspace by using:
+5. Clone relevant packages (replace ``<branch>`` with the correct one as listed on the `README <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver#release-status>`_), install dependencies, compile, and source the workspace by using:
 
    .. code-block:: bash
 


### PR DESCRIPTION
Same as https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1958 but for Humble

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only link and wording updates with no runtime or build logic changes.
> 
> **Overview**
> Updates **`ur_robot_driver/doc/installation/installation.rst`** so install and source-from-source instructions match the **Humble** branch instead of Rolling.
> 
> ROS 2 install and “source the setup files” links now use `docs.ros.org/en/humble/...` and the **Ubuntu Install Debs** page (`Ubuntu-Install-Debs.html` rather than Debians). Prose now states this branch targets **ROS 2 Humble** only.
> 
> The clone step no longer lists example branch names (`humble`, `iron`, `main`); it directs readers to the driver **README release-status** section to pick the right `<branch>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebbde3581271ee042976d9a74716f74966afb624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->