### PR TITLE
Release/6.1.0

### DIFF
--- a/ur/CHANGELOG.rst
+++ b/ur/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ur
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Contributors: Felix Exner
+
 6.0.0 (2026-05-12)
 ------------------
 

--- a/ur/CHANGELOG.rst
+++ b/ur/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+6.1.0 (2026-09-10)
+------------------
 * Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
 * Contributors: Felix Exner
 

--- a/ur/package.xml
+++ b/ur/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur</name>
-  <version>6.0.0</version>
+  <version>6.1.0</version>
   <description>Metapackage for universal robots</description>
   <maintainer email="feex@universal-robots.com">Felix Exner</maintainer>
   <maintainer email="rsk@universal-robots.com">Rune Søe-Knudsen</maintainer>

--- a/ur_calibration/CHANGELOG.rst
+++ b/ur_calibration/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ur_calibration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Contributors: Felix Exner
+
 6.0.0 (2026-05-12)
 ------------------
 

--- a/ur_calibration/CHANGELOG.rst
+++ b/ur_calibration/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_calibration
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+6.1.0 (2026-09-10)
+------------------
 * Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
 * Contributors: Felix Exner
 

--- a/ur_calibration/package.xml
+++ b/ur_calibration/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>ur_calibration</name>
-  <version>6.0.0</version>
+  <version>6.1.0</version>
   <description>Package for extracting the factory calibration from a UR robot and change it such that it can be used by ur_description to gain a correct URDF</description>
 
   <maintainer email="feex@universal-robots.com">Felix Exner</maintainer>

--- a/ur_controllers/CHANGELOG.rst
+++ b/ur_controllers/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog for package ur_controllers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fix tolerance parsing in passthrough controller (backport `#1941 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1941>`_) (`#1967 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1967>`_)
+* Set command interface in tool contact controller (backport `#1939 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1939>`_) (`#1949 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1949>`_)
+* Add Cartesian twist controller (backport `#1586 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1586>`_) (`#1926 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1926>`_)
+* Allow setting payload inertia matrix via set_payload service in a backwards-compatible way (`#1811 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1811>`_)
+* Allow updating robot gravity (`#1606 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1606>`_)
+* Use a realtime_tools::RealtimePublisher for publishing the state (`#1822 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1822>`_)
+* Make GPIO controller publishers realtime-safe (`#1807 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1807>`_)
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Contributors: AdamPettinger, Felix Exner, Hasan Amin, Sergi Romero, mergify[bot]
+
 6.0.0 (2026-05-12)
 ------------------
 * Check payload state in gpio_controller (`#1770 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1770>`_)

--- a/ur_controllers/CHANGELOG.rst
+++ b/ur_controllers/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_controllers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+6.1.0 (2026-09-10)
+------------------
 * Fix tolerance parsing in passthrough controller (backport `#1941 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1941>`_) (`#1967 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1967>`_)
 * Set command interface in tool contact controller (backport `#1939 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1939>`_) (`#1949 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1949>`_)
 * Add Cartesian twist controller (backport `#1586 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1586>`_) (`#1926 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1926>`_)

--- a/ur_controllers/package.xml
+++ b/ur_controllers/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_controllers</name>
-  <version>6.0.0</version>
+  <version>6.1.0</version>
   <description>Provides controllers that use the speed scaling interface of Universal Robots.</description>
 
   <maintainer email="feex@universal-robots.com">Felix Exner</maintainer>

--- a/ur_dashboard_msgs/CHANGELOG.rst
+++ b/ur_dashboard_msgs/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_dashboard_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+6.1.0 (2026-09-10)
+------------------
 * Update dashboard client for 10.14.0 (backport `#1945 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1945>`_) (`#1975 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1975>`_)
 * Update safety status message with new IO plane stop (`#1817 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1817>`_)
 * Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)

--- a/ur_dashboard_msgs/CHANGELOG.rst
+++ b/ur_dashboard_msgs/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog for package ur_dashboard_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Update dashboard client for 10.14.0 (backport `#1945 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1945>`_) (`#1975 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1975>`_)
+* Update safety status message with new IO plane stop (`#1817 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1817>`_)
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Contributors: Felix Exner, Mads Holm Peters, mergify[bot]
+
 6.0.0 (2026-05-12)
 ------------------
 

--- a/ur_dashboard_msgs/package.xml
+++ b/ur_dashboard_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_dashboard_msgs</name>
-  <version>6.0.0</version>
+  <version>6.1.0</version>
   <description>Messages around the UR Dashboard server.</description>
 
   <maintainer email="feex@universal-robots.com">Felix Exner</maintainer>

--- a/ur_moveit_config/CHANGELOG.rst
+++ b/ur_moveit_config/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package ur_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+6.1.0 (2026-09-10)
+------------------
 * Fix a typo in launch file argument docstring (backport `#1917 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1917>`_) (`#1932 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1932>`_)
 * Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
 * Contributors: Felix Exner, mergify[bot]

--- a/ur_moveit_config/CHANGELOG.rst
+++ b/ur_moveit_config/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package ur_moveit_config
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fix a typo in launch file argument docstring (backport `#1917 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1917>`_) (`#1932 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1932>`_)
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Contributors: Felix Exner, mergify[bot]
+
 6.0.0 (2026-05-12)
 ------------------
 * BREAKING: Remove scaled joint trajectory controller (`#1769 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1769>`_)

--- a/ur_moveit_config/package.xml
+++ b/ur_moveit_config/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_moveit_config</name>
-  <version>6.0.0</version>
+  <version>6.1.0</version>
   <description>
      An example package with MoveIt2 configurations for UR robots.
   </description>

--- a/ur_robot_driver/CHANGELOG.rst
+++ b/ur_robot_driver/CHANGELOG.rst
@@ -1,5 +1,5 @@
-Forthcoming
------------
+6.1.0 (2026-09-10)
+------------------
 * Allow using blocking read in controller manager (backport `#1760 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1760>`_) (`#1922 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1922>`_)
 * Update dashboard client for 10.14.0 (backport `#1945 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1945>`_) (`#1975 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1975>`_)
 * Fix tolerance parsing in passthrough controller (backport `#1941 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1941>`_) (`#1967 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1967>`_)

--- a/ur_robot_driver/CHANGELOG.rst
+++ b/ur_robot_driver/CHANGELOG.rst
@@ -1,3 +1,33 @@
+Forthcoming
+-----------
+* Allow using blocking read in controller manager (backport `#1760 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1760>`_) (`#1922 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1922>`_)
+* Update dashboard client for 10.14.0 (backport `#1945 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1945>`_) (`#1975 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1975>`_)
+* Fix tolerance parsing in passthrough controller (backport `#1941 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1941>`_) (`#1967 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1967>`_)
+* [RobotStateHelper] Fix worker thread lifecycle management (backport `#1950 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1950>`_) (`#1971 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1971>`_)
+* [Docs] Update links to ROS installation documentation (`#1959 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1959>`_)
+* Fix passthrough controller handling of very short trajectories (backport `#1940 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1940>`_) (`#1957 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1957>`_)
+* Report operational status with mock hardware (backport `#1923 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1923>`_) (`#1935 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1935>`_)
+* Fix a typo in launch file argument docstring (backport `#1917 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1917>`_) (`#1932 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1932>`_)
+* Add Cartesian twist controller (backport `#1586 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1586>`_) (`#1926 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1926>`_)
+* Fix ``trajectory_until_node`` goal acceptance handshake (backport `#1909 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1909>`_) (`#1915 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1915>`_)
+* Add note about blocked tool comm port (backport `#1904 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1904>`_) (`#1907 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1907>`_)
+* Add autoconnect parameter to dashboard client (backport `#1881 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1881>`_) (`#1890 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1890>`_)
+* Fix link to action_definitions doc page (backport `#1876 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1876>`_) (`#1885 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1885>`_)
+* Allow setting payload inertia matrix via set_payload service in a backwards-compatible way (`#1811 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1811>`_)
+* Fix whitespace errors (backport `#1869 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1869>`_) (`#1877 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1877>`_)
+* Migrate URScript interface to primary client (`#1833 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1833>`_)
+* Remove controller switch to passthrough controller (`#1857 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1857>`_)
+* Replace linking to moprim controller by using its include directories (`#1853 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1853>`_)
+* Update model test (`#1848 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1848>`_)
+* Allow updating robot gravity (`#1606 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1606>`_)
+* [tests] Fix shadowed function argument (`#1835 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1835>`_)
+* Explicitly send MODE_STOPPED when returning control to the robot (`#1678 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1678>`_)
+* Update minimum CMake version to 3.28.3 (`#1814 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1814>`_)
+* Fix whitespace error introduced earlier (`#1805 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1805>`_)
+* Clarify effort control limitations in URSim (`#1800 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1800>`_)
+* Fail example move on error (`#1795 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1795>`_)
+* Contributors: AdamPettinger, Felix Exner, Sergi Romero, URJala, mergify[bot]
+
 6.0.0 (2026-05-12)
 ------------------
 * [driver] Remove deprecated packages from package.xml (`#1785 <https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/1785>`_)

--- a/ur_robot_driver/package.xml
+++ b/ur_robot_driver/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_robot_driver</name>
-  <version>6.0.0</version>
+  <version>6.1.0</version>
     <description>
       The ROS 2 driver for Universal Robots manipulators. This driver supports all robot
       models as listed in the documentation. For robot controllers, PolyScope X, PolyScope 5 and


### PR DESCRIPTION
Release to Lyrical

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> The diff only updates version numbers and changelogs; no application code or build logic changes in this PR.
> 
> **Overview**
> This PR cuts **release 6.1.0** by bumping the `ur` metapackage and `ur_calibration`, `ur_controllers`, `ur_dashboard_msgs`, `ur_moveit_config`, and `ur_robot_driver` from **6.0.0 → 6.1.0** in each `package.xml` and adding matching **6.1.0 (2026-09-10)** sections to the package changelogs.
> 
> The new changelog text records what ships in this release (already merged elsewhere): **CMake minimum 3.28.3** across packages; driver/controller fixes and features such as **Cartesian twist controller**, **payload inertia / gravity updates**, **realtime-safe GPIO/state publishing**, **URScript via primary client**, **dashboard client 10.14.0** and **safety status IO plane stop**, plus assorted backported passthrough/dashboard/threading/doc fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0117203fad1f136edd20e405725e29cde1eabb8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->